### PR TITLE
fix(eval): address code review — bound warm-up retries and surface 50…

### DIFF
--- a/suchi_phase1_pack/eval/cli.ts
+++ b/suchi_phase1_pack/eval/cli.ts
@@ -97,7 +97,7 @@ program
       // ✅ NEW: Warm-up API to prevent cold start on first test case
       console.log("\n🔥 Warming up API...");
       try {
-        const warmupClient = new ApiClient(config.apiBaseUrl, 30000, config.authBearer); // 30s timeout
+        const warmupClient = new ApiClient(config.apiBaseUrl, 30000, config.authBearer, 0); // 30s timeout, no retries
         const warmupSession = await warmupClient.createSession("web");
         await warmupClient.sendMessage(
           warmupSession,

--- a/suchi_phase1_pack/eval/runner/api-client.ts
+++ b/suchi_phase1_pack/eval/runner/api-client.ts
@@ -91,6 +91,7 @@ export class ApiClient {
     channel: "web" | "app" | "whatsapp" = "web"
   ): Promise<ChatResponse> {
     let lastError: Error | null = null;
+    let allTimeouts = true;
 
     for (let attempt = 0; attempt <= this.retries; attempt++) {
       try {
@@ -99,26 +100,40 @@ export class ApiClient {
           channel,
           userText,
         });
-        
+
         if (attempt > 0) {
           console.log(`  ✅ Retry ${attempt} succeeded`);
         }
-        
+
         return response.data;
       } catch (error: any) {
         lastError = error;
-        
+
+        const isTimeout =
+          error.code === 'ECONNABORTED' ||
+          error.response?.status === 504;
+
+        if (!isTimeout) {
+          allTimeouts = false;
+        }
+
         // Check if retryable (transient errors)
         const isRetryable =
-          error.code === 'ECONNABORTED' || // Timeout
+          isTimeout ||
           error.code === 'ECONNRESET' ||   // Connection reset
           error.response?.status === 429 || // Rate limit
           error.response?.status === 500 || // Internal server error (cold start)
           error.response?.status === 502 || // Bad gateway
-          error.response?.status === 503 || // Service unavailable
-          error.response?.status === 504;   // Gateway timeout
+          error.response?.status === 503;   // Service unavailable
 
         if (!isRetryable || attempt === this.retries) {
+          if (allTimeouts) {
+            const err = new Error(
+              `All ${attempt + 1} attempts timed out (504). API unreachable or overloaded.`
+            );
+            (err as any).timedOut = true;
+            throw err;
+          }
           throw new Error(`Failed to send message: ${error.message}`);
         }
 


### PR DESCRIPTION
…4 timeouts

- Warm-up client now uses 0 retries (single attempt) with 30s timeout to prevent pre-eval hangs in CI when the API is unreachable
- sendMessage tracks whether all failures were 504/timeout and throws an explicit timeout error with `timedOut` flag instead of silently returning canned fallback responses, keeping pass/fail metrics clean

https://claude.ai/code/session_01W7vkcx2sKbiU1TmbjhvdLh

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/gautamgauri/suchi-cancer-bot/12?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->