### PR TITLE
fix(ci): separate eval outcome from notification delivery in Tier1 eval workflow

### DIFF
--- a/.github/workflows/eval-tier1.yml
+++ b/.github/workflows/eval-tier1.yml
@@ -1,5 +1,31 @@
 name: Eval Tier1 - Retrieval Quality
 
+# Status model (issue #47) — three independently reported outcomes:
+#   1. Evaluation outcome  -> the ONLY thing that decides the job's CI conclusion
+#                             (enforced by the final "Enforce evaluation status" step).
+#   2. Report/artifact     -> shown in the job summary; upload failure emits a
+#                             warning annotation but does not fail CI.
+#   3. Notification (email)-> runs with continue-on-error; a delivery failure is a
+#                             DEGRADED OPERATION (warning + summary line), never a
+#                             CI failure. A true eval failure fails CI regardless
+#                             of whether the email was delivered.
+#
+# Simulating the notification-failure regression (run 28731647092, SMTP 535):
+#   - Locally:   cd eval && npm run test:ci
+#                (eval/ci/eval-status.test.js contains the regression test:
+#                 "eval passed + email delivery failed => CI still passes")
+#   - In CI:     trigger workflow_dispatch with an invalid SMTP_PASSWORD secret (or
+#                revoke the app password). Expected statuses:
+#                  * eval passes  -> job GREEN, summary shows
+#                    "Notification: degraded: notification failed" + warning annotation
+#                  * eval fails   -> job RED with "Evaluation failed" error annotation,
+#                    regardless of email delivery outcome
+#                  * no report    -> job RED with "Eval infrastructure error" annotation
+#
+# Log hygiene: SMTP secrets are auto-masked by Actions; the recipient address is
+# additionally masked via ::add-mask:: before any step that could echo it, and the
+# helper script (eval/ci/eval-status.js) never handles recipients or credentials.
+
 on:
   # Manual trigger
   workflow_dispatch:
@@ -8,12 +34,12 @@ on:
         description: 'API Base URL (optional, defaults to live service)'
         required: false
         default: 'https://suchi-api-lxiveognla-uc.a.run.app/v1'
-  
+
   # Nightly schedule (runs at 2 AM UTC)
   schedule:
     - cron: '0 2 * * *'
-  
-  # On PRs touching RAG/evidence modules (non-blocking initially)
+
+  # On PRs touching RAG/evidence modules
   pull_request:
     paths:
       - 'apps/api/src/modules/rag/**'
@@ -22,15 +48,23 @@ on:
       - 'apps/api/src/config/trusted-sources.config.ts'
       - 'eval/cases/tier1/**'
       - 'eval/**/*.ts'
-    # Non-blocking: continue-on-error is set on the eval step
+      - 'eval/ci/**'
+      - '.github/workflows/eval-tier1.yml'
+
+env:
+  # Notification recipient. Kept in one place; masked from logs at job start.
+  EVAL_NOTIFY_TO: gautamgauri@dikshafoundation.org
 
 jobs:
   eval-tier1:
     name: Run Tier1 Retrieval Quality Eval
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    
+
     steps:
+      - name: Redact notification recipient from logs
+        run: echo "::add-mask::$EVAL_NOTIFY_TO"
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -48,6 +82,10 @@ jobs:
       - name: Build eval package
         working-directory: eval
         run: npm run build
+
+      - name: Test CI status helper
+        working-directory: eval
+        run: npm run test:ci
 
       - name: Verify case manifest (disappearance guard)
         working-directory: eval
@@ -68,6 +106,8 @@ jobs:
           curl -f "$API_URL/health" || echo "Warning: Health check failed, but continuing..."
         continue-on-error: true
 
+      # continue-on-error so the reporting/notification steps below always run;
+      # the true evaluation outcome is enforced by the final step of this job.
       - name: Run Tier1 Eval
         working-directory: eval
         env:
@@ -78,164 +118,85 @@ jobs:
           GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT || 'gen-lang-client-0202543132' }}
         run: |
           npm run eval:tier1
-        continue-on-error: true  # Non-blocking until Pass 2/3 verified
+        continue-on-error: true
         id: eval-run
 
-      - name: Generate summary
+      # Machine-readable outcome + metrics (schema in eval/ci/eval-status.js).
+      # Distinguishes: passed | failed (true eval failure) | infra_error (no usable report).
+      - name: Build eval-result.json
+        id: eval-result
+        if: always()
         working-directory: eval
-        if: always()
         run: |
-          if [ -f "reports/tier1-report.json" ]; then
-            echo "## Tier1 Eval Summary" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            node -e "
-              const fs = require('fs');
-              const report = JSON.parse(fs.readFileSync('reports/tier1-report.json', 'utf8'));
-              const q = report.summary.retrievalQuality || {};
-              console.log('### Retrieval Quality Metrics');
-              console.log('');
-              console.log(\`- **Top-3 Trusted Source Presence:** \${(q.top3TrustedPresenceRate * 100).toFixed(1)}%\`);
-              console.log(\`- **Citation Coverage:** \${(q.citationCoverageRate * 100).toFixed(1)}%\`);
-              console.log(\`- **Abstention Rate:** \${(q.abstentionRate * 100).toFixed(1)}%\`);
-              console.log('');
-              console.log(\`- **Total Cases:** \${report.summary.total}\`);
-              console.log(\`- **Passed:** \${report.summary.passed}\`);
-              console.log(\`- **Failed:** \${report.summary.failed}\`);
-              console.log(\`- **Average Score:** \${(report.summary.averageScore * 100).toFixed(1)}%\`);
-            " >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️ No report file found" >> $GITHUB_STEP_SUMMARY
-          fi
+          node ci/eval-status.js result \
+            --report reports/tier1-report.json \
+            --eval-outcome "${{ steps.eval-run.outcome }}" \
+            --output reports/eval-result.json
 
+      # Includes the per-case structured records (*.records.json) and the
+      # failure-cluster report emitted by the run (issue #48).
       - name: Upload eval report
+        id: upload-report
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: tier1-eval-report-${{ github.run_number }}
           path: |
-            eval/reports/tier1-report.json
-            eval/reports/tier1-*.json
-            eval/reports/tier1-*.md
+            eval/reports/*.json
+            eval/reports/*.md
           retention-days: 30
           if-no-files-found: warn
 
-      - name: Check eval results
+      - name: Write job summary (eval result, metrics, artifact status)
         if: always()
+        working-directory: eval
         run: |
-          if [ "${{ steps.eval-run.outcome }}" != "success" ]; then
-            echo "⚠️ Eval run completed with errors (non-blocking mode)"
-            echo "Review the report artifact to identify issues"
-            exit 0  # Don't fail the workflow in non-blocking mode
-          fi
-          
-          # Check if report exists and has reasonable metrics
-          if [ -f "eval/reports/tier1-report.json" ]; then
-            node -e "
-              const fs = require('fs');
-              const report = JSON.parse(fs.readFileSync('eval/reports/tier1-report.json', 'utf8'));
-              const q = report.summary.retrievalQuality || {};
-              
-              // Count improved cases (top3TrustedPresence === true)
-              const improved = report.results.filter(r => r.retrievalQuality?.top3TrustedPresence).length;
-              
-              console.log('Improved cases:', improved);
-              console.log('Top-3 Trusted Rate:', (q.top3TrustedPresenceRate * 100).toFixed(1) + '%');
-              console.log('Citation Coverage:', (q.citationCoverageRate * 100).toFixed(1) + '%');
-              
-              // Warn if metrics are below expectations (but don't fail in non-blocking mode)
-              if (improved < 3) {
-                console.warn('⚠️ WARNING: Less than 3 cases showing improved top-3 relevance');
-              }
-              if (q.citationCoverageRate < 0.90) {
-                console.warn('⚠️ WARNING: Citation coverage below 90%');
-              }
-              if (q.abstentionRate > 0.10) {
-                console.warn('⚠️ WARNING: Abstention rate above 10%');
-              }
-            "
+          node ci/eval-status.js summary \
+            --result reports/eval-result.json \
+            --artifact-outcome "${{ steps.upload-report.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.upload-report.outcome }}" = "failure" ]; then
+            echo "::warning title=Artifact upload failed::Report artifact upload failed (reporting issue, not an eval failure)."
           fi
 
       - name: Generate email report
         id: email-report
-        if: always()
+        if: always() && steps.eval-result.outputs.should_notify == 'true'
         working-directory: eval
-        run: |
-          if [ -f "reports/tier1-report.json" ]; then
-            node -e "
-              const fs = require('fs');
-              const report = JSON.parse(fs.readFileSync('reports/tier1-report.json', 'utf8'));
-              const s = report.summary;
-              const q = s.retrievalQuality || {};
+        run: node ci/eval-status.js email --report reports/tier1-report.json --out-dir .
 
-              // Get failed cases (up to 5 with details)
-              const failed = report.results.filter(r => !r.passed).slice(0, 5);
-
-              let body = '# Suchi Daily Eval Report\\n\\n';
-              body += '## Summary\\n';
-              body += '| Metric | Value |\\n|--------|-------|\\n';
-              body += '| Total Tests | ' + s.total + ' |\\n';
-              body += '| Passed | ' + s.passed + ' (' + ((s.passed/s.total)*100).toFixed(1) + '%) |\\n';
-              body += '| Failed | ' + s.failed + ' |\\n';
-              body += '| Average Score | ' + (s.averageScore * 100).toFixed(1) + '% |\\n';
-              body += '| Trusted Source Rate | ' + (q.top3TrustedPresenceRate * 100).toFixed(1) + '% |\\n';
-              body += '| Citation Coverage | ' + (q.citationCoverageRate * 100).toFixed(1) + '% |\\n\\n';
-
-              if (failed.length > 0) {
-                body += '## Failed Cases (Top 5)\\n\\n';
-                failed.forEach((r, i) => {
-                  body += '### ' + (i+1) + '. ' + r.testCaseId + ' (Score: ' + (r.score*100).toFixed(1) + '%)\\n';
-
-                  // Deterministic failures
-                  const detFail = (r.deterministicResults || []).filter(c => !c.passed);
-                  if (detFail.length > 0) {
-                    body += '**Deterministic:** ' + detFail.map(c => c.checkId).join(', ') + '\\n';
-                  }
-
-                  // LLM failures
-                  const llmFail = (r.llmJudgeResults || []).filter(c => !c.passed && !c.skipped);
-                  if (llmFail.length > 0) {
-                    body += '**LLM Judge:** ' + llmFail.map(c => c.checkId + (c.count !== null ? ' ('+c.count+')' : '')).join(', ') + '\\n';
-                  }
-                  body += '\\n';
-                });
-
-                if (s.failed > 5) {
-                  body += '_...and ' + (s.failed - 5) + ' more failures. See full report in GitHub Actions._\\n';
-                }
-              } else {
-                body += '## All tests passed! ✅\\n';
-              }
-
-              body += '\\n---\\n';
-              body += 'View full report: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\\n';
-
-              // Output for email
-              const subject = s.failed > 0
-                ? 'Suchi Eval: ' + s.failed + ' failures (' + (s.averageScore*100).toFixed(0) + '% avg)'
-                : 'Suchi Eval: All ' + s.total + ' tests passed ✅';
-
-              fs.writeFileSync('email-subject.txt', subject);
-              fs.writeFileSync('email-body.md', body);
-
-              // Set outputs
-              console.log('should_send=' + (s.failed > 0 ? 'true' : 'false'));
-            " > /tmp/email-output.txt
-
-            echo "should_send=$(cat /tmp/email-output.txt | grep should_send | cut -d= -f2)" >> $GITHUB_OUTPUT
-          else
-            echo "should_send=false" >> $GITHUB_OUTPUT
-          fi
-
+      # continue-on-error: a delivery failure must never fail the workflow (issue #47).
+      # Its outcome is reported by the "Report notification status" step below.
       - name: Send email notification
-        if: always() && steps.email-report.outputs.should_send == 'true'
+        id: send-email
+        if: always() && steps.eval-result.outputs.should_notify == 'true'
+        continue-on-error: true
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.SMTP_SERVER }}
           server_port: ${{ secrets.SMTP_PORT }}
           username: ${{ secrets.SMTP_USERNAME }}
           password: ${{ secrets.SMTP_PASSWORD }}
-          subject: ${{ steps.email-report.outputs.email_subject || 'Suchi Daily Eval Report' }}
-          to: gautamgauri@dikshafoundation.org
+          subject: ${{ steps.eval-result.outputs.email_subject || 'Suchi Daily Eval Report' }}
+          to: ${{ env.EVAL_NOTIFY_TO }}
           from: ${{ secrets.SMTP_USERNAME }}
           body: file://eval/email-body.md
           convert_markdown: true
+
+      - name: Report notification status
+        if: always()
+        working-directory: eval
+        run: |
+          node ci/eval-status.js notify-status \
+            --send-outcome "${{ steps.send-email.outcome }}" \
+            --should-notify "${{ steps.eval-result.outputs.should_notify }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.send-email.outcome }}" = "failure" ]; then
+            echo "::warning title=Notification degraded::Email delivery failed. This is a degraded operation only — the evaluation status is unaffected."
+          fi
+
+      # The single source of truth for the job's CI conclusion:
+      # exit 0 only when the evaluation itself passed.
+      - name: Enforce evaluation status
+        if: always()
+        working-directory: eval
+        run: node ci/eval-status.js check --result reports/eval-result.json

--- a/eval/ci/eval-status.js
+++ b/eval/ci/eval-status.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ * CI status helper for the Tier1 eval workflow (.github/workflows/eval-tier1.yml).
+ *
+ * Separates three independently reported outcomes so the GitHub status is
+ * unambiguous (see issue #47):
+ *   1. evaluation outcome        -> drives the CI conclusion (check subcommand)
+ *   2. report/artifact outcome   -> shown in the job summary, warning on failure
+ *   3. notification outcome      -> shown in the job summary; failure is a
+ *                                   "degraded operation" warning, never a CI failure
+ *
+ * Plain Node (no deps) so it is unit-testable with `node --test` and does not
+ * interact with the TypeScript build. Never prints secrets or recipient
+ * addresses; callers must not pass them in.
+ *
+ * Subcommands:
+ *   result        --report <tier1-report.json> --eval-outcome <success|failure|...>
+ *                 --output <eval-result.json>
+ *                 Writes the machine-readable eval-result.json and emits
+ *                 GITHUB_OUTPUT lines (eval_status, should_notify, email_subject).
+ *   summary       --result <eval-result.json> --artifact-outcome <outcome>
+ *                 Prints the job-summary markdown (pipe to $GITHUB_STEP_SUMMARY).
+ *   email         --report <tier1-report.json> --out-dir <dir>
+ *                 Writes email-subject.txt and email-body.md.
+ *   notify-status --send-outcome <success|failure|skipped> --should-notify <true|false>
+ *                 Prints the notification section for the job summary.
+ *   check         --result <eval-result.json>
+ *                 Exits 0 only if evaluation passed; exits 1 with a distinct
+ *                 ::error:: for eval failure vs infrastructure error.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const EVAL_STATUS = {
+  PASSED: 'passed',
+  FAILED: 'failed',
+  INFRA_ERROR: 'infra_error',
+};
+
+/**
+ * Derive the evaluation status from the eval step outcome and the report.
+ * - No report            -> infra_error (the harness never produced results)
+ * - Report with failures -> failed (true evaluation failure)
+ * - Clean report but the eval process exited non-zero -> infra_error
+ * - Clean report, clean exit -> passed
+ */
+function deriveEvalStatus(evalStepOutcome, report) {
+  if (!report || !report.summary) return EVAL_STATUS.INFRA_ERROR;
+  if ((report.summary.failed || 0) > 0) return EVAL_STATUS.FAILED;
+  if (evalStepOutcome !== 'success') return EVAL_STATUS.INFRA_ERROR;
+  return EVAL_STATUS.PASSED;
+}
+
+/** Build the machine-readable eval-result.json payload. */
+function buildEvalResult({ report, evalStepOutcome, env = process.env, now = new Date() }) {
+  const status = deriveEvalStatus(evalStepOutcome, report);
+  const s = (report && report.summary) || {};
+  const q = s.retrievalQuality || null;
+  const failedCaseIds = report && Array.isArray(report.results)
+    ? report.results.filter((r) => !r.passed).map((r) => r.testCaseId)
+    : [];
+
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    run: {
+      repository: env.GITHUB_REPOSITORY || null,
+      runId: env.GITHUB_RUN_ID || null,
+      runNumber: env.GITHUB_RUN_NUMBER || null,
+      sha: env.GITHUB_SHA || null,
+      ref: env.GITHUB_REF_NAME || null,
+      workflow: env.GITHUB_WORKFLOW || null,
+    },
+    evaluation: {
+      status,
+      evalStepOutcome: evalStepOutcome || null,
+      reportFound: Boolean(report),
+      total: s.total ?? null,
+      passed: s.passed ?? null,
+      failed: s.failed ?? null,
+      skipped: s.skipped ?? null,
+      averageScore: s.averageScore ?? null,
+      retrievalQuality: q,
+      failedCaseIds,
+    },
+  };
+}
+
+function pct(x) {
+  return typeof x === 'number' ? `${(x * 100).toFixed(1)}%` : 'n/a';
+}
+
+function statusBadge(status) {
+  switch (status) {
+    case EVAL_STATUS.PASSED:
+      return '✅ passed';
+    case EVAL_STATUS.FAILED:
+      return '❌ failed (evaluation failure)';
+    default:
+      return '⚠️ infrastructure error (no usable eval result)';
+  }
+}
+
+/** Job-summary markdown: eval result, quality metrics, artifact status. */
+function buildSummaryMarkdown(result, artifactOutcome) {
+  const e = result.evaluation;
+  const q = e.retrievalQuality || {};
+  const artifactBadge =
+    artifactOutcome === 'success'
+      ? '✅ uploaded'
+      : artifactOutcome === 'skipped'
+        ? '⏭️ skipped'
+        : `⚠️ upload ${artifactOutcome || 'unknown'} (reporting issue, not an eval failure)`;
+
+  const lines = [
+    '## Tier1 Retrieval Quality — Status',
+    '',
+    '| Component | Status |',
+    '|-----------|--------|',
+    `| Evaluation | ${statusBadge(e.status)} |`,
+    `| Report artifact | ${artifactBadge} |`,
+    '',
+  ];
+
+  if (e.reportFound) {
+    lines.push(
+      '### Quality Metrics',
+      '',
+      '| Metric | Value |',
+      '|--------|-------|',
+      `| Total cases | ${e.total} |`,
+      `| Passed | ${e.passed} |`,
+      `| Failed | ${e.failed} |`,
+      `| Average score | ${pct(e.averageScore)} |`,
+      `| Top-3 trusted source presence | ${pct(q.top3TrustedPresenceRate)} |`,
+      `| Citation coverage | ${pct(q.citationCoverageRate)} |`,
+      `| Abstention rate | ${pct(q.abstentionRate)} |`,
+      ''
+    );
+    if (e.failedCaseIds.length > 0) {
+      lines.push(`**Failed cases:** ${e.failedCaseIds.join(', ')}`, '');
+    }
+  } else {
+    lines.push('⚠️ No report file was produced by the eval run.', '');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Notification section for the job summary. A delivery failure is reported as
+ * a degraded operation — it must never change the evaluation status.
+ */
+function buildNotificationSummary(sendOutcome, shouldNotify) {
+  let line;
+  if (shouldNotify !== 'true') {
+    line = '**Notification:** ⏭️ skipped (no notification required for this result)';
+  } else if (sendOutcome === 'success') {
+    line = '**Notification:** ✅ email sent';
+  } else if (sendOutcome === 'skipped') {
+    line = '**Notification:** ⏭️ skipped';
+  } else {
+    line =
+      '**Notification:** ⚠️ degraded: notification failed (email delivery error — ' +
+      'evaluation status is NOT affected)';
+  }
+  return `${line}\n`;
+}
+
+/** Email subject/body generation (recipient is never handled here). */
+function buildEmailReport(report, env = process.env) {
+  const s = report.summary;
+  const q = s.retrievalQuality || {};
+  const failed = report.results.filter((r) => !r.passed).slice(0, 5);
+
+  let body = '# Suchi Daily Eval Report\n\n';
+  body += '## Summary\n';
+  body += '| Metric | Value |\n|--------|-------|\n';
+  body += `| Total Tests | ${s.total} |\n`;
+  body += `| Passed | ${s.passed} (${((s.passed / s.total) * 100).toFixed(1)}%) |\n`;
+  body += `| Failed | ${s.failed} |\n`;
+  body += `| Average Score | ${(s.averageScore * 100).toFixed(1)}% |\n`;
+  body += `| Trusted Source Rate | ${((q.top3TrustedPresenceRate || 0) * 100).toFixed(1)}% |\n`;
+  body += `| Citation Coverage | ${((q.citationCoverageRate || 0) * 100).toFixed(1)}% |\n\n`;
+
+  if (failed.length > 0) {
+    body += '## Failed Cases (Top 5)\n\n';
+    failed.forEach((r, i) => {
+      body += `### ${i + 1}. ${r.testCaseId} (Score: ${(r.score * 100).toFixed(1)}%)\n`;
+      const detFail = (r.deterministicResults || []).filter((c) => !c.passed);
+      if (detFail.length > 0) {
+        body += `**Deterministic:** ${detFail.map((c) => c.checkId).join(', ')}\n`;
+      }
+      const llmFail = (r.llmJudgeResults || []).filter((c) => !c.passed && !c.skipped);
+      if (llmFail.length > 0) {
+        body += `**LLM Judge:** ${llmFail
+          .map((c) => c.checkId + (c.count !== null && c.count !== undefined ? ` (${c.count})` : ''))
+          .join(', ')}\n`;
+      }
+      body += '\n';
+    });
+    if (s.failed > 5) {
+      body += `_...and ${s.failed - 5} more failures. See full report in GitHub Actions._\n`;
+    }
+  } else {
+    body += '## All tests passed! ✅\n';
+  }
+
+  body += '\n---\n';
+  body += `View full report: https://github.com/${env.GITHUB_REPOSITORY || ''}/actions/runs/${env.GITHUB_RUN_ID || ''}\n`;
+
+  const subject =
+    s.failed > 0
+      ? `Suchi Eval: ${s.failed} failures (${(s.averageScore * 100).toFixed(0)}% avg)`
+      : `Suchi Eval: All ${s.total} tests passed ✅`;
+
+  return { subject, body, shouldSend: s.failed > 0 };
+}
+
+/** Exit code + annotations for the final CI gate. */
+function evaluateCheck(result) {
+  if (!result || !result.evaluation) {
+    return {
+      exitCode: 1,
+      message: '::error title=Eval infrastructure error::eval-result.json is missing or malformed.',
+    };
+  }
+  const e = result.evaluation;
+  switch (e.status) {
+    case EVAL_STATUS.PASSED:
+      return { exitCode: 0, message: `Evaluation passed (${e.passed}/${e.total} cases).` };
+    case EVAL_STATUS.FAILED:
+      return {
+        exitCode: 1,
+        message: `::error title=Evaluation failed::${e.failed} of ${e.total} eval cases failed. This is a true evaluation failure (not a notification or reporting issue).`,
+      };
+    default:
+      return {
+        exitCode: 1,
+        message:
+          '::error title=Eval infrastructure error::The eval run did not produce a usable result (harness/report failure, not a quality failure).',
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) {
+      args[argv[i].slice(2)] = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function readJsonIfExists(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function appendGithubOutput(lines, env = process.env) {
+  if (env.GITHUB_OUTPUT) {
+    fs.appendFileSync(env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+  } else {
+    // Local/dry-run mode: show what would be exported.
+    lines.forEach((l) => process.stdout.write(`${l}\n`));
+  }
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  const args = parseArgs(rest);
+
+  switch (command) {
+    case 'result': {
+      const report = readJsonIfExists(args.report);
+      const result = buildEvalResult({ report, evalStepOutcome: args['eval-outcome'] });
+      const outFile = args.output || 'reports/eval-result.json';
+      fs.mkdirSync(path.dirname(outFile), { recursive: true });
+      fs.writeFileSync(outFile, `${JSON.stringify(result, null, 2)}\n`);
+      const shouldNotify = report ? buildEmailReport(report).shouldSend : false;
+      const subject = report ? buildEmailReport(report).subject : 'Suchi Eval: no report produced';
+      appendGithubOutput([
+        `eval_status=${result.evaluation.status}`,
+        `should_notify=${shouldNotify}`,
+        `email_subject=${subject}`,
+      ]);
+      process.stdout.write(`eval-result.json written (status: ${result.evaluation.status})\n`);
+      return 0;
+    }
+    case 'summary': {
+      const result = readJsonIfExists(args.result) || buildEvalResult({ report: null, evalStepOutcome: 'failure' });
+      process.stdout.write(`${buildSummaryMarkdown(result, args['artifact-outcome'])}\n`);
+      return 0;
+    }
+    case 'email': {
+      const report = readJsonIfExists(args.report);
+      if (!report) {
+        process.stderr.write('No report available; skipping email generation.\n');
+        return 0;
+      }
+      const { subject, body } = buildEmailReport(report);
+      const outDir = args['out-dir'] || '.';
+      fs.writeFileSync(path.join(outDir, 'email-subject.txt'), subject);
+      fs.writeFileSync(path.join(outDir, 'email-body.md'), body);
+      process.stdout.write('Email subject/body files written.\n');
+      return 0;
+    }
+    case 'notify-status': {
+      process.stdout.write(buildNotificationSummary(args['send-outcome'], args['should-notify']));
+      return 0;
+    }
+    case 'check': {
+      const result = readJsonIfExists(args.result);
+      const { exitCode, message } = evaluateCheck(result);
+      process.stdout.write(`${message}\n`);
+      return exitCode;
+    }
+    default:
+      process.stderr.write(`Unknown command: ${command || '(none)'}\n`);
+      return 2;
+  }
+}
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+module.exports = {
+  EVAL_STATUS,
+  deriveEvalStatus,
+  buildEvalResult,
+  buildSummaryMarkdown,
+  buildNotificationSummary,
+  buildEmailReport,
+  evaluateCheck,
+  main,
+};

--- a/eval/ci/eval-status.test.js
+++ b/eval/ci/eval-status.test.js
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for eval/ci/eval-status.js (issue #47).
+ *
+ * Run with: node --test eval/ci/
+ * (or from eval/: npm run test:ci)
+ *
+ * The key regression: a notification (email) delivery failure must never be
+ * reported as an evaluation failure, and a true evaluation failure must fail
+ * CI regardless of the notification outcome.
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  EVAL_STATUS,
+  deriveEvalStatus,
+  buildEvalResult,
+  buildSummaryMarkdown,
+  buildNotificationSummary,
+  buildEmailReport,
+  evaluateCheck,
+} = require('./eval-status');
+
+function makeReport({ failed = 0, total = 21 } = {}) {
+  const results = [];
+  for (let i = 0; i < total; i += 1) {
+    const isFailed = i < failed;
+    results.push({
+      testCaseId: `tier1-case-${i + 1}`,
+      passed: !isFailed,
+      score: isFailed ? 0.4 : 1,
+      deterministicResults: isFailed ? [{ checkId: 'has_citation', passed: false }] : [],
+      llmJudgeResults: [],
+      retrievalQuality: { top3TrustedPresence: true, citationCoverage: 1, hasAbstention: false },
+    });
+  }
+  return {
+    summary: {
+      total,
+      passed: total - failed,
+      failed,
+      skipped: 0,
+      averageScore: failed > 0 ? 0.85 : 0.97,
+      retrievalQuality: {
+        top3TrustedPresenceRate: 1,
+        citationCoverageRate: 0.95,
+        abstentionRate: 0.05,
+      },
+    },
+    results,
+  };
+}
+
+// --- deriveEvalStatus: the three distinguishable outcomes --------------------
+
+test('clean report + clean exit => passed', () => {
+  assert.equal(deriveEvalStatus('success', makeReport()), EVAL_STATUS.PASSED);
+});
+
+test('report with failing cases => failed (true evaluation failure)', () => {
+  assert.equal(deriveEvalStatus('success', makeReport({ failed: 3 })), EVAL_STATUS.FAILED);
+});
+
+test('missing report => infra_error', () => {
+  assert.equal(deriveEvalStatus('success', null), EVAL_STATUS.INFRA_ERROR);
+});
+
+test('clean report but eval process crashed => infra_error', () => {
+  assert.equal(deriveEvalStatus('failure', makeReport()), EVAL_STATUS.INFRA_ERROR);
+});
+
+// --- Regression for run 28731647092: notification failure must not flip eval status
+
+test('REGRESSION: eval passed + email delivery failed => CI still passes', () => {
+  // Simulates run 28731647092's failure mode: SMTP auth error (535 BadCredentials)
+  // on the send step, while the evaluation itself succeeded.
+  const result = buildEvalResult({ report: makeReport(), evalStepOutcome: 'success', env: {} });
+  const check = evaluateCheck(result); // notification outcome plays no part in the gate
+  assert.equal(check.exitCode, 0);
+
+  // The notification failure is surfaced as a degraded operation in the summary…
+  const notifLine = buildNotificationSummary('failure', 'true');
+  assert.match(notifLine, /degraded: notification failed/);
+  // …and explicitly does not affect the evaluation status.
+  assert.match(notifLine, /NOT affected/);
+});
+
+test('true evaluation failure fails CI even if notification succeeds', () => {
+  const result = buildEvalResult({
+    report: makeReport({ failed: 5 }),
+    evalStepOutcome: 'success',
+    env: {},
+  });
+  const check = evaluateCheck(result);
+  assert.equal(check.exitCode, 1);
+  assert.match(check.message, /Evaluation failed/);
+  assert.match(check.message, /5 of 21/);
+  // Message clarifies this is a quality failure, not plumbing.
+  assert.match(check.message, /not a notification or reporting issue/);
+});
+
+test('infrastructure error fails CI with a distinct message', () => {
+  const result = buildEvalResult({ report: null, evalStepOutcome: 'failure', env: {} });
+  const check = evaluateCheck(result);
+  assert.equal(check.exitCode, 1);
+  assert.match(check.message, /infrastructure error/);
+  assert.doesNotMatch(check.message, /Evaluation failed::/);
+});
+
+test('missing eval-result.json fails the check gate', () => {
+  const check = evaluateCheck(null);
+  assert.equal(check.exitCode, 1);
+  assert.match(check.message, /missing or malformed/);
+});
+
+// --- eval-result.json artifact shape -----------------------------------------
+
+test('buildEvalResult produces machine-readable payload with metrics', () => {
+  const env = {
+    GITHUB_REPOSITORY: 'gautamgauri/suchi-cancer-bot',
+    GITHUB_RUN_ID: '123',
+    GITHUB_RUN_NUMBER: '7',
+    GITHUB_SHA: 'abc',
+    GITHUB_REF_NAME: 'main',
+    GITHUB_WORKFLOW: 'Eval Tier1 - Retrieval Quality',
+  };
+  const result = buildEvalResult({
+    report: makeReport({ failed: 2 }),
+    evalStepOutcome: 'success',
+    env,
+    now: new Date('2026-07-05T00:00:00Z'),
+  });
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.generatedAt, '2026-07-05T00:00:00.000Z');
+  assert.equal(result.run.repository, 'gautamgauri/suchi-cancer-bot');
+  assert.equal(result.evaluation.status, EVAL_STATUS.FAILED);
+  assert.equal(result.evaluation.total, 21);
+  assert.equal(result.evaluation.failed, 2);
+  assert.deepEqual(result.evaluation.failedCaseIds, ['tier1-case-1', 'tier1-case-2']);
+  assert.equal(result.evaluation.retrievalQuality.citationCoverageRate, 0.95);
+});
+
+// --- Job summary --------------------------------------------------------------
+
+test('summary shows eval result, metrics, and artifact status', () => {
+  const result = buildEvalResult({ report: makeReport(), evalStepOutcome: 'success', env: {} });
+  const md = buildSummaryMarkdown(result, 'success');
+  assert.match(md, /\| Evaluation \| ✅ passed \|/);
+  assert.match(md, /\| Report artifact \| ✅ uploaded \|/);
+  assert.match(md, /Top-3 trusted source presence \| 100\.0%/);
+  assert.match(md, /Citation coverage \| 95\.0%/);
+});
+
+test('summary flags artifact upload failure as reporting issue, not eval failure', () => {
+  const result = buildEvalResult({ report: makeReport(), evalStepOutcome: 'success', env: {} });
+  const md = buildSummaryMarkdown(result, 'failure');
+  assert.match(md, /\| Evaluation \| ✅ passed \|/);
+  assert.match(md, /upload failure \(reporting issue, not an eval failure\)/);
+});
+
+test('summary handles missing report', () => {
+  const result = buildEvalResult({ report: null, evalStepOutcome: 'failure', env: {} });
+  const md = buildSummaryMarkdown(result, 'skipped');
+  assert.match(md, /infrastructure error/);
+  assert.match(md, /No report file was produced/);
+});
+
+// --- Notification summary states ----------------------------------------------
+
+test('notification summary: sent / skipped / degraded / not-needed', () => {
+  assert.match(buildNotificationSummary('success', 'true'), /✅ email sent/);
+  assert.match(buildNotificationSummary('skipped', 'true'), /⏭️ skipped/);
+  assert.match(buildNotificationSummary('failure', 'true'), /⚠️ degraded/);
+  assert.match(buildNotificationSummary('skipped', 'false'), /no notification required/);
+});
+
+// --- Email report (no recipient handling here — redaction by construction) -----
+
+test('email report contains failure details but never recipient/secret fields', () => {
+  const { subject, body, shouldSend } = buildEmailReport(makeReport({ failed: 7 }), {
+    GITHUB_REPOSITORY: 'gautamgauri/suchi-cancer-bot',
+    GITHUB_RUN_ID: '123',
+  });
+  assert.equal(shouldSend, true);
+  assert.match(subject, /7 failures/);
+  assert.match(body, /Failed Cases \(Top 5\)/);
+  assert.match(body, /and 2 more failures/);
+  assert.match(body, /actions\/runs\/123/);
+  assert.doesNotMatch(body, /@dikshafoundation\.org/);
+  assert.doesNotMatch(subject, /@/);
+});
+
+test('email report for all-pass run does not request sending', () => {
+  const { subject, shouldSend } = buildEmailReport(makeReport(), {});
+  assert.equal(shouldSend, false);
+  assert.match(subject, /All 21 tests passed/);
+});

--- a/eval/package.json
+++ b/eval/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "typecheck": "tsc --noEmit",
+    "test:ci": "node --test ci/",
     "check": "npm run typecheck && npm run lint",
     "eval": "ts-node cli.ts",
     "eval:run": "npm run build && node dist/cli.js run",


### PR DESCRIPTION
Closes #47

## Root cause (run 28731647092)

The `Send email notification` step (`dawidd6/action-send-mail@v3`) failed with an SMTP auth error — `535-5.7.8 Username and Password not accepted` (Gmail BadCredentials) — and had no `continue-on-error`, so the entire job was marked failed even though every evaluation, summary, artifact, and result-check step succeeded. The workflow status conflated notification delivery with evaluation outcome.

## What changed

- **New testable helper `eval/ci/eval-status.js`** (plain Node, zero deps). It derives a three-way evaluation status — `passed` | `failed` (true eval failure: report shows failing cases) | `infra_error` (no usable report / harness crash) — and provides subcommands used by the workflow: `result`, `summary`, `email`, `notify-status`, `check`. It never handles recipients or credentials, so it cannot leak them.
- **Machine-readable `eval-result.json`** (schema v1: status, run metadata, totals, average score, retrieval-quality metrics, failed case IDs) written every run and uploaded with the report artifact.
- **Job summary (`$GITHUB_STEP_SUMMARY`)** now shows four things: evaluation result, quality metrics table, artifact upload status, and notification status.
- **Notification is a degraded operation, never a CI failure**: the send step now has `continue-on-error: true`; a delivery failure emits a `::warning::` annotation plus a "degraded: notification failed (evaluation status is NOT affected)" summary line.
- **CI conclusion is decided solely by the final `Enforce evaluation status` step**, which exits non-zero with distinct `::error::` annotations for eval failure vs infrastructure error. (Previously the "Check eval results" step always exited 0 in "non-blocking mode", so a true eval failure could not fail CI at all — while an email hiccup did. Both directions are now correct.)
- **Redaction**: recipient address is `::add-mask::`-ed at job start and referenced from a single `env` var; SMTP secrets remain auto-masked by Actions.
- **Bug fix en passant**: the old `steps.email-report.outputs.email_subject` was never set (subject always fell back to the generic default); the subject output is now actually populated.
- `eval/ci/**` and the workflow file added to the PR path triggers; `npm run test:ci` added and run in the workflow before the eval.

## Before / after status matrix

| Scenario | Before | After |
|----------|--------|-------|
| Eval passes, email delivery fails (the run 28731647092 case) | ❌ workflow failed | ✅ workflow **green**; warning annotation + "degraded: notification failed" in summary |
| Eval has failing cases (regardless of email outcome) | ✅ green ("non-blocking mode" exit 0) — masked real failures | ❌ workflow **red** with `Evaluation failed: N of M cases` error annotation |
| Eval harness crashes / no report produced (regardless of email outcome) | ✅ green (exit 0) | ❌ workflow **red** with `Eval infrastructure error` annotation (distinct from quality failure) |
| Eval passes, artifact upload fails | ❌ failed | ✅ green; warning annotation + "upload failure (reporting issue, not an eval failure)" in summary |
| Eval passes, email delivered | ✅ green | ✅ green; summary shows "email sent" |

A reviewer can now answer unambiguously from the run page: the job conclusion = evaluation outcome; artifact and notification outcomes are separate labeled rows in the job summary with warning annotations when degraded.

## How tested / simulated

- **Regression test suite** `eval/ci/eval-status.test.js` (15 tests, `node --test` / `npm run test:ci`, all passing), including the exact regression: *"eval passed + email delivery failed => CI still passes"*, plus true-failure-fails-CI, infra-error, artifact-failure labeling, summary content, and a check that email subject/body never contain recipient addresses.
- **End-to-end CLI simulation** of all three outcomes against a real Tier1 report (`tier1-report-v4.json`): passed → `check` exit 0 + degraded notification line; 5 failing cases → exit 1 with "Evaluation failed" error; missing report → exit 1 with "Eval infrastructure error".
- **Workflow YAML validated** by parsing with js-yaml and verifying step structure (`continue-on-error`/`if: always()` placement); `actionlint` not available locally.
- **In-CI simulation documented** in the workflow header comment: dispatch the workflow with an invalid `SMTP_PASSWORD` and observe green job + degraded-notification warning.

No changes to medical prompts, retrieval sources, escalation policy, or secrets. CI/workflow/script changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)