### PR TITLE
fix(distribution): drop doubled v1 route prefix so approval links resolve

### DIFF
--- a/apps/api/src/modules/distribution/distribution.controller.spec.ts
+++ b/apps/api/src/modules/distribution/distribution.controller.spec.ts
@@ -1,0 +1,14 @@
+import { PATH_METADATA } from "@nestjs/common/constants";
+import { DistributionController } from "./distribution.controller";
+
+// Regression guard: the app sets a global `v1` prefix (main.ts). If this
+// controller's @Controller path also starts with `v1`, routes serve at
+// /v1/v1/distribution and the pack-mailer approval links (which point at
+// /v1/distribution/...) 404 — silently breaking the one-click approve flow.
+describe("DistributionController routing", () => {
+  it("does not repeat the global v1 prefix", () => {
+    const path = Reflect.getMetadata(PATH_METADATA, DistributionController);
+    expect(path).toBe("distribution");
+    expect(path).not.toMatch(/^v1\b/);
+  });
+});

--- a/apps/api/src/modules/distribution/distribution.controller.ts
+++ b/apps/api/src/modules/distribution/distribution.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Param, Query, Res, Logger } from "@nestjs/common";
 import { Response } from "express";
 import { DistributionApproveService } from "./distribution-approve.service";
 
-@Controller("v1/distribution")
+// NOTE: the app sets a global `v1` prefix (main.ts), so this must NOT repeat it —
+// otherwise routes serve at /v1/v1/distribution and the email approval links 404.
+@Controller("distribution")
 export class DistributionController {
   private readonly logger = new Logger(DistributionController.name);
 


### PR DESCRIPTION
## Problem

The app sets a global \`v1\` prefix (\`main.ts\`: \`app.setGlobalPrefix("v1")\`), but \`distribution.controller.ts\` declared \`@Controller("v1/distribution")\` — so the routes actually served at **\`/v1/v1/distribution/...\`**.

Meanwhile \`distribution/pack-mailer.ts\` builds the one-click approval links at the single-prefix path \`/v1/distribution/approve/:slug\`. Result: **every approve/reject email link 404'd** — the feature was dead end-to-end in production (verified against the live service: single-prefix path → \`Cannot GET\` 404; doubled-prefix path → 401 with the proper HTML error page).

## Fix

- \`@Controller("v1/distribution")\` → \`@Controller("distribution")\` (now serves at \`/v1/distribution\`, matching the email links).
- Added a reflection-based regression test asserting the controller path never starts with \`v1\`.

## Note

The \`whatsapp-navigator\` controller has the identical \`v1/\`-prefix flaw, but its webhook URL is likely already registered with Meta at the current path — fixing it needs a coordinated change (update Meta's webhook config too), so it's intentionally left out of this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)