### PR TITLE
docs: reliability handoff pack — architecture, operations, baseline, backlog, agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# AGENTS.md — Rules for Coding Agents Working in This Repository
+
+This repository powers **Suchi**, a cancer-information assistant operated by the
+Suchitra Cancer Care Foundation (SCCF). Real patients and caregivers in Bihar,
+India talk to this bot about cancer. Mistakes here are not cosmetic — they can
+produce unsafe medical guidance. Read this file before making any change.
+
+Companion documents:
+
+- `CLAUDE.md` — project map, key commands, git-safety preflight (mandatory).
+- `docs/ARCHITECTURE.md` — modules, data flows, deployment surfaces.
+- `docs/OPERATIONS_RUNBOOK.md` — setup, tests, CI, health checks, rollback.
+- `docs/RELIABILITY_BASELINE.md` — verified state of the repo at handoff.
+- `docs/RELIABILITY_BACKLOG.md` — ranked known issues.
+- `docs/SUCHI_SAFETY_CONTRACT.md` and `docs/SUCHI_ANSWER_POLICY.md` — the
+  clinical safety rules the runtime must uphold.
+
+## 1. Safety boundaries (non-negotiable)
+
+1. **Never bypass or weaken the safety module** (`apps/api/src/modules/safety/`).
+   The chat pipeline runs safety checks *before* retrieval and generation;
+   emergency/red-flag queries must keep their fast escalation path. Do not
+   reorder, short-circuit, or add feature flags around it.
+2. **Never return medical advice without KB backing.** Responses are grounded
+   in the knowledge base (`kb/`) via the RAG module
+   (`apps/api/src/modules/rag/`). If evidence is insufficient, the correct
+   behavior is abstention (`apps/api/src/modules/abstention/`), not a fluent
+   guess.
+3. **Do not edit medical content, prompts, or clinical policy on your own
+   authority.** Changes to `kb/**`, system prompts under
+   `apps/api/src/modules/llm/` or `chat/`, safety keyword lists, escalation
+   wording, or `docs/SUCHI_ANSWER_POLICY.md` require SCCF human/medical review.
+   Propose them in a separate, clearly-labeled PR (see issue #48 boundaries for
+   the precedent).
+4. **No secrets in code, docs, logs, or fixtures.** Secrets live in GCP Secret
+   Manager (project `gen-lang-client-0202543132`) and are referenced by *name
+   only* (e.g. `database-url`, `DISTRIBUTION_APPROVAL_SECRET`). Never paste
+   values, tokens, or connection strings anywhere in the repo.
+5. **No patient data.** Never copy raw chat transcripts, phone numbers
+   (WhatsApp contacts), or any personal data into fixtures, tests, docs, or
+   commit messages. See `docs/PRIVACY_RETENTION.md`.
+6. **Do not deploy or push to `main`.** Work on a branch, open a PR. Deploys go
+   through Cloud Build (`cloudbuild.yaml`) and are a human decision.
+
+## 2. Git safety (mandatory preflight)
+
+Before ANY destructive git command (`reset --hard`, `clean -f/-fd`,
+`checkout`/`restore` that discards changes, `branch -D`, `stash drop`,
+force-push):
+
+1. Run `git status --short`.
+2. If anything is uncommitted/untracked, preserve it first (WIP branch, stash,
+   or `git diff > patch`).
+3. Only then run the destructive command.
+
+This rule exists because real work was lost to an unguarded `git reset --hard`.
+It is restated in `CLAUDE.md`; both copies are binding.
+
+## 3. Repository conventions
+
+- **Layout:** NestJS API in `apps/api` (the main codebase), React+Vite UI in
+  `apps/web`, eval framework in `eval/`, knowledge base in `kb/`, docs in
+  `docs/`, Python ingestion in `scripts/`. Pipeline data/tools live in
+  `content/`, `distribution/`, `navigator/`, `evals/`, `repairable/`.
+- **NestJS module pattern:** every feature is `src/modules/<name>/` with
+  `*.module.ts`, `*.service.ts`, `*.controller.ts`. Follow it for new features.
+- **Routing:** the global prefix `v1` is set once in `apps/api/src/main.ts`.
+  Controllers must use bare paths (`@Controller("chat")`, **not**
+  `@Controller("v1/chat")`). Doubling the prefix has caused two production
+  bugs already (PRs #44, #45) — links generated for approval emails 404'd.
+- **Tests:** Jest, colocated as `*.spec.ts` next to the source file. Unit tests
+  mock Prisma/LLM; no live DB or network needed (`npx jest` passes on a clean
+  checkout — see `docs/RELIABILITY_BASELINE.md` for the verified count).
+- **Env vars:** every new variable must be declared in
+  `apps/api/src/config/env.validation.ts` AND added to **both**
+  `cloudbuild.yaml` and `cloudbuild.gated.yaml`. Both pipelines use
+  `--set-env-vars`/`--set-secrets`, which **replace** (not merge) the Cloud Run
+  configuration — a variable missing from the pipeline file is silently dropped
+  on the next deploy. This has caused real outages (Meta/Instagram posting was
+  silently dead for weeks).
+- **Migrations:** Prisma migrations in `apps/api/prisma/migrations/`. Note that
+  `prisma migrate dev` fails against the production DB (no shadow-DB
+  permissions); the operational pattern is diff + psql + `migrate resolve`
+  (see `docs/OPERATIONS_RUNBOOK.md`).
+- **Commit style:** conventional-ish (`fix(scope): ...`, `feat: ...`,
+  `docs: ...`), imperative mood, small focused PRs.
+
+## 4. Test-first expectations
+
+- **Run the full API suite before and after your change:**
+  `cd apps/api && npx jest`. The baseline is green (see
+  `docs/RELIABILITY_BASELINE.md`); if you inherit a red suite, say so in the PR
+  rather than papering over it.
+- **New behavior ships with tests.** A bug fix ships with a regression test
+  that fails before the fix. Safety-relevant changes (safety, abstention,
+  citations, evidence gating) require tests without exception — several of
+  these paths are currently under-tested (see the "test gaps" section of
+  `docs/REQUIREMENTS_TRACEABILITY_MATRIX.md`), so do not make that worse.
+- **Do not delete or silently skip failing tests** to get green. Quarantine
+  with a linked issue if truly necessary, and record it in
+  `docs/RELIABILITY_BACKLOG.md`.
+- **Eval awareness:** retrieval/citation changes should be checked against the
+  Tier1 eval (`cd eval && npm run eval:tier1`, needs API access + judge LLM
+  credentials). The nightly Tier1 workflow (`.github/workflows/eval-tier1.yml`)
+  is the canary for retrieval quality; its current red status is a
+  *notification* failure, not an eval failure — see
+  `docs/RELIABILITY_BASELINE.md` before "fixing" it blind.
+
+## 5. Scope discipline for agents
+
+- Implement exactly what the issue/PR asks. Do not refactor unrelated code,
+  reformat files you didn't change, or "improve" prompts opportunistically.
+- Cite evidence. When you claim something about the system, point at the file,
+  test, workflow, or CI run that proves it.
+- When you find a real problem outside your task, file/append it to
+  `docs/RELIABILITY_BACKLOG.md` or open an issue — don't fix it inline.
+- Documentation edits must not contradict the canonical sources: requirements
+  live in `docs/REQUIREMENTS.md`, decisions in `docs/OPEN_DECISIONS.md`,
+  deployment truth in `cloudbuild.yaml` / `docs/DEPLOYMENT.md`. Cross-reference
+  instead of duplicating.
+- State what you verified vs. what you assumed. Unverifiable claims belong in
+  an "unverified assumptions" note, not asserted as fact.
+
+## 6. Things that look wrong but are intentional
+
+- **Citations are for auditors, not users:** the UI intentionally avoids
+  citation clutter and voice responses never mention citations
+  (OD-003 in `docs/OPEN_DECISIONS.md`). Do not "fix" this.
+- **Gemini is the only active LLM provider** in production. DeepSeek/OpenAI
+  code paths in `apps/api/src/modules/llm/` are legacy plumbing kept for
+  fallback wiring — do not build new features on them.
+- **Two Cloud Build pipelines exist on purpose:** `cloudbuild.yaml` (simple,
+  active) and `cloudbuild.gated.yaml` (migration job + health gate, has known
+  issues documented in `docs/cloudbuild-gated-issues.md`). Keep their env/secret
+  lists byte-identical when touching either.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,232 @@
+# Suchi Architecture
+
+System-level map of the Suchi Cancer Bot: modules, data flows, deployment
+surfaces, and external dependencies. Written as part of the reliability
+handoff pack (issue #46). Every non-obvious claim cites a source file.
+
+Related docs (canonical, not duplicated here): `docs/CHAT_ARCHITECTURE.md`
+(chat pipeline deep-dive), `docs/REQUIREMENTS.md` (what the system must do),
+`docs/SUCHI_SAFETY_CONTRACT.md` / `docs/SUCHI_ANSWER_POLICY.md` (clinical
+policy), `docs/NAVIGATOR_PIPELINE.md`, `docs/DISTRIBUTION_PIPELINE_SPEC.md`,
+`docs/VECTOR_RAG_SETUP.md`.
+
+## 1. Top-level layout
+
+| Path | What it is |
+|---|---|
+| `apps/api/` | NestJS backend — the main codebase (service name `suchi-api`, `apps/api/package.json`) |
+| `apps/web/` | React + Vite chat UI, served by nginx on Cloud Run (`apps/web/Dockerfile`, `apps/web/nginx.conf`) |
+| `apps/landing/` | Astro static marketing site, deployed to GitHub Pages (`.github/workflows/deploy-landing.yml`) |
+| `eval/` | Evaluation framework: cases, runner, rubrics, autoresearch (`eval/cli.ts`) |
+| `evals/` | Separate, older eval datasets/runners (distinct from `eval/`) |
+| `kb/` | Knowledge base markdown + manifest, ingested into Postgres |
+| `content/`, `distribution/` | Article-drafting and social-distribution pipeline code + queue data |
+| `navigator/` | Hospital-directory research/approval tooling (Cloud Run Jobs) |
+| `repairable/` | Manifest of KB articles patched by autoresearch |
+| `scripts/` | Python ingestion pipelines (NCI, YouTube transcripts) |
+| `docs/` | Specs, policies, runbooks |
+
+## 2. API bootstrap
+
+`apps/api/src/main.ts`:
+
+- Global route prefix `v1` (`app.setGlobalPrefix("v1")`, line 12). Controllers
+  therefore declare **bare** paths; doubling the prefix caused the bugs fixed
+  in PRs #44 and #45 (commits `a029286`, `e902ae1`).
+- Port from `PORT` env (3001 locally, 8080 in the container).
+- CORS enabled, Helmet headers, global `ValidationPipe`
+  (whitelist + forbidNonWhitelisted + transform).
+- Raw request body preserved for WhatsApp webhook HMAC verification.
+- Optional Socket.io adapter for `/v1/voice/stream` when `VOICE_WS_ENABLED=true`.
+- Startup logs include latest DB migration name, build ID, and a DB target
+  fingerprint (operational sanity check for "which build am I talking to").
+
+`apps/api/src/app.module.ts` wires ~20 feature modules plus `ConfigModule`
+(env validation via `apps/api/src/config/env.validation.ts`) and
+`ThrottlerModule` (default 20 req / 60 s, tunable via `RATE_LIMIT_TTL_SEC`,
+`RATE_LIMIT_REQ_PER_TTL`). `VoiceWsModule` is imported conditionally on
+`VOICE_WS_ENABLED`.
+
+## 3. Modules
+
+HTTP-facing modules (controller path shown is under the global `/v1` prefix):
+
+| Module | Route | Purpose |
+|---|---|---|
+| `chat` | `POST /v1/chat` | Core conversational pipeline (see §4). 55 s controller timeout. |
+| `sessions` | `POST /v1/sessions`, `GET /v1/sessions/:id` | Session creation with locale/channel/greeting state and IP-based city-level geolocation. |
+| `feedback` | `POST /v1/feedback` | Thumbs up/down + comment on messages. |
+| `voice` | `POST /v1/voice/respond`, `POST /v1/voice/tts` | STT upload → chat → TTS; audio limits enforced. |
+| `voice-ws` | WS `/v1/voice/stream` | Streaming voice via Socket.io gateway (`voice-ws.gateway.ts`), optional. |
+| `health` | `GET /v1/health` | Deep health check: runs `SELECT 1` against Postgres and reports `database: connected|disconnected` (`src/modules/health/health.service.ts`). Used by deploy health gates. |
+| `admin` | `/v1/admin/*` | Conversations, metrics, KB stats, daily report, hospital + article research triggers, navigator review portal, content/social approve-reject links, housekeeping (retention, draft expiry), review queue, analytics. Mixed auth (see §6). |
+| `youtube` | `/v1/admin/youtube/*` | YouTube transcript ingestion into the KB (BasicAuth). |
+| `distribution` | `GET /v1/distribution/approve/:slug`, `/reject/:slug` | One-click HMAC-tokenized approval links for social content packs (added in PR #43, prefix fixed in PR #44). |
+| `review` | `/v1/review/*` | Review Copilot records, queue, policies, metrics (BasicAuth). |
+| `copilot` | `/v1/copilot/sessions/*` | Review Copilot session workflow: diagnose → plan → approve → execute → compare. |
+| `whatsapp` | `GET/POST /v1/whatsapp/webhook` | Meta WhatsApp Cloud API webhook: verify challenge, HMAC-SHA256 signature check, async message processing (`whatsapp.service.ts`). |
+| `whatsapp-navigator` | `POST /v1/whatsapp-navigator/webhook` | Hospital-directory flow over WhatsApp text; in-memory sessions with 30-min TTL (prefix fixed in PR #45). |
+
+Service-only modules (no controller; consumed by the pipeline):
+
+| Module | Purpose |
+|---|---|
+| `safety` | Rule-based classification: emergency, self-harm, stop-treatment, alternative-only, report-interpretation, treatment-choice, prognosis, dosage, diagnosis. Priority-ordered in `safety.service.ts`; Devanagari-safe matching (see `hindi-safety-regression.spec.ts`). |
+| `abstention` | Urgency indicators + Safe-but-Helpful abstention templates when evidence is insufficient. |
+| `rag` | Hybrid retrieval: pgvector similarity + Postgres FTS, multi-query expansion, reranking, cross-lingual and cross-cancer-topic handling. Entry: `RagService.retrieveWithMetadata()`. |
+| `embeddings` | Google Embeddings REST API (768-dim vectors) for both ingestion and query time. |
+| `evidence` | Evidence gate: hybrid score threshold or trusted-top-3 rule, trust-first filtering, recency checks. Entry: `evaluateEvidenceGate()`; reason codes `NO_RESULTS/LOW_TRUST/LOW_SCORE/RECENCY_FAIL/LOW_DIVERSITY`. |
+| `llm` | Multi-provider LLM wrapper (`llm.service.ts`): Gemini (default, via API key or Vertex ADC), OpenAI and DeepSeek plumbing retained as legacy fallback — production is 100% Gemini (`LLM_PROVIDER=gemini` in `cloudbuild.yaml`). `generateWithCitations()` embeds `[citation:docId:chunkId]` markers; `generateRaw()` used by content/social generation. |
+| `citations` | Extraction, validation against retrieved chunks, and repair of citation markers. |
+| `analytics` | Event emission (`chat_turn_submitted`, `safety_triggered`, `emergency_fast_path_triggered`, …) + daily report generation. |
+| `observability` | Optional Langfuse traces/spans/generations (`LANGFUSE_ENABLED`). |
+| `email` | Nodemailer SMTP transport for reports and approval emails. |
+| `prisma` | Prisma client wrapper (Postgres + pgvector). |
+
+## 4. Chat request flow (the safety-critical path)
+
+Implemented in `apps/api/src/modules/chat/chat.service.ts` (`handle()`), with a
+45 s request budget inside the 55 s controller timeout. Order matters and must
+not be changed without medical review:
+
+1. **Input cleanup** — `cleanVoiceInput()` strips Web-Speech stutter.
+2. **Emergency fast path** — `evaluateEmergencyFastPath()`: regex-based,
+   sub-millisecond, returns an escalation response immediately and logs a
+   `SafetyEvent`. Never reaches the LLM.
+3. **Safety classification** — `SafetyService.evaluate()` over normalized text
+   (`normalizeForMatch()`), producing `normal | amber_flag | red_flag` +
+   fired rules.
+4. **Urgency detection** — `AbstentionService.hasUrgencyIndicators()`; urgent
+   but non-emergency queries get a template response with optional
+   RAG enhancement under a hard deadline.
+5. **Greeting flow** — `GreetingFlowService.processGreeting()` +
+   `detectCancerType()` for first-message context.
+6. **RAG retrieval** — `RagService.retrieveWithMetadata()` (hybrid vector+FTS,
+   query expansion, rerank).
+7. **Evidence gate** — `EvidenceGateService.evaluateEvidenceGate()`; on
+   `insufficient` the pipeline **abstains** (step 8) rather than generating.
+8. **Abstention** — `AbstentionService.generateAbstentionMessage()` renders a
+   safe fallback with escalation guidance.
+9. **LLM generation** — `LlmService.generateWithCitations()` with mode
+   detection and cancer-type-aware template selection, under the remaining
+   deadline budget (`llmWithDeadline()`).
+10. **Citation extraction/repair** — `CitationService`; citations must resolve
+    to retrieved chunks.
+11. **Response validation** — `ResponseValidatorService.validate()` (hallucinated
+    citations, guardrails), then `ClinicalKeywordEnforcerService.enforce()`.
+12. **Formatting** — `ResponseFormatter.format()`; citation markers are
+    stripped from user-visible text (citations are for auditors, not users —
+    OD-003 in `docs/OPEN_DECISIONS.md`); `stripForVoice()` for voice output.
+13. **Persistence** — `Message` rows store `safetyClassification`,
+    `policyRulesFired`, `kbDocIds`, `latencyMs`, `evidenceQuality`,
+    `citationCount`, `abstentionReason`.
+14. **Analytics emission** — non-blocking.
+
+Invariants: safety runs **before** retrieval and generation; insufficient
+evidence produces abstention, never a fluent guess; emergencies bypass the LLM
+entirely.
+
+## 5. Data model
+
+`apps/api/prisma/schema.prisma` (PostgreSQL + pgvector; 9 migrations in
+`apps/api/prisma/migrations/`):
+
+| Model | Purpose |
+|---|---|
+| `Session` | Locale, channel, cancer type, greeting state, geolocation, `isEval` marker, review flag. |
+| `Message` | User/assistant turns with safety + evidence + citation metadata. |
+| `Feedback` | Reactions and comments. |
+| `SafetyEvent` | Safety gate triggers per session/message. |
+| `AnalyticsEvent` | Generic event stream. |
+| `KbDocument` / `KbChunk` | KB docs and chunks; `KbChunk.embedding` is `vector(768)` (pgvector) plus FTS column (migration `20260120163141_add_fts_to_kbchunk`). |
+| `MessageCitation` | Extracted citation markers per assistant message. |
+| `VoiceInteraction` | STT confidence, transcript, durations, TTS URL (migration `20260217000000_add_voice_interaction`). |
+| `WhatsAppContact` | Persistent phone→session mapping (migration `20260622000000_add_whatsapp_contact`). |
+| `ReviewRecord` / `ReviewPolicy` | Review Copilot verdicts and policy definitions (migration `20260606000000_phase2_user_role_review_kb_metadata`). |
+
+## 6. AuthN/AuthZ surfaces
+
+- **HTTP Basic** — `apps/api/src/common/guards/basic-auth.guard.ts`
+  (`ADMIN_BASIC_USER`/`ADMIN_BASIC_PASS` secrets) on `/v1/admin`,
+  `/v1/admin/youtube`, `/v1/review`.
+- **Cloud Scheduler OIDC** — `apps/api/src/common/guards/scheduler-oidc.guard.ts`
+  verifies Google-issued ID tokens (audience `SCHEDULER_OIDC_AUDIENCE`, caller
+  `SCHEDULER_SA_EMAIL`) on scheduled POSTs: daily report, article/hospital
+  research, notify-publish, housekeeping, review-queue digest.
+- **HMAC one-click links** — approval/reject URLs carry
+  HMAC-SHA256 tokens derived from `NAVIGATOR_APPROVAL_SECRET`,
+  `CONTENT_APPROVAL_SECRET`, `SOCIAL_APPROVAL_SECRET`,
+  `DISTRIBUTION_APPROVAL_SECRET` (Secret Manager names; never values).
+- **WhatsApp webhook** — Meta `X-Hub-Signature-256` HMAC with `META_APP_SECRET`
+  plus verify-token challenge (`whatsapp.service.ts`).
+- Public, unauthenticated: chat, sessions, feedback, voice, health
+  (rate-limited by the global throttler).
+
+## 7. External dependencies
+
+| Dependency | Used by | Source |
+|---|---|---|
+| Google Gemini (LLM) | chat, content/social generation, autoresearch | `apps/api/src/modules/llm/llm.service.ts` |
+| Google Embeddings API (768-dim) | RAG + KB ingestion | `apps/api/src/modules/embeddings/embeddings.service.ts` |
+| Google Cloud Speech-to-Text v2 | voice | `apps/api/src/modules/voice/providers/google-stt-v2.provider.ts` |
+| Google Cloud TTS (Chirp3-HD) | voice | `apps/api/src/modules/voice/providers/google-tts.provider.ts` |
+| Google Cloud Storage | TTS audio (`GCS_BUCKET_TTS`), pipeline queues (`QUEUE_GCS_BUCKET=suchi-navigator-state`), public assets (`suchi-public-assets`) | `apps/api/src/modules/voice/services/gcs-storage.service.ts`, `cloudbuild.yaml` |
+| Meta WhatsApp Cloud API | whatsapp module (graph.facebook.com v21.0) | `apps/api/src/modules/whatsapp/whatsapp.service.ts` |
+| Meta Facebook/Instagram Graph API | social publishing | `apps/api/src/modules/admin/social-post.service.ts` |
+| LinkedIn UGC API | social publishing (currently disabled; token expiry tracked in issue #27) | `apps/api/src/modules/admin/social-post.service.ts` |
+| SMTP (Gmail) via nodemailer | reports, approval emails | `apps/api/src/modules/email/email.service.ts` |
+| Langfuse | optional LLM observability | `apps/api/src/modules/observability/observability.service.ts` |
+| Anthropic Claude API | navigator hospital research job only (not the chat runtime) | `Dockerfile.navigator-research`, `cloudbuild.navigator-research.yaml` |
+| OpenAI / DeepSeek | legacy LLM fallback plumbing; also eval-judge options | `llm.service.ts`, `eval/config/loader.ts` |
+
+Environment variables for all of the above are declared (required vs optional)
+in `apps/api/src/config/env.validation.ts`; see also
+`docs/ENVIRONMENT_VARIABLES.md`.
+
+## 8. Deployment surfaces
+
+GCP project `gen-lang-client-0202543132`, region `us-central1`. Full
+operational detail in `docs/OPERATIONS_RUNBOOK.md`; pipeline internals in
+`docs/DEPLOYMENT.md` and `docs/GATED_DEPLOYMENT.md`.
+
+| Surface | Kind | Deployed by |
+|---|---|---|
+| `suchi-api` | Cloud Run service (Node 20 image, port 8080) | `cloudbuild.yaml` (active), `cloudbuild.gated.yaml` (gated: migration job + health gate + traffic promotion), `.github/workflows/deploy-api.yml` (auto on push to `main` touching `apps/api/**` or `kb/**`) |
+| `suchi-web` | Cloud Run service (nginx serving Vite build; API URL baked in via `VITE_API_URL` build arg) | `cloudbuild.yaml`, `.github/workflows/deploy-web.yml` |
+| Landing site | GitHub Pages (Astro) | `.github/workflows/deploy-landing.yml` |
+| `suchi-db-migrate` / `suchi-migrate` | Cloud Run Jobs running `prisma migrate deploy` | `cloudbuild.gated.yaml` / `deploy-api.yml` respectively |
+| `suchi-kb-ingest` | Cloud Run Job image (KB ingestion, `Dockerfile.kb-ingest`) | `cloudbuild.kb-ingest.yaml` |
+| `suchi-navigator-research`, `suchi-navigator-sender` | Cloud Run Jobs (hospital research via Claude API; daily sender) | `cloudbuild.navigator-research.yaml` |
+| Autoresearch loop | Cloud Build run producing `autoresearch/*` proposal branches (never auto-merged) | `cloudbuild-autoresearch.yaml` |
+| Database | Cloud SQL Postgres `suchi-db` with pgvector | connection `gen-lang-client-0202543132:us-central1:suchi-db` |
+
+**Critical property:** every deploy path uses `--set-env-vars` /
+`--set-secrets`, which **replace** the entire Cloud Run env/secret
+configuration. Any env var not listed in the pipeline file is dropped on the
+next deploy. `cloudbuild.yaml` and `cloudbuild.gated.yaml` are currently in
+sync (verified byte-identical env/secret lists, `cloudbuild.yaml:90-93` vs
+`cloudbuild.gated.yaml:107-110`); `.github/workflows/deploy-api.yml` is **not**
+in sync — see P0-1 in `docs/RELIABILITY_BACKLOG.md`.
+
+## 9. Evaluation & quality engine
+
+- `eval/cli.ts` — commands: `run`, `voice-e2e`, `report`, `voice-transcript`,
+  `release-gate`, `judge-compare`, `loop`, `eval-optimize`, `autoresearch`,
+  `generate-cases`.
+- Cases in `eval/cases/` (gold, tier1, tier1.5, tier2, voice, generalinfo);
+  Tier1 retrieval-quality suite is `eval/cases/tier1/retrieval_quality.yaml`,
+  run via `npm run eval:tier1` (`eval/package.json`).
+- Runner in `eval/runner/` (`evaluator.ts`, `api-client.ts`, `llm-judge.ts`,
+  `deterministic-checker.ts`, `release-gate.ts`, voice evaluators); rubrics in
+  `eval/rubrics/rubrics.v1.json` and `voice-rubrics.v1.json`.
+- Judge LLM provider resolved in `eval/config/loader.ts` (line 57):
+  `EVAL_LLM_PROVIDER` env → secret → config default (`vertex_ai` in
+  `eval/config/default.json`); the CI workflow instead defaults to `deepseek`
+  (`.github/workflows/eval-tier1.yml:69`).
+- Autoresearch engine in `eval/autoresearch/` (`autoresearch-runner.ts`,
+  `failure-miner.ts`, `patcher.ts`, `gatekeeper.ts`, `archivist.ts`,
+  `triage-router.ts`, agents) — nightly Cloud Build proposal loop.
+- Eval targets the live API by default
+  (`EVAL_API_BASE_URL`, default in `eval/config/default.json`); eval sessions
+  are flagged via `Session.isEval` (migration
+  `20260131000000_add_is_eval_to_session`).

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -1,0 +1,213 @@
+# Suchi Operations Runbook
+
+How to set up, test, deploy, monitor, and roll back Suchi. Part of the
+reliability handoff pack (issue #46). Deployment internals live in
+`docs/DEPLOYMENT.md`, `docs/GATED_DEPLOYMENT.md`, `docs/GCP_DEPLOYMENT.md`;
+preflight checklist in `docs/DEPLOY_PREFLIGHT.md`; gated-pipeline known issues
+in `docs/cloudbuild-gated-issues.md`. This runbook is the operational index.
+
+## 1. Local setup
+
+Prerequisites: Node 20 (images and CI use Node 20; verified locally on
+v20.20.0), Docker (optional), gcloud CLI for anything touching GCP.
+
+```bash
+# API — http://localhost:3001, all routes under /v1
+cd apps/api
+npm ci
+npx prisma generate
+npm run dev
+
+# Web UI — http://localhost:3000
+cd apps/web
+npm ci
+npm run dev
+
+# Eval framework
+cd eval
+npm ci
+```
+
+- Env vars: see `apps/api/src/config/env.validation.ts` for the authoritative
+  required/optional list and `docs/ENVIRONMENT_VARIABLES.md` for descriptions.
+  Minimum for a local API: `DATABASE_URL`, `ADMIN_BASIC_USER`,
+  `ADMIN_BASIC_PASS`, plus an LLM provider (default `LLM_PROVIDER=gemini`).
+- Local DB needs the pgvector extension
+  (`apps/api/prisma/migrations/add_pgvector_extension.sql`).
+- Unit tests do **not** need a DB or network — Prisma and LLM calls are mocked
+  in the specs.
+
+### Production DB access (migrations, debugging)
+
+Use the Cloud SQL proxy against instance
+`gen-lang-client-0202543132:us-central1:suchi-db`; `DATABASE_URL` is in Secret
+Manager under the secret name `database-url`.
+
+Known constraint: `prisma migrate dev` **fails against the prod DB** (P3014 —
+the `suchi_app` user has no shadow-database permissions). Use
+`prisma migrate diff` + `psql` + `prisma migrate resolve` instead, or let the
+deploy pipeline's migration job run `prisma migrate deploy`
+(`docs/DEPLOYMENT.md`).
+
+## 2. Test commands
+
+```bash
+# Full API unit suite (41 suites / 821 tests green at handoff baseline —
+# see docs/RELIABILITY_BASELINE.md)
+cd apps/api && npx jest
+
+# One module / file
+cd apps/api && npx jest --testPathPattern=safety
+
+# API build (must be clean before any deploy)
+cd apps/api && npm run build
+
+# Web unit tests (Vitest) and E2E (Playwright)
+cd apps/web && npm test
+cd apps/web && npx playwright test
+
+# Tier1 retrieval-quality eval (hits the live API by default; needs judge-LLM
+# credentials — see eval/config/loader.ts)
+cd eval && npm run eval:tier1
+
+# Full eval CLI
+cd eval && npx ts-node cli.ts run --cases <cases.yaml> --output reports/out.json
+```
+
+Safety-relevant regression suites worth knowing by name:
+`apps/api/src/modules/safety/hindi-safety-regression.spec.ts`,
+`apps/api/src/modules/chat/` (16 spec files),
+`apps/api/src/modules/safety/` (5 spec files).
+
+## 3. CI workflows (`.github/workflows/`)
+
+| Workflow | Trigger | What it does | Failure semantics |
+|---|---|---|---|
+| `deploy-api.yml` ("Deploy API to Cloud Run") | push to `main` touching `apps/api/**`, `kb/**`, or itself; manual | Build image → push → run `suchi-migrate` Cloud Run Job (`continue-on-error: true`, line 48) → `gcloud run deploy suchi-api` → health check `GET /v1/health` ×5 | Fails only on deploy or health-check failure; a failed migration does NOT block deploy. **Warning:** its env/secret list is stale relative to `cloudbuild.yaml` — see P0-1 in `docs/RELIABILITY_BACKLOG.md` before letting it run. No tests are run before deploying. |
+| `deploy-web.yml` | push to `main` touching `apps/web/**`; manual | Build web image (API URL baked in) → deploy `suchi-web` → HTTP 200 check | Fails on deploy/health failure |
+| `deploy-landing.yml` | push touching `apps/landing/**`; manual | Astro build → GitHub Pages | Standard |
+| `e2e-tests.yml` ("Web Tests") | PR/push touching `apps/web/**`; manual | Vitest unit tests + Playwright (`@smoke` against dev server, or full suite against a provided `base_url`) | Blocking for web PRs |
+| `eval-tier1.yml` ("Eval Tier1 - Retrieval Quality") | nightly 02:00 UTC; PRs touching rag/evidence/citations/eval paths; manual | Runs `npm run eval:tier1` against the live API, uploads `tier1-eval-report-<run>` artifact (30-day retention), emails a report when failures > 0 | Eval step itself is `continue-on-error` (line 75). The workflow's red/green currently reflects **email delivery**, not eval outcome — see §5 and issue #47. |
+
+There is **no CI job that runs the API jest suite**; run it locally before
+merging (tracked as P1-4 in `docs/RELIABILITY_BACKLOG.md`).
+
+## 4. Deploying
+
+Active pipeline (per `MEMORY`/`docs/DEPLOYMENT.md` practice): **simple**
+Cloud Build from the repo root:
+
+```bash
+gcloud builds submit --config cloudbuild.yaml .
+```
+
+- Builds + deploys both `suchi-api` and `suchi-web`.
+- No migration step and no health gate; after a simple-pipeline deploy,
+  verify and promote the latest revision to 100% traffic manually if needed.
+
+Gated pipeline (migration job `suchi-db-migrate` + candidate revision at 0%
+traffic + `/v1/health` gate + promotion):
+
+```bash
+gcloud builds submit --config cloudbuild.gated.yaml .
+```
+
+- Known issues before using it: the `MIG` env var and the column checks in
+  `migrate-with-repair.sh` are hardcoded to the newest-known migration
+  (currently `20260606000000_phase2_user_role_review_kb_metadata`,
+  `cloudbuild.gated.yaml` step `update-migrate-job-image`) and must be updated
+  whenever a migration is added — full list in `docs/cloudbuild-gated-issues.md`.
+
+Rules that apply to **any** deploy path:
+
+1. `--set-env-vars`/`--set-secrets` REPLACE the whole Cloud Run config. Adding
+   an env var means editing `apps/api/src/config/env.validation.ts` **and**
+   both cloudbuild files (and `deploy-api.yml` if it stays enabled).
+2. Run the preflight checklist in `docs/DEPLOY_PREFLIGHT.md` (build green,
+   tests green, `prisma migrate status` clean, no doubled route prefixes,
+   health 200).
+3. Deploys are a human decision; agents open PRs only (see `AGENTS.md`).
+
+## 5. Production health checks
+
+```bash
+# Deep health (checks DB connectivity, not just liveness)
+curl -s https://suchi-api-lxiveognla-uc.a.run.app/v1/health
+# → {"status":"ok", "database":"connected", ...} on success
+
+# Which revision is serving, and with what config (env/secret NAMES only)
+gcloud run services describe suchi-api --region us-central1 \
+  --project gen-lang-client-0202543132 \
+  --format 'value(status.latestReadyRevisionName)'
+gcloud run revisions list --service suchi-api --region us-central1
+
+# Recent runtime errors
+gcloud logging read 'resource.type=cloud_run_revision AND resource.labels.service_name=suchi-api AND severity>=ERROR' \
+  --project gen-lang-client-0202543132 --limit 20
+
+# Nightly retrieval-quality canary
+gh run list --workflow eval-tier1.yml --limit 5
+gh run download <run-id> -n tier1-eval-report-<n>   # tier1-report.json has summary + per-case results
+```
+
+Interpreting the Tier1 workflow: a red run does **not** necessarily mean the
+eval failed. Open the run and check which step failed — since 2026-06-24 every
+nightly failure has been the "Send email notification" step (SMTP 535
+BadCredentials) while all eval steps passed (verified on runs 28731647092,
+28424590294, 28079102548). The real eval result is in the run's step summary
+and the report artifact. Fix tracked in issue #47.
+
+Other signals:
+
+- Langfuse (`https://us.cloud.langfuse.com`) for per-request LLM traces when
+  `LANGFUSE_ENABLED=true` (it is, in `cloudbuild.yaml`).
+- Daily report email (admin module, Cloud Scheduler → `POST /v1/admin/daily-report`
+  with OIDC).
+- Startup log line with build ID + latest migration + DB fingerprint
+  (`apps/api/src/main.ts`) — confirms which build/schema a revision runs.
+
+## 6. Rollback path
+
+Cloud Run keeps previous revisions; rollback is a traffic shift, no rebuild
+(`docs/GATED_DEPLOYMENT.md` §rollback):
+
+```bash
+# 1. Find the last known-good revision
+gcloud run revisions list --service=suchi-api --region=us-central1
+
+# 2. Point 100% traffic at it
+gcloud run services update-traffic suchi-api \
+  --to-revisions=<GOOD_REVISION>=100 --region=us-central1
+
+# 3. Verify
+curl -s https://suchi-api-lxiveognla-uc.a.run.app/v1/health
+```
+
+Same pattern for `suchi-web`.
+
+Caveats:
+
+- **Migrations do not roll back.** Prisma has no down-migrations here; undoing
+  schema requires a new forward migration (`docs/DEPLOYMENT.md:136-157`).
+  Rolling traffic back to an older image after a migration is generally safe
+  only if the migration was additive — check the migration in
+  `apps/api/prisma/migrations/` before shifting.
+- If the bad deploy came from a pipeline with a stale env/secret list, plain
+  traffic rollback also restores the old (correct) env config, since env is
+  part of the revision.
+- Landing site rollback: revert the commit and let `deploy-landing.yml` re-run.
+
+## 7. Scheduled/background operations
+
+- Cloud Scheduler (service account
+  `suchi-scheduler@gen-lang-client-0202543132.iam.gserviceaccount.com`) hits
+  OIDC-guarded admin endpoints: daily report, article/hospital research,
+  housekeeping (retention, draft expiry), review-queue digest
+  (`apps/api/src/common/guards/scheduler-oidc.guard.ts`).
+- Navigator research/sender Cloud Run Jobs: `cloudbuild.navigator-research.yaml`
+  (state in `gs://suchi-navigator-state`; secret names
+  `ANTHROPIC_API_KEY`, `NAVIGATOR_APPROVAL_SECRET`, `SMTP_PASS`).
+- Autoresearch nightly loop: `cloudbuild-autoresearch.yaml`, proposal-mode
+  only — it pushes `autoresearch/*` branches for human review.
+- KB ingestion job image: `cloudbuild.kb-ingest.yaml` + `Dockerfile.kb-ingest`
+  (runs `src/scripts/ingest-kb.ts --wipeChunks`).

--- a/docs/RELIABILITY_BACKLOG.md
+++ b/docs/RELIABILITY_BACKLOG.md
@@ -1,0 +1,217 @@
+# Reliability Backlog — ranked
+
+Ranked P0/P1/P2 reliability issues derived from the 2026-07-05 baseline
+(`docs/RELIABILITY_BASELINE.md`). Each item links to exact code paths and the
+test gap that lets it survive. Ranking criteria: patient-facing safety impact
+first, then silent-failure potential, then developer friction.
+
+Status legend: **tracked** = an open GitHub issue exists; **new** = surfaced
+by this handoff review.
+
+---
+
+## P0 — fix before relying on anything else
+
+### P0-1. `deploy-api.yml` silently strips production env/secrets on every merge (new)
+
+- **What:** `.github/workflows/deploy-api.yml:81-102` deploys `suchi-api` with
+  a stale config: 6 secrets / 14 env vars vs the 15 secrets / ~20 env vars in
+  `cloudbuild.yaml:90-93` (missing `GEMINI_API_KEY`, `META_PAGE_ACCESS_TOKEN`,
+  `META_PAGE_ID`, `META_IG_USER_ID`, `NAVIGATOR_APPROVAL_SECRET`,
+  `CONTENT_APPROVAL_SECRET`, `DISTRIBUTION_APPROVAL_SECRET`,
+  `langfuse-public-key`, `langfuse-secret-key`, `LANGFUSE_ENABLED/HOST`,
+  `QUEUE_GCS_BUCKET`, `SUCHI_SITE_URL`, `SUCHI_SOCIAL_CARD_URL`; and
+  `LLM_TIMEOUT_MS=25000` vs `45000`). `gcloud run deploy --set-env-vars/
+  --set-secrets` REPLACES the entire config, and this workflow auto-runs on
+  any `main` push touching `apps/api/**` or `kb/**` — it ran successfully
+  three times on 2026-06-28 (runs 28331131428, 28332667342, 28333372955),
+  *after* the reconciliation of the two cloudbuild files (commit `1f39a31`).
+- **Impact:** silently disables Instagram/Facebook posting, all HMAC approval
+  links (distribution/content/navigator — i.e. the feature shipped in PR #43
+  may be dead in prod), Langfuse tracing, and the GCS queue. Identical failure
+  mode to the June 2026 Meta-secrets incident.
+- **First step:** verify live config —
+  `gcloud run services describe suchi-api --region us-central1 --format json`
+  (env names only). Then either delete the deploy step from `deploy-api.yml`
+  (keeping build+test), or reconcile it byte-for-byte with `cloudbuild.yaml`
+  and add a CI check that diffs the three env/secret lists.
+- **Test gap:** nothing compares pipeline env lists; no post-deploy smoke test
+  exercises an approval link or social config
+  (`apps/api/src/modules/admin/social-post.service.ts` reads the vars lazily,
+  so boot succeeds and `/v1/health` stays green — health checks DB only,
+  `apps/api/src/modules/health/health.service.ts:10-27`).
+
+### P0-2. Nightly Tier1 canary red for 12+ nights; status measures email, not eval (tracked: issue #47)
+
+- **What:** every scheduled "Eval Tier1 - Retrieval Quality" run since
+  2026-06-24 is red only because the "Send email notification" step fails with
+  SMTP `535-5.7.8 BadCredentials` (verified runs 28731647092, 28424590294,
+  28079102548). The eval itself passes its steps; the true result (21 cases,
+  20 pass) is buried in the artifact.
+- **Impact:** the only automated retrieval-quality signal is
+  uninterpretable at a glance; a genuine clinical-retrieval regression would
+  look identical to the SMTP failure. Alert fatigue guarantees reds get
+  ignored.
+- **Code paths:** `.github/workflows/eval-tier1.yml:222-234` (email step),
+  `:75` (`continue-on-error` on the eval step — so a hard eval crash also
+  cannot fail the workflow), `:115-122` ("Check eval results" always exits 0).
+  Also a concrete bug: line 230 reads
+  `steps.email-report.outputs.email_subject`, but the report step only writes
+  `should_send` to `$GITHUB_OUTPUT` (line 217), so the subject silently falls
+  back to the default.
+- **Fix shape:** per issue #47 — separate eval outcome / report generation /
+  notification into distinct signals, write `eval-result.json`, mark
+  notification failure as degraded-not-failed, and rotate the SMTP app
+  password (Secret names `SMTP_USERNAME`/`SMTP_PASSWORD` in GitHub secrets).
+
+---
+
+## P1 — high value, do next
+
+### P1-1. Standing citation failure `RQ-LUNG-02` + no citation-integrity verifier (tracked: issue #48)
+
+- **What:** `RQ-LUNG-02` in `eval/cases/tier1/retrieval_quality.yaml` fails
+  deterministic checks `citations_present` and
+  `citation_confidence_acceptable` with per-case `citationCoverage: 0`
+  (artifact `tier1-eval-report-184`, run 28731647092). One evidence-required
+  case produces zero supporting citations in production.
+- **Code paths:** retrieval `apps/api/src/modules/rag/rag.service.ts`
+  (`retrieveWithMetadata()`), gate
+  `apps/api/src/modules/evidence/` (`evaluateEvidenceGate()`), extraction
+  `apps/api/src/modules/citations/`; checks in
+  `eval/runner/deterministic-checker.ts`.
+- **Test gap:** exactly what issue #48 specifies — no citation-integrity
+  verifier (fabricated/unresolvable citations, zero-citation evidence-required
+  cases), no failure clustering, no rule that eval cases can't disappear
+  silently.
+
+### P1-2. Safety-critical pipeline behaviors are untested (new; gaps enumerated in `docs/REQUIREMENTS_TRACEABILITY_MATRIX.md`)
+
+- **What:** the properties that make Suchi safe are asserted by code order in
+  `apps/api/src/modules/chat/chat.service.ts` but not pinned by tests:
+  emergency fast path (FR-CHAT-003, `evaluateEmergencyFastPath()`), safety
+  gate ordering before RAG (FR-CHAT-005), evidence-gate thresholds
+  (FR-CHAT-008/-009, `evaluateEvidenceGate()`), citation repair (FR-CHAT-012),
+  voice citation stripping (FR-CHAT-014, `stripForVoice()`), SafetyEvent
+  persistence (FR-SAFETY-002/-003/-007).
+- **Impact:** a refactor could reorder safety after retrieval, or weaken the
+  gate, with 821 tests still green.
+- **Fix shape:** pipeline-order contract tests in
+  `apps/api/src/modules/chat/` (mock services, assert call order and
+  short-circuits), plus threshold-boundary tests in
+  `apps/api/src/modules/evidence/`.
+
+### P1-3. DB-unavailable path does not degrade to abstention (partial per NFR-AVAIL-002)
+
+- **What:** `docs/REQUIREMENTS_TRACEABILITY_MATRIX.md` marks NFR-AVAIL-002
+  ("DB unavailable → abstention") as partial/untested. `chat.service.ts` has
+  `prismaRetry()` for pool exhaustion, but there is no test that a hard DB
+  outage yields a safe abstention rather than a 500.
+- **Impact:** during a Cloud SQL blip, patients could get raw errors instead
+  of safe guidance; `GET /v1/health` will correctly go red
+  (`health.service.ts`) but chat behavior is unspecified.
+- **Test gap:** no spec simulates Prisma throwing on the persistence/retrieval
+  steps end-to-end.
+
+### P1-4. No CI runs the API unit suite; migrations can't block a bad deploy (new)
+
+- **What:** none of the five workflows runs `cd apps/api && npx jest`
+  (`.github/workflows/` — only web tests and the eval exist). Additionally
+  `deploy-api.yml:48` runs `prisma migrate deploy` with
+  `continue-on-error: true`, so a failed migration still deploys new code
+  against an old schema.
+- **Impact:** the 821-test suite protects nothing on the merge path; schema/
+  code mismatch reaches prod with a green workflow.
+- **Fix shape:** add an `api-tests.yml` (jest + `npm run build` on PRs
+  touching `apps/api/**`); make the migration step blocking or gate deploy on
+  it, mirroring `cloudbuild.gated.yaml`'s ordering.
+
+### P1-5. Zero-spec modules on trust boundaries (new)
+
+- **What:** 10 modules have no spec files at all (verified by `find`):
+  `analytics`, `copilot`, `email`, `embeddings`, `feedback`, `health`,
+  `observability`, `prisma`, `sessions`, `youtube`. The riskiest are
+  `sessions` (public endpoint, geolocation parsing), `embeddings` (RAG input —
+  a dimension/model drift breaks retrieval silently), and `email` (every
+  approval/report flow depends on it).
+- **Fix shape:** start with `sessions.controller/service` specs and an
+  `embeddings.service` contract test (768-dim, model name pinned to
+  `EMBEDDING_MODEL`).
+
+### P1-6. WhatsApp PII retention job missing (FR-WA-015, partial)
+
+- **What:** `WhatsAppContact` stores phone→session mappings
+  (`apps/api/prisma/migrations/20260622000000_add_whatsapp_contact`,
+  `schema.prisma`), but the retention/deletion job required by FR-WA-015 is
+  marked missing/untested in `docs/REQUIREMENTS_TRACEABILITY_MATRIX.md`;
+  housekeeping endpoints exist (`POST /v1/admin/housekeeping/run-retention`)
+  but don't cover WhatsApp contacts.
+- **Impact:** privacy commitment in `docs/PRIVACY_RETENTION.md` not met for
+  the WhatsApp channel.
+
+---
+
+## P2 — track and schedule
+
+### P2-1. Gated pipeline hardcodings (tracked in `docs/cloudbuild-gated-issues.md`)
+
+`MIG` env var pinned to `20260606000000_phase2_user_role_review_kb_metadata`
+and column checks in `migrate-with-repair.sh` pinned to old columns — every
+new migration silently invalidates the repair path. Fix by deriving `MIG` from
+`ls prisma/migrations | tail -1` at build time.
+
+### P2-2. Eval judge-provider ambiguity (new)
+
+CI defaults the judge to `deepseek` (`.github/workflows/eval-tier1.yml:69`)
+while the eval config defaults to `vertex_ai` (`eval/config/loader.ts:57`,
+`eval/config/default.json`) and production policy is Gemini-only. Nightly
+scores may come from a judge nobody intends to fund or maintain. Pin one
+provider explicitly in the workflow.
+
+### P2-3. Duplicate/legacy build surfaces (new)
+
+`apps/api/cloudbuild.ingest.yaml` + `apps/api/Dockerfile.ingest` duplicate the
+root `cloudbuild.kb-ingest.yaml` + `Dockerfile.kb-ingest`; top-level `evals/`
+duplicates `eval/` conceptually. Confirm unused, then delete or mark
+deprecated — agents keep rediscovering them.
+
+### P2-4. GitHub Actions Node-20 deprecation (new)
+
+Tier1 runs annotate: checkout@v4, setup-node@v4, upload-artifact@v4,
+dawidd6/action-send-mail@v3 target deprecated Node 20 runners (visible on run
+28731647092). Bump action majors when touching workflows.
+
+### P2-5. Known TODOs in the chat pipeline (new)
+
+`apps/api/src/modules/chat/chat.service.ts`: `district: null // TODO` and
+`budgetConcern: false // TODO` — patient-state fields the clinical-reasoning
+layer expects but that are never populated. Either implement or remove from
+the contract. Also placeholder generators in
+`eval/autoresearch/eval-optimizer.ts` (`[TODO: write user message...]`) mean
+`eval-optimize` can emit unusable cases.
+
+### P2-6. LinkedIn token expiry (tracked: issue #27)
+
+`LINKEDIN_ACCESS_TOKEN` (60-day OAuth token,
+`apps/api/src/modules/admin/social-post.service.ts`) expires ~2026-07-20;
+LinkedIn posting is intentionally disabled until an org page exists. Decide:
+rotate or remove the code path.
+
+### P2-7. Instagram social card placeholder (tracked: issue #28)
+
+`SUCHI_SOCIAL_CARD_URL` points at a placeholder object in
+`gs://suchi-public-assets` (`cloudbuild.yaml` env list). IG publishing will
+post the placeholder until the real card is uploaded and the env updated in
+**both** cloudbuild files (and `deploy-api.yml` per P0-1).
+
+---
+
+## Human decisions required (cannot be resolved by an agent)
+
+1. P0-1: keep `deploy-api.yml` as a deploy path (and reconcile it) or demote
+   it to build+test only? Who owns keeping three env lists in sync?
+2. P0-2: rotate the Gmail SMTP app password (credential owner action) —
+   agents must not touch credentials.
+3. P1-1/issue #48: any change to retrieval sources or citation rules for
+   RQ-LUNG-02 needs SCCF medical review before merge.
+4. P2-6: LinkedIn — rotate token or drop the integration.

--- a/docs/RELIABILITY_BASELINE.md
+++ b/docs/RELIABILITY_BASELINE.md
@@ -1,0 +1,172 @@
+# Reliability Baseline — 2026-07-05
+
+Verified state of the repository at handoff (issue #46). Facts below were
+established by running the stated commands on 2026-07-05; anything not
+directly verified is listed under "Unverified assumptions".
+
+## 1. Commit baseline
+
+- **HEAD:** `e31dfc4d5549e36c5eb3a7041061295543379e25` on `main`
+  (`git rev-parse HEAD`), merge of PR #45
+  ("fix(whatsapp-navigator): drop doubled v1 route prefix").
+- Recent history: PR #45 and #44 fixed doubled `/v1` route prefixes
+  (commits `e902ae1`, `a029286`); PR #43 added the distribution approval API;
+  PR #39 added the git-safety preflight.
+- Toolchain: Node v20.20.0 locally; NestJS `^10.4.0`, Prisma client `^5.20.0`
+  (`apps/api/package.json`).
+
+## 2. Test suite status (verified locally)
+
+Command: `cd apps/api && npx jest` at commit `e31dfc4` (WSL2, Node v20.20.0,
+2026-07-05):
+
+```
+Test Suites: 41 passed, 41 total
+Tests:       821 passed, 821 total
+Time:        48.809 s
+```
+
+- **No failing tests.** Unit tests run without DB or network (Prisma/LLM
+  mocked). Noisy-but-passing suites log intentional errors
+  (`whatsapp.service.spec.ts` "boom" scenarios).
+- Coverage is uneven: 10 of 24 module directories have **zero** spec files —
+  `analytics`, `copilot`, `email`, `embeddings`, `feedback`, `health`,
+  `observability`, `prisma`, `sessions`, `youtube` (counted via
+  `find src/modules/<m> -name "*.spec.ts"`). Best-covered: `chat` (16),
+  `admin` (5), `safety` (5).
+- Web (Vitest/Playwright) and eval suites were **not** executed for this
+  baseline (see §7).
+
+## 3. Database migrations
+
+`apps/api/prisma/migrations/` contains 9 migrations plus
+`add_pgvector_extension.sql` (manual bootstrap) and `migration_lock.toml`:
+
+1. `20250101000000_add_greeting_context_to_session`
+2. `20260120163141_add_fts_to_kbchunk`
+3. `20260125000000_add_current_greeting_step`
+4. `20260130000000_add_geolocation_to_session`
+5. `20260131000000_add_is_eval_to_session`
+6. `20260217000000_add_voice_interaction`
+7. `20260218000000_fts_simple_config`
+8. `20260606000000_phase2_user_role_review_kb_metadata`
+9. `20260622000000_add_whatsapp_contact`
+
+Note: the gated pipeline's repair variables are hardcoded to migration #8
+(`cloudbuild.gated.yaml`, `MIG=20260606000000_...`); adding migration #10
+requires updating it (`docs/cloudbuild-gated-issues.md`, issue 2).
+
+## 4. CI status (verified via `gh` on 2026-07-05)
+
+`gh workflow list` — 5 active workflows: Deploy API to Cloud Run, Deploy
+Landing Site, Deploy Web to Cloud Run, Web Tests, Eval Tier1 - Retrieval
+Quality.
+
+`gh run list --limit 15`:
+
+- **Eval Tier1 nightly: red for 12+ consecutive nights (2026-06-24 →
+  2026-07-05; red on every listed run back through 2026-06-23).**
+  Verified on runs `28731647092`, `28424590294`, `28079102548`: every eval
+  step succeeded; only the final "Send email notification" step failed with
+  `535-5.7.8 Username and Password not accepted` (Gmail SMTP BadCredentials).
+  The workflow status therefore reflects notification delivery, not eval
+  outcome. Tracked as issue #47.
+- Last three "Deploy API to Cloud Run" runs (2026-06-28, for PRs #43/#44/#45
+  merges): **success** — runs `28331131428`, `28332667342`, `28333372955`.
+  See §6 for why this is concerning despite the green status.
+- Annotation on Tier1 runs: several actions (checkout@v4, setup-node@v4,
+  upload-artifact@v4, action-send-mail@v3) target deprecated Node 20 runners.
+
+## 5. Latest real eval result (artifact `tier1-eval-report-184`, run 28731647092, 2026-07-05)
+
+From `tier1-report.json` (downloaded via `gh run download`):
+
+| Metric | Value |
+|---|---|
+| Total cases | 21 |
+| Passed | 20 |
+| Failed | 1 (`RQ-LUNG-02`) |
+| Average score | 98.5% |
+| Top-3 trusted-source presence | 95.2% |
+| Citation coverage | 95.2% |
+| Abstention rate | 0% |
+
+`RQ-LUNG-02` failure detail: deterministic checks `citations_present` and
+`citation_confidence_acceptable` failed; per-case `citationCoverage: 0` and
+`top3TrustedPresence: false` (score 0.694). This is the standing P0 retrieval/
+citation failure referenced by issue #48.
+
+## 6. Critical workflows and known risks at baseline
+
+1. **`deploy-api.yml` env/secret drift (highest risk).**
+   `.github/workflows/deploy-api.yml:81-102` deploys `suchi-api` with only 14
+   env vars and 6 secrets (`database-url`, `deepseek-api-key`,
+   `embedding-api-key`, `admin-basic-user`, `admin-basic-pass`, `SMTP_PASS`),
+   while `cloudbuild.yaml:90-93` sets ~20 env vars and 15 secrets (adds
+   `GEMINI_API_KEY`, `langfuse-public-key`/`langfuse-secret-key`,
+   `NAVIGATOR_APPROVAL_SECRET`, `CONTENT_APPROVAL_SECRET`,
+   `DISTRIBUTION_APPROVAL_SECRET`, `META_PAGE_ACCESS_TOKEN`, `META_PAGE_ID`,
+   `META_IG_USER_ID`, plus `LANGFUSE_*`, `QUEUE_GCS_BUCKET`, `SUCHI_SITE_URL`,
+   `SUCHI_SOCIAL_CARD_URL`; `LLM_TIMEOUT_MS` 25000 vs 45000). Because
+   `--set-env-vars`/`--set-secrets` replace the whole config, and this
+   workflow auto-runs on any `main` push touching `apps/api/**` or `kb/**`
+   (and DID run, successfully, on 2026-06-28 after PRs #43/#44/#45), the
+   currently serving revision was **likely deployed with the reduced set** —
+   which would silently disable Meta/Instagram posting, Langfuse, distribution/
+   content/navigator approval links, and the GCS queue. This exact failure
+   mode occurred before (Meta secrets silently dropped, fixed on revision
+   suchi-api-00394+). P0-1 in `docs/RELIABILITY_BACKLOG.md`; verification
+   command in §7.
+2. **Tier1 nightly canary is blind** until issue #47 is fixed: a genuine
+   retrieval regression and an SMTP failure both show as the same red X.
+3. **Migration ordering:** `deploy-api.yml` runs migrations with
+   `continue-on-error: true` (line 48) — a failed migration does not stop the
+   code deploy, allowing schema/code mismatch.
+4. **`cloudbuild.yaml` vs `cloudbuild.gated.yaml`:** env/secret lists verified
+   identical at this commit (they must be kept that way — replace semantics).
+5. **Safety-critical test gaps** (from
+   `docs/REQUIREMENTS_TRACEABILITY_MATRIX.md`): emergency fast path
+   (FR-CHAT-003), safety-gate-before-RAG ordering (FR-CHAT-005), evidence gate
+   thresholds (FR-CHAT-008/009), citation repair (FR-CHAT-012), voice citation
+   stripping (FR-CHAT-014), safety events (FR-SAFETY-002/003/007), DB-down →
+   abstention (NFR-AVAIL-002) are implemented but untested.
+
+## 7. Unverified assumptions
+
+Recorded honestly; each has a verification command.
+
+1. **Live Cloud Run env config.** Could not run `gcloud run services describe
+   suchi-api` from this environment (gcloud auth token expired,
+   non-interactive). Therefore the claim in §6.1 that production is currently
+   running with the reduced env/secret set is an **inference** from workflow
+   history, not observed state. Verify with:
+   `gcloud run services describe suchi-api --region us-central1 --project gen-lang-client-0202543132 --format json`
+   and inspect `spec.template.spec.containers[0].env` (names only).
+2. **Production health.** `GET /v1/health` on the live service was not called
+   during this baseline. Verify: `curl -s https://suchi-api-lxiveognla-uc.a.run.app/v1/health`.
+3. **Which judge provider the nightly eval actually uses.** The workflow
+   defaults `EVAL_LLM_PROVIDER` to `deepseek` unless a repo secret overrides it
+   (`.github/workflows/eval-tier1.yml:69`); the secret's value cannot be read.
+   The eval config default is `vertex_ai` (`eval/config/loader.ts:57`,
+   `eval/config/default.json`).
+4. **Web/E2E/eval suites' pass state.** `apps/web` Vitest/Playwright and the
+   full `eval/` suites were not run for this baseline (Playwright needs
+   browsers; eval hits the live API and spends LLM tokens). Last "Web Tests"
+   CI conclusions can be checked with `gh run list --workflow e2e-tests.yml`.
+5. **Cloud SQL / Secret Manager state** (secret presence, DB reachability)
+   was not re-verified; secret names cited here come from pipeline files, not
+   from listing Secret Manager.
+6. **`evals/` (top-level) and `apps/api/cloudbuild.ingest.yaml` /
+   `apps/api/Dockerfile.ingest`** appear to be legacy/duplicate surfaces; no
+   runtime evidence either way. Confirm before deleting.
+
+## 8. How to regenerate this baseline
+
+```bash
+git rev-parse HEAD
+cd apps/api && npx jest 2>&1 | tail -5
+ls apps/api/prisma/migrations
+gh workflow list && gh run list --limit 15
+gh run list --workflow eval-tier1.yml --limit 10
+gh run download <latest-tier1-run-id> -n tier1-eval-report-<n>
+```


### PR DESCRIPTION
Closes #46

Documentation-only PR: no runtime code, prompts, medical guidance, deployment configuration, or data were changed.

## Changed files
- `docs/ARCHITECTURE.md` — modules and routes, 14-phase chat pipeline (safety-gate-first), data model, auth surfaces, external dependencies, deployment surfaces
- `docs/OPERATIONS_RUNBOOK.md` — local setup, test commands, the 5 CI workflows, production health checks, rollback path (traffic shift; migrations don't roll back)
- `docs/RELIABILITY_BASELINE.md` — verified state at `e31dfc4`: test-suite result, migrations list, CI status, latest real Tier1 eval metrics, unverified assumptions
- `docs/RELIABILITY_BACKLOG.md` — ranked P0/P1/P2 issues with exact code paths and test gaps
- `AGENTS.md` (repo root) — safety boundaries, repo conventions, test-first expectations, rules for future coding agents

## Commands run to establish baseline facts
- `git rev-parse HEAD` → `e31dfc4d5549e36c5eb3a7041061295543379e25`
- `cd apps/api && npx jest` → **41 suites / 821 tests, all passing** (48.8s, Node v20.20.0, no DB/network needed)
- `ls apps/api/prisma/migrations` → 9 migrations + pgvector bootstrap SQL
- `gh workflow list` / `gh run list --limit 15` / `gh run list --workflow eval-tier1.yml --limit 30`
- `gh run view 28731647092` (and 28424590294, 28079102548) → all eval steps green; only "Send email notification" fails (SMTP 535 BadCredentials) — this is what has made every nightly Tier1 run red since 2026-06-24 (issue #47)
- `gh run download 28731647092 -n tier1-eval-report-184` → real eval result: 21 cases, 20 pass, 1 fail (`RQ-LUNG-02`, zero citation coverage — the standing P0 behind issue #48)
- `grep @Controller` across `apps/api/src` → confirmed no remaining doubled `/v1` prefixes after PRs #44/#45
- Per-module `find ... -name "*.spec.ts" | wc -l` → 10 modules with zero specs

## Key finding (P0-1 in the backlog)
`.github/workflows/deploy-api.yml` deploys `suchi-api` with a stale env/secret list (6 secrets vs 15 in `cloudbuild.yaml`; missing `GEMINI_API_KEY`, all `META_*`, all three approval secrets, Langfuse, `QUEUE_GCS_BUCKET`, …). Because `--set-env-vars`/`--set-secrets` replace the whole config and this workflow auto-ran on the three 2026-06-28 merges (runs 28331131428/28332667342/28333372955, all *after* reconciliation commit `1f39a31`), the live revision was likely deployed with the reduced set — silently disabling IG/FB posting, approval links (including PR #43's distribution approvals), and Langfuse.

## Known limitations
- Could not verify the live Cloud Run service config or hit `/v1/health`: gcloud auth in this environment is expired (non-interactive). The P0-1 production-impact claim is an inference from workflow history; verification commands are included in `docs/RELIABILITY_BASELINE.md` §7.
- Web (Vitest/Playwright) and `eval/` suites were not executed for the baseline (browser deps; live-API + LLM cost). Recorded as unverified assumptions.
- The nightly eval's actual judge provider depends on the `EVAL_LLM_PROVIDER` repo secret, whose value cannot be read (workflow default `deepseek`, config default `vertex_ai`).
- Secret Manager contents were not listed; secret names cited come from pipeline files.

## Human decisions still required
1. **P0-1:** keep `deploy-api.yml` as a deploy path (and reconcile its env/secret list) or demote it to build+test only — and first run `gcloud run services describe suchi-api` to check whether prod is currently degraded and needs a redeploy via `cloudbuild.yaml`.
2. **P0-2 / issue #47:** rotate the Gmail SMTP app password (credential-owner action).
3. **Issue #48 / RQ-LUNG-02:** any retrieval-source or citation-rule change needs SCCF medical review.
4. **Issue #27:** LinkedIn token expiring ~2026-07-20 — rotate or drop the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)