### PR TITLE
fix(rag): Hindi/Hinglish retrieval coverage (Cluster C — retrieval half)

### DIFF
--- a/apps/api/src/modules/chat/structured-output-templates.spec.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.spec.ts
@@ -21,9 +21,18 @@ describe("StructuredOutputTemplates", () => {
         expect(result).toBe(BIOPSY_NEXT_STEPS);
       });
 
-      test("signal: next_steps", () => {
-        const result = selectOutputTemplate("NAVIGATION", ["next_steps"], "what to do next");
+      // `next_steps` alone is intentionally too broad to route to the biopsy
+      // template (it matches generic "what should I do" on symptom queries), so
+      // it only routes WITH explicit biopsy/report context. This reflects the
+      // documented behavior in selectOutputTemplate() (commit e6436aa).
+      test("signal: next_steps + biopsy context", () => {
+        const result = selectOutputTemplate("NAVIGATION", ["next_steps"], "biopsy done, what to do next");
         expect(result).toBe(BIOPSY_NEXT_STEPS);
+      });
+
+      test("signal: next_steps alone does NOT route to biopsy", () => {
+        const result = selectOutputTemplate("NAVIGATION", ["next_steps"], "what to do next");
+        expect(result).not.toBe(BIOPSY_NEXT_STEPS);
       });
 
       test("keyword: biopsy in text", () => {

--- a/apps/api/src/modules/chat/structured-output-templates.spec.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.spec.ts
@@ -21,33 +21,38 @@ describe("StructuredOutputTemplates", () => {
         expect(result).toBe(BIOPSY_NEXT_STEPS);
       });
 
-      // ── Biopsy routing contract (acceptance cases) ──
-      // At this boundary, the "report_received" signal represents reliable
-      // ACTIVE biopsy context (the upstream sets it from the current message or
-      // recent session context, NOT from a stale/unrelated historical mention).
+      // ── ACTIVE biopsy context — boundary definition ──
+      // Defines exactly what counts as "active" biopsy context for the router.
+      // Mirrors the JSDoc on selectOutputTemplate(). At this boundary the
+      // `report_received` signal == reliable active context, which the caller
+      // sets from the current message or current care thread — NEVER from a
+      // stale, unrelated historical mention.
+      describe("ACTIVE biopsy context — boundary definition", () => {
+        // (1) Current message references a biopsy/report → active.
+        test('current message biopsy phrase → active ("Biopsy ho gayi, ab kya?")', () => {
+          expect(selectOutputTemplate("NAVIGATION", [], "Biopsy ho gayi, ab kya?")).toBe(BIOPSY_NEXT_STEPS);
+        });
 
-      // "What next?" alone → generic next-steps, never the biopsy template.
-      test('"what next?" alone does NOT route to biopsy', () => {
-        expect(selectOutputTemplate("NAVIGATION", ["next_steps"], "what next?")).not.toBe(BIOPSY_NEXT_STEPS);
-      });
+        // (2) Current care thread is about a biopsy (caller sets report_received)
+        //     + a bare "what next?" → active.
+        test('active care thread (report_received) + "what next?" → active', () => {
+          expect(
+            selectOutputTemplate("NAVIGATION", ["report_received", "next_steps"], "what next?"),
+          ).toBe(BIOPSY_NEXT_STEPS);
+        });
 
-      // Biopsy context in the current message → biopsy template.
-      test('"Biopsy ho gayi, ab kya?" → biopsy template', () => {
-        expect(selectOutputTemplate("NAVIGATION", [], "Biopsy ho gayi, ab kya?")).toBe(BIOPSY_NEXT_STEPS);
-      });
+        // NOT active: bare "what next?" with no biopsy context.
+        test('"what next?" alone → NOT active', () => {
+          expect(selectOutputTemplate("NAVIGATION", ["next_steps"], "what next?")).not.toBe(BIOPSY_NEXT_STEPS);
+        });
 
-      // Prior turn established biopsy (active session context → report_received) +
-      // current "what next?" → biopsy template.
-      test('active biopsy session context + "what next?" → biopsy template', () => {
-        expect(
-          selectOutputTemplate("NAVIGATION", ["report_received", "next_steps"], "what next?"),
-        ).toBe(BIOPSY_NEXT_STEPS);
-      });
-
-      // Stale/unrelated historical biopsy → upstream does NOT set report_received,
-      // so a bare "what next?" must NOT auto-route to biopsy.
-      test("stale biopsy history (no active signal) does NOT route to biopsy", () => {
-        expect(selectOutputTemplate("NAVIGATION", ["next_steps"], "what next?")).not.toBe(BIOPSY_NEXT_STEPS);
+        // NOT active: stale/unrelated history → caller does not set
+        // report_received, so a generic message must not auto-route to biopsy.
+        test("stale history (no active signal) → NOT active", () => {
+          expect(selectOutputTemplate("NAVIGATION", [], "what should I eat this week?")).not.toBe(
+            BIOPSY_NEXT_STEPS,
+          );
+        });
       });
 
       test("keyword: biopsy in text", () => {

--- a/apps/api/src/modules/chat/structured-output-templates.spec.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.spec.ts
@@ -21,18 +21,33 @@ describe("StructuredOutputTemplates", () => {
         expect(result).toBe(BIOPSY_NEXT_STEPS);
       });
 
-      // `next_steps` alone is intentionally too broad to route to the biopsy
-      // template (it matches generic "what should I do" on symptom queries), so
-      // it only routes WITH explicit biopsy/report context. This reflects the
-      // documented behavior in selectOutputTemplate() (commit e6436aa).
-      test("signal: next_steps + biopsy context", () => {
-        const result = selectOutputTemplate("NAVIGATION", ["next_steps"], "biopsy done, what to do next");
-        expect(result).toBe(BIOPSY_NEXT_STEPS);
+      // ── Biopsy routing contract (acceptance cases) ──
+      // At this boundary, the "report_received" signal represents reliable
+      // ACTIVE biopsy context (the upstream sets it from the current message or
+      // recent session context, NOT from a stale/unrelated historical mention).
+
+      // "What next?" alone → generic next-steps, never the biopsy template.
+      test('"what next?" alone does NOT route to biopsy', () => {
+        expect(selectOutputTemplate("NAVIGATION", ["next_steps"], "what next?")).not.toBe(BIOPSY_NEXT_STEPS);
       });
 
-      test("signal: next_steps alone does NOT route to biopsy", () => {
-        const result = selectOutputTemplate("NAVIGATION", ["next_steps"], "what to do next");
-        expect(result).not.toBe(BIOPSY_NEXT_STEPS);
+      // Biopsy context in the current message → biopsy template.
+      test('"Biopsy ho gayi, ab kya?" → biopsy template', () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "Biopsy ho gayi, ab kya?")).toBe(BIOPSY_NEXT_STEPS);
+      });
+
+      // Prior turn established biopsy (active session context → report_received) +
+      // current "what next?" → biopsy template.
+      test('active biopsy session context + "what next?" → biopsy template', () => {
+        expect(
+          selectOutputTemplate("NAVIGATION", ["report_received", "next_steps"], "what next?"),
+        ).toBe(BIOPSY_NEXT_STEPS);
+      });
+
+      // Stale/unrelated historical biopsy → upstream does NOT set report_received,
+      // so a bare "what next?" must NOT auto-route to biopsy.
+      test("stale biopsy history (no active signal) does NOT route to biopsy", () => {
+        expect(selectOutputTemplate("NAVIGATION", ["next_steps"], "what next?")).not.toBe(BIOPSY_NEXT_STEPS);
       });
 
       test("keyword: biopsy in text", () => {

--- a/apps/api/src/modules/chat/structured-output-templates.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.ts
@@ -488,6 +488,26 @@ export const TEMPLATE_REGISTRY: Record<string, OutputTemplate> = {
  * Select the best template based on agentic category + detected signals.
  * Returns null if no structured template matches (falls back to existing flow).
  */
+/**
+ * Select a structured output template for an agentic scenario, or null.
+ *
+ * ── ACTIVE BIOPSY CONTEXT (biopsy router boundary) ──
+ * The biopsy template is used ONLY when biopsy/report context is *active*,
+ * defined as exactly one of:
+ *   1. the CURRENT user message references a biopsy/report — a keyword or phrase
+ *      such as "biopsy report", "biopsy ho gayi", "बायोप्सी रिपोर्ट"; OR
+ *   2. the CURRENT care thread is about a biopsy/report — surfaced by the caller
+ *      as the `report_received` signal (e.g. the immediately prior turn).
+ *
+ * It is explicitly NOT active for:
+ *   - a bare "what next?" / `next_steps` with no biopsy context; or
+ *   - a vague, unrelated biopsy mention from earlier history. Recency / thread
+ *     relevance is the CALLER's responsibility: the caller MUST NOT set
+ *     `report_received` for a stale historical mention.
+ *
+ * Executable boundary: structured-output-templates.spec.ts →
+ * "ACTIVE biopsy context — boundary definition".
+ */
 export function selectOutputTemplate(
   category: string,
   signals: string[],

--- a/apps/api/src/modules/chat/structured-output-templates.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.ts
@@ -503,10 +503,17 @@ export function selectOutputTemplate(
   const biopsyContext =
     /\b(biopsy|report|pathology|diagnosed|result)\b/i.test(lowerText) ||
     /(बायोप्सी|रिपोर्ट|पैथोलॉजी)/.test(lowerText);
+  // Route to biopsy ONLY with real biopsy context — either:
+  //  • report_received signal (the upstream sets this from the current message
+  //    OR reliable *active* session context; it must NOT set it for a stale,
+  //    unrelated historical biopsy mention), or
+  //  • next_steps + an in-message biopsy keyword, or
+  //  • an explicit "biopsy report/done" phrase in the message.
+  // "next_steps" / "what next?" ALONE never routes here (too broad).
   if (
     signals.includes("report_received") ||
     (signals.includes("next_steps") && biopsyContext) ||
-    /\bbiopsy\s+(report|result|says?|shows?)\b/i.test(lowerText) ||
+    /\bbiopsy\s+(report|result|says?|shows?|ho\s*gay[ai]|hui|done|complete[d]?)\b/i.test(lowerText) ||
     /बायोप्सी\s*(रिपोर्ट|रिज़ल्ट|रिजल्ट|आई|आ\s*गई|हो\s*गई)/.test(lowerText)
   ) {
     return BIOPSY_NEXT_STEPS;

--- a/apps/api/src/modules/chat/structured-output-templates.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.ts
@@ -12,6 +12,8 @@
  * Zero LLM cost: templates are deterministic structures.
  */
 
+import { normalizeForMatch } from "../safety/text-normalizer";
+
 // ─── Template Definitions ─────────────────────────────────────
 
 export interface OutputSection {
@@ -491,28 +493,40 @@ export function selectOutputTemplate(
   signals: string[],
   userText: string
 ): OutputTemplate | null {
-  const lowerText = userText.toLowerCase();
+  // NFC + invisible-char/whitespace normalization, then lowercase. Note: ASCII
+  // terms keep \b boundaries; Devanagari terms must NOT use \b — JavaScript word
+  // boundaries only recognize ASCII, so \b adjacent to Devanagari never matches.
+  const lowerText = normalizeForMatch(userText).toLowerCase();
 
-  // Biopsy-related queries — require explicit biopsy/report context
-  // "next_steps" alone is too broad (matches "what should I do" on symptom queries)
+  // Biopsy-related queries — require explicit biopsy/report context.
+  // "next_steps" alone is too broad (matches "what should I do" on symptom queries).
+  const biopsyContext =
+    /\b(biopsy|report|pathology|diagnosed|result)\b/i.test(lowerText) ||
+    /(बायोप्सी|रिपोर्ट|पैथोलॉजी)/.test(lowerText);
   if (
     signals.includes("report_received") ||
-    (signals.includes("next_steps") && /\b(biopsy|report|pathology|diagnosed|result|रिपोर्ट|बायोप्सी)\b/i.test(lowerText)) ||
-    /\b(biopsy|बायोप्सी)\s+(report|result|says?|shows?)\b/i.test(lowerText)
+    (signals.includes("next_steps") && biopsyContext) ||
+    /\bbiopsy\s+(report|result|says?|shows?)\b/i.test(lowerText) ||
+    /बायोप्सी\s*(रिपोर्ट|रिज़ल्ट|रिजल्ट|आई|आ\s*गई|हो\s*गई)/.test(lowerText)
   ) {
     return BIOPSY_NEXT_STEPS;
   }
 
   // Chemo preparation
-  if (
-    /\b(chemo|chemotherapy|कीमो|कीमोथेरेपी)\b/i.test(lowerText) &&
-    /\b(prepare|preparation|ready|day|what to|kya|kaise|तैयारी)\b/i.test(lowerText)
-  ) {
+  const isChemo = /\b(chemo|chemotherapy)\b/i.test(lowerText) || /कीमो/.test(lowerText);
+  const isPrep =
+    /\b(prepare|preparation|ready|day|what to|kya|kaise)\b/i.test(lowerText) ||
+    /तैयारी/.test(lowerText);
+  if (isChemo && isPrep) {
     return CHEMO_DAY_PREP;
   }
 
   // Second opinion
-  if (/\b(second opinion|दूसरी राय|dusri raay)\b/i.test(lowerText)) {
+  if (
+    /\bsecond opinion\b/i.test(lowerText) ||
+    /\bdusri\s*raay\b/i.test(lowerText) ||
+    /दूसरी\s*राय/.test(lowerText)
+  ) {
     return SECOND_OPINION_PREP;
   }
 
@@ -520,7 +534,8 @@ export function selectOutputTemplate(
   if (
     category === "SCHEMES" ||
     signals.includes("budget_concern") ||
-    /\b(ayushman|scheme|योजना|आयुष्मान|card|कार्ड|paisa|पैसा)\b/i.test(lowerText)
+    /\b(ayushman|scheme|card|paisa)\b/i.test(lowerText) ||
+    /(योजना|आयुष्मान|कार्ड|पैसा)/.test(lowerText)
   ) {
     return SCHEME_APPLICATION_CHECKLIST;
   }

--- a/apps/api/src/modules/rag/cross-lingual.service.spec.ts
+++ b/apps/api/src/modules/rag/cross-lingual.service.spec.ts
@@ -137,8 +137,21 @@ describe("CrossLingualService", () => {
       const result = service.generateParallelQueries(
         "What is cancer treatment in Hindi कैंसर"
       );
-      // Mostly English → should still translate the Hindi terms
-      expect(result.detectedLanguage).toBe("en"); // Mostly English
+      // Mostly English → classified "en"...
+      expect(result.detectedLanguage).toBe("en");
+      // ...but the Devanagari term is STILL translated for KB retrieval (a low
+      // Devanagari ratio must not skip translation — regression guard).
+      expect(result.translatedTerms).toContain("cancer");
+    });
+
+    test("low-Devanagari mixed query still translates its Devanagari term", () => {
+      const result = service.generateParallelQueries(
+        "I want some information about कैंसर treatment options please"
+      );
+      expect(result.detectedLanguage).toBe("en"); // ~10% Devanagari by ratio
+      expect(result.translatedTerms).toContain("cancer");
+      // The translated variant is offered as a parallel query for retrieval.
+      expect(result.parallelQueries.length).toBeGreaterThan(1);
     });
   });
 });

--- a/apps/api/src/modules/rag/cross-lingual.service.ts
+++ b/apps/api/src/modules/rag/cross-lingual.service.ts
@@ -29,8 +29,9 @@ export interface CrossLingualResult {
 // ─── Hindi → English medical dictionary ──────────────────────────
 
 const HI_EN_DICTIONARY: Array<[RegExp, string]> = [
-  // Cancer types
-  [/कैंसर/g, "cancer"],
+  // Cancer types — specific (multi-word) types MUST come before the generic
+  // /कैंसर/, otherwise "स्तन कैंसर" gets the bare word replaced first and
+  // "breast cancer" never forms (longest-match-first ordering).
   [/स्तन\s*कैंसर/g, "breast cancer"],
   [/फेफड़े?\s*(का|के|की)?\s*कैंसर/g, "lung cancer"],
   [/गर्भाशय\s*(का|के|की)?\s*कैंसर/g, "cervical cancer"],
@@ -41,6 +42,7 @@ const HI_EN_DICTIONARY: Array<[RegExp, string]> = [
   [/गुर्दे?\s*(का|के|की)?\s*कैंसर/g, "kidney cancer"],
   [/प्रोस्टेट\s*कैंसर/g, "prostate cancer"],
   [/ब्रेन\s*(ट्यूमर|कैंसर)/g, "brain cancer"],
+  [/कैंसर/g, "cancer"],
 
   // Symptoms
   [/लक्षण/g, "symptoms"],
@@ -252,7 +254,10 @@ export class CrossLingualService {
     const devanagariRatio = devanagariCount / total;
 
     if (devanagariRatio > 0.6) return "hi";
-    if (devanagariRatio > 0.1) return "mixed";
+    // Threshold of 0.2 (not 0.1): a lone Hindi word inside an otherwise English
+    // sentence (e.g. "...in Hindi कैंसर") should read as English, while a
+    // genuinely code-mixed query (~40%+ Devanagari) reads as mixed.
+    if (devanagariRatio > 0.2) return "mixed";
 
     // Check for Romanized Hindi (Hinglish) — all Latin script but Hindi words
     const hinglishMarkers = /\b(mujhe|jaankari|jankari|baare\s*mein|bare\s*me|batao|bataiye|chahiye|kaise|kya\s*hai|ilaaj|dawai|gaanth|bukhar|saans|lakshan|janch|aage\s*kya|paise|sarkari|kharcha)\b/gi;

--- a/apps/api/src/modules/rag/cross-lingual.service.ts
+++ b/apps/api/src/modules/rag/cross-lingual.service.ts
@@ -157,9 +157,14 @@ export class CrossLingualService {
     const translatedTerms: string[] = [];
     const parallelQueries: string[] = [query]; // Always include original
 
-    if (language === "en") {
-      // English query — no translation needed for English KB
-      // (English is the primary KB language)
+    // Short-circuit ONLY for pure English (no Devanagari at all). A query that
+    // classifies "en" by ratio but still contains Devanagari medical terms
+    // (e.g. "treatment for स्तन cancer stage 2") must still be translated for the
+    // English KB — the Devanagari nouns are the highest-value retrieval terms.
+    // We keep detectedLanguage as classified; only the translation runs.
+    const hasDevanagari = /[ऀ-ॿ]/.test(query);
+    if (language === "en" && !hasDevanagari) {
+      // Pure English — no translation needed for the English-primary KB.
       return {
         original: query,
         parallelQueries: [query],

--- a/apps/api/src/modules/rag/query-decomposer.service.ts
+++ b/apps/api/src/modules/rag/query-decomposer.service.ts
@@ -109,10 +109,10 @@ const SIGNALS: Signal[] = [
   {
     name: "report_received",
     patterns: [
-      /\b(biopsy|report|result)\s*(aaya|aya|came|received|milaa?|aai|mil\s*gaya)\b/i,
+      /\b(biopsy|report|result)\s+(aa\s*gaya|aa\s*gayi|aa\s*gai|aaya|aya|aai|came|received|mil\s*gaya|mil\s*gayi|milaa?)\b/i,
       /\b(got|have|received)\s+(my|the|a)\s+(biopsy|report|test\s*result|scan\s*result)/i,
-      /बायोप्सी\s*(रिपोर्ट)?\s*(आया|आई|मिला)/i,
-      /रिपोर्ट\s*(आ\s*गई|मिल\s*गई|आई)/i,
+      /बायोप्सी\s*(रिपोर्ट)?\s*(आया|आई|मिला|आ\s*गई|आ\s*गया)/i,
+      /रिपोर्ट\s*(आ\s*गई|आ\s*गया|मिल\s*गई|आई)/i,
     ],
     retrieval: {
       intent: "checklist",


### PR DESCRIPTION
## Cluster C — retrieval half (Hindi/Hinglish coverage)

Stacked on #31. The **same `\b`-on-Devanagari anti-pattern** that disabled the safety rules also silently broke Hindi handling in the retrieval layer. This restores it.

> **Base branch: `fix/hindi-safety`** (reuses `normalizeForMatch`). Review/merge #31 first; this diff shows only the RAG changes.

### Fixes
- **`structured-output-templates`** — `/\b(...|कीमो|योजना|आयुष्मान|दूसरी राय|बायोप्सी)\b/` never matched the Devanagari terms (JS `\b` is ASCII-only), so Hindi biopsy / chemo-prep / second-opinion / scheme queries fell through to *no template*. Reworked `selectOutputTemplate` to normalize input and test ASCII terms with `\b`, Devanagari terms without. Added Hindi biopsy-report routing.
- **`cross-lingual`** — two bugs: (1) generic `/कैंसर/→cancer` ran *before* `/स्तन कैंसर/→breast cancer`, so specific types never formed → reordered longest-match-first; (2) the mixed-language threshold of `0.1` mis-flagged a lone Hindi word in an English sentence as `"mixed"` → raised to `0.2`.
- **`query-decomposer`** — `report_received` missed the common Romanized `"aa gaya/gayi"` ("biopsy report aa gaya hai") → added those + Devanagari `"आ गया/गई"` variants.

### ⚠️ One behavior contract — please confirm
`next_steps` alone still does **not** route to the biopsy template — it requires explicit biopsy/report context. This is the documented intent in `selectOutputTemplate` (commit `e6436aa`, a false-positive fix), but the test asserted the old over-broad behavior. I updated it to match the documented contract + added a negative test. **If you intended `next_steps` alone to route to biopsy, this is the one to flag.**

### Tests
- cross-lingual **15/15**, structured-output-templates **50/50**, query-decomposer **19/19**; `nest build` clean.

### Deliberately NOT done (noted for follow-up)
- **Locale-threshold unification** (disclaimer-engine 0.3 vs cross-lingual 0.2/0.6). The two detectors do different jobs and each passes its own tests; forcing unification risks regressions for marginal gain. Left as a separate, considered decision rather than a drive-by change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
