### PR TITLE
fix(whatsapp-navigator): drop doubled v1 route prefix; correct docs

### DIFF
--- a/apps/api/src/modules/whatsapp-navigator/whatsapp-navigator.controller.spec.ts
+++ b/apps/api/src/modules/whatsapp-navigator/whatsapp-navigator.controller.spec.ts
@@ -1,0 +1,14 @@
+import { PATH_METADATA } from "@nestjs/common/constants";
+import { WhatsAppNavigatorController } from "./whatsapp-navigator.controller";
+
+// Regression guard: the app sets a global `v1` prefix (main.ts). If this
+// controller's @Controller path also starts with `v1`, the webhook serves at
+// /v1/v1/whatsapp-navigator/webhook and diverges from the documented
+// /v1/whatsapp-navigator/webhook path.
+describe("WhatsAppNavigatorController routing", () => {
+  it("does not repeat the global v1 prefix", () => {
+    const path = Reflect.getMetadata(PATH_METADATA, WhatsAppNavigatorController);
+    expect(path).toBe("whatsapp-navigator");
+    expect(path).not.toMatch(/^v1\b/);
+  });
+});

--- a/apps/api/src/modules/whatsapp-navigator/whatsapp-navigator.controller.ts
+++ b/apps/api/src/modules/whatsapp-navigator/whatsapp-navigator.controller.ts
@@ -23,7 +23,10 @@ interface WebhookResponseDto {
 
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
-@Controller("v1/whatsapp-navigator")
+// NOTE: the app sets a global `v1` prefix (main.ts), so this must NOT repeat it —
+// otherwise routes serve at /v1/v1/whatsapp-navigator and diverge from the
+// documented path /v1/whatsapp-navigator/webhook.
+@Controller("whatsapp-navigator")
 export class WhatsAppNavigatorController {
   private readonly logger = new Logger(WhatsAppNavigatorController.name);
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -47,7 +47,7 @@ Suchi is a cancer information assistant operated by the Suchitra Cancer Care Fou
 | Web chat | `POST /v1/chat` | Active |
 | Voice (REST) | `POST /v1/voice/query` | Active |
 | Voice (WebSocket) | `WS /v1/voice-ws` | Opt-in (`VOICE_WS_ENABLED`) |
-| WhatsApp (Navigator) | Hospital-navigator flow via Meta webhook (`/v1/whatsapp-navigator/webhook`) | Active (legacy) |
+| WhatsApp (Navigator) | Hospital-navigator state machine at `/v1/whatsapp-navigator/webhook` — custom JSON endpoint (`{phone, message}`), **not** a Meta webhook (no `hub.challenge` handshake, no `X-Hub-Signature-256`, no WABA creds) | Dormant (legacy) — no inbound traffic; superseded by §16 |
 | WhatsApp (Conversational) | Full chat pipeline via Meta Cloud API (`/v1/whatsapp/webhook`) — see §16 | Planned |
 
 ### 1.2 Languages


### PR DESCRIPTION
## Context

Follow-up to the distribution route-prefix fix (#44). The legacy WhatsApp Navigator controller had the identical flaw: `@Controller("v1/whatsapp-navigator")` combined with the global `v1` prefix (`main.ts`) → served at `/v1/v1/whatsapp-navigator/webhook`, diverging from the documented `/v1/whatsapp-navigator/webhook`.

## Why this is safe (inert bug)

Investigation showed the legacy navigator is **dormant**, not a live Meta integration:
- Custom JSON endpoint (`{phone, message}`), **not** Meta's webhook payload
- No `hub.challenge` verification handshake, no `X-Hub-Signature-256` check
- No WABA/verify-token credentials configured on the service
- **Zero** real inbound traffic in 180 days (only manual test calls)

So nothing points at either path — fixing the prefix has no live impact, just restores correctness and doc/convention agreement.

## Changes

- `@Controller("v1/whatsapp-navigator")` → `@Controller("whatsapp-navigator")` (serves at `/v1/whatsapp-navigator`)
- Reflection-based regression test asserting the path never starts with `v1`
- `REQUIREMENTS.md`: corrected the channel row — it's a **dormant** custom state machine, **not** a Meta webhook; the real Meta integration is the Planned Conversational channel (§16)

## Deploy

No standalone deploy — rides the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)