### PR TITLE
ci: single-owner deployment — deploy-api.yml becomes build verification, Cloud Build is sole deployer

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -64,6 +64,12 @@ jobs:
             --wait \
             --quiet
 
+      # IMPORTANT: --set-env-vars / --set-secrets REPLACE the full set on the service
+      # (they do not merge). The lists below MUST stay in exact sync with
+      # cloudbuild.yaml and cloudbuild.gated.yaml — drift here silently wipes
+      # config from production (this happened on 2026-06-28: revisions deployed by
+      # this workflow dropped the Meta, Langfuse, approval-secret, and queue config).
+      # When adding any new env var or secret, update all three pipelines.
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy $SERVICE \
@@ -73,7 +79,7 @@ jobs:
             --allow-unauthenticated \
             --memory 512Mi \
             --cpu 1 \
-            --timeout 600 \
+            --timeout 300 \
             --min-instances 0 \
             --max-instances 10 \
             --port 8080 \
@@ -85,21 +91,35 @@ jobs:
           RATE_LIMIT_TTL_SEC=60,\
           RATE_LIMIT_REQ_PER_TTL=20,\
           LLM_PROVIDER=gemini,\
-          LLM_TIMEOUT_MS=25000,\
+          LLM_TIMEOUT_MS=45000,\
           GCS_BUCKET_TTS=suchi-tts-audio,\
           SCHEDULER_OIDC_AUDIENCE=https://suchi-api-lxiveognla-uc.a.run.app,\
           SCHEDULER_SA_EMAIL=suchi-scheduler@${{ env.PROJECT_ID }}.iam.gserviceaccount.com,\
           DAILY_REPORT_EMAIL=gautamgauri@dikshafoundation.org,\
           SMTP_HOST=smtp.gmail.com,\
           SMTP_PORT=587,\
-          SMTP_USER=gautamgauri@dikshafoundation.org" \
+          SMTP_USER=gautamgauri@dikshafoundation.org,\
+          LANGFUSE_ENABLED=true,\
+          LANGFUSE_HOST=https://us.cloud.langfuse.com,\
+          QUEUE_GCS_BUCKET=suchi-navigator-state,\
+          SUCHI_SITE_URL=https://suchicancercare.org,\
+          SUCHI_SOCIAL_CARD_URL=https://storage.googleapis.com/suchi-public-assets/suchi_social_card.png" \
             --set-secrets "\
           DATABASE_URL=database-url:latest,\
           DEEPSEEK_API_KEY=deepseek-api-key:latest,\
           EMBEDDING_API_KEY=embedding-api-key:latest,\
           ADMIN_BASIC_USER=admin-basic-user:latest,\
           ADMIN_BASIC_PASS=admin-basic-pass:latest,\
-          SMTP_PASS=SMTP_PASS:latest"
+          SMTP_PASS=SMTP_PASS:latest,\
+          LANGFUSE_PUBLIC_KEY=langfuse-public-key:latest,\
+          LANGFUSE_SECRET_KEY=langfuse-secret-key:latest,\
+          NAVIGATOR_APPROVAL_SECRET=NAVIGATOR_APPROVAL_SECRET:latest,\
+          CONTENT_APPROVAL_SECRET=CONTENT_APPROVAL_SECRET:latest,\
+          META_PAGE_ACCESS_TOKEN=META_PAGE_ACCESS_TOKEN:latest,\
+          META_PAGE_ID=META_PAGE_ID:latest,\
+          META_IG_USER_ID=META_IG_USER_ID:latest,\
+          GEMINI_API_KEY=GEMINI_API_KEY:latest,\
+          DISTRIBUTION_APPROVAL_SECRET=DISTRIBUTION_APPROVAL_SECRET:latest"
 
       - name: Verify deployment
         run: |

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,137 +1,51 @@
-name: Deploy API to Cloud Run
+# API build verification — this workflow does NOT deploy.
+#
+# Cloud Build (cloudbuild.yaml) is the SINGLE deployment authority for
+# suchi-api. Deploys are a human decision, run manually:
+#     gcloud builds submit --config cloudbuild.yaml .
+# (then promote the new revision to traffic — see docs/OPERATIONS_RUNBOOK.md).
+#
+# History: this workflow used to auto-deploy on push to main with its own
+# copy of the Cloud Run env/secret config. Because --set-env-vars/--set-secrets
+# REPLACE the full set (no merge), its stale copy wiped production config on
+# 2026-06-28 (see PR #51). It now only verifies that the API image builds and
+# that the two Cloud Build pipelines carry identical runtime config.
+name: API build verification
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'kb/**'
+      - 'cloudbuild.yaml'
+      - 'cloudbuild.gated.yaml'
+      - 'scripts/check_deploy_config_parity.py'
+      - '.github/workflows/deploy-api.yml'
   push:
     branches: [main]
     paths:
       - 'apps/api/**'
       - 'kb/**'
+      - 'cloudbuild.yaml'
+      - 'cloudbuild.gated.yaml'
+      - 'scripts/check_deploy_config_parity.py'
       - '.github/workflows/deploy-api.yml'
 
-env:
-  PROJECT_ID: gen-lang-client-0202543132
-  REGION: us-central1
-  REGISTRY: us-central1-docker.pkg.dev/gen-lang-client-0202543132/suchi-images
-  SERVICE: suchi-api
-  CLOUDSQL_INSTANCE: gen-lang-client-0202543132:us-central1:suchi-db
-
 jobs:
-  deploy:
+  verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
+      - name: Check deploy pipeline config parity
+        run: python3 scripts/check_deploy_config_parity.py
 
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-
-      - name: Build image
+      - name: Build API image (verification only, not pushed)
         run: |
           docker build \
-            -t $REGISTRY/$SERVICE:${{ github.sha }} \
-            -t $REGISTRY/$SERVICE:latest \
+            -t suchi-api:verify-${{ github.sha }} \
             -f apps/api/Dockerfile \
             apps/api
-
-      - name: Push image
-        run: docker push --all-tags $REGISTRY/$SERVICE
-
-      - name: Run database migrations
-        continue-on-error: true
-        run: |
-          gcloud run jobs deploy suchi-migrate \
-            --image $REGISTRY/$SERVICE:${{ github.sha }} \
-            --region $REGION \
-            --command "npx" \
-            --args "prisma,migrate,deploy" \
-            --set-cloudsql-instances $CLOUDSQL_INSTANCE \
-            --set-secrets "DATABASE_URL=database-url:latest" \
-            --set-env-vars "NODE_ENV=production" \
-            --max-retries 0 \
-            --task-timeout 120s \
-            --quiet
-
-          gcloud run jobs execute suchi-migrate \
-            --region $REGION \
-            --wait \
-            --quiet
-
-      # IMPORTANT: --set-env-vars / --set-secrets REPLACE the full set on the service
-      # (they do not merge). The lists below MUST stay in exact sync with
-      # cloudbuild.yaml and cloudbuild.gated.yaml — drift here silently wipes
-      # config from production (this happened on 2026-06-28: revisions deployed by
-      # this workflow dropped the Meta, Langfuse, approval-secret, and queue config).
-      # When adding any new env var or secret, update all three pipelines.
-      - name: Deploy to Cloud Run
-        run: |
-          gcloud run deploy $SERVICE \
-            --image $REGISTRY/$SERVICE:${{ github.sha }} \
-            --region $REGION \
-            --platform managed \
-            --allow-unauthenticated \
-            --memory 512Mi \
-            --cpu 1 \
-            --timeout 300 \
-            --min-instances 0 \
-            --max-instances 10 \
-            --port 8080 \
-            --add-cloudsql-instances $CLOUDSQL_INSTANCE \
-            --set-env-vars "\
-          NODE_ENV=production,\
-          GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }},\
-          EMBEDDING_MODEL=gemini-embedding-001,\
-          RATE_LIMIT_TTL_SEC=60,\
-          RATE_LIMIT_REQ_PER_TTL=20,\
-          LLM_PROVIDER=gemini,\
-          LLM_TIMEOUT_MS=45000,\
-          GCS_BUCKET_TTS=suchi-tts-audio,\
-          SCHEDULER_OIDC_AUDIENCE=https://suchi-api-lxiveognla-uc.a.run.app,\
-          SCHEDULER_SA_EMAIL=suchi-scheduler@${{ env.PROJECT_ID }}.iam.gserviceaccount.com,\
-          DAILY_REPORT_EMAIL=gautamgauri@dikshafoundation.org,\
-          SMTP_HOST=smtp.gmail.com,\
-          SMTP_PORT=587,\
-          SMTP_USER=gautamgauri@dikshafoundation.org,\
-          LANGFUSE_ENABLED=true,\
-          LANGFUSE_HOST=https://us.cloud.langfuse.com,\
-          QUEUE_GCS_BUCKET=suchi-navigator-state,\
-          SUCHI_SITE_URL=https://suchicancercare.org,\
-          SUCHI_SOCIAL_CARD_URL=https://storage.googleapis.com/suchi-public-assets/suchi_social_card.png" \
-            --set-secrets "\
-          DATABASE_URL=database-url:latest,\
-          DEEPSEEK_API_KEY=deepseek-api-key:latest,\
-          EMBEDDING_API_KEY=embedding-api-key:latest,\
-          ADMIN_BASIC_USER=admin-basic-user:latest,\
-          ADMIN_BASIC_PASS=admin-basic-pass:latest,\
-          SMTP_PASS=SMTP_PASS:latest,\
-          LANGFUSE_PUBLIC_KEY=langfuse-public-key:latest,\
-          LANGFUSE_SECRET_KEY=langfuse-secret-key:latest,\
-          NAVIGATOR_APPROVAL_SECRET=NAVIGATOR_APPROVAL_SECRET:latest,\
-          CONTENT_APPROVAL_SECRET=CONTENT_APPROVAL_SECRET:latest,\
-          META_PAGE_ACCESS_TOKEN=META_PAGE_ACCESS_TOKEN:latest,\
-          META_PAGE_ID=META_PAGE_ID:latest,\
-          META_IG_USER_ID=META_IG_USER_ID:latest,\
-          GEMINI_API_KEY=GEMINI_API_KEY:latest,\
-          DISTRIBUTION_APPROVAL_SECRET=DISTRIBUTION_APPROVAL_SECRET:latest"
-
-      - name: Verify deployment
-        run: |
-          URL=$(gcloud run services describe $SERVICE --region $REGION --format 'value(status.url)')
-          for i in 1 2 3 4 5; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL/v1/health" || true)
-            if [ "$STATUS" = "200" ]; then
-              echo "Health check passed: $URL/v1/health"
-              exit 0
-            fi
-            echo "Attempt $i: HTTP $STATUS, retrying in 10s..."
-            sleep 10
-          done
-          echo "Health check failed after 5 attempts"
-          exit 1

--- a/scripts/check_deploy_config_parity.py
+++ b/scripts/check_deploy_config_parity.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fail if the Cloud Run runtime config drifts between deploy pipelines.
+
+Cloud Run's --set-env-vars/--set-secrets REPLACE the full set on the service
+(no merge), so any pipeline that deploys with a stale list silently wipes
+config from production. This happened twice (Jun 27 and Jun 28, 2026).
+
+Cloud Build (cloudbuild.yaml) is the single deployment authority; this script
+asserts that every other pipeline that declares Cloud Run runtime config for
+suchi-api stays byte-identical to it. Run locally or in CI:
+
+    python3 scripts/check_deploy_config_parity.py
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANONICAL = ("cloudbuild.yaml", "deploy-api")
+# Pipelines that must match the canonical env/secret sets exactly: file -> API deploy step id.
+MIRRORS = {"cloudbuild.gated.yaml": "deploy-candidate"}
+
+
+def parse_kv(csv: str) -> dict:
+    out = {}
+    for item in csv.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        key, _, value = item.partition("=")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def extract_cloudbuild(path: Path, step_id: str) -> tuple[dict, dict]:
+    """Pull --set-env-vars / --set-secrets values for the deploy-api step.
+
+    Deliberately line-based rather than yaml.safe_load so it needs no
+    third-party deps in CI. The flag value is the next list item after the
+    flag, within the step whose id is deploy-api.
+    """
+    lines = path.read_text().splitlines()
+    step_ranges = []
+    current = None
+    for i, line in enumerate(lines):
+        if re.match(r"\s*-\s+name:", line) and "steps" not in line:
+            if current is not None:
+                step_ranges.append((current, i))
+            current = i
+    if current is not None:
+        step_ranges.append((current, len(lines)))
+
+    for start, end in step_ranges:
+        block = lines[start:end]
+        if not any(re.search(rf"id:\s*'?{step_id}'?\s*$", l) for l in block):
+            continue
+        found = {}
+        for flag in ("--set-env-vars", "--set-secrets"):
+            for j, line in enumerate(block):
+                if flag in line and j + 1 < len(block):
+                    value = block[j + 1].strip().lstrip("-").strip().strip("'\"")
+                    found[flag] = parse_kv(value)
+        if "--set-env-vars" in found and "--set-secrets" in found:
+            return found["--set-env-vars"], found["--set-secrets"]
+    raise SystemExit(f"{path.name}: could not locate {step_id} step with --set-env-vars/--set-secrets")
+
+
+def normalize(kv: dict) -> dict:
+    return {k: v.replace("${PROJECT_ID}", "gen-lang-client-0202543132") for k, v in kv.items()}
+
+
+def diff(kind: str, canonical: dict, mirror: dict, mirror_name: str) -> list[str]:
+    problems = []
+    for key in sorted(set(canonical) | set(mirror)):
+        if key not in mirror:
+            problems.append(f"  {mirror_name} is MISSING {kind} {key}")
+        elif key not in canonical:
+            problems.append(f"  {mirror_name} has EXTRA {kind} {key} (not in the canonical pipeline)")
+        elif canonical[key] != mirror[key]:
+            problems.append(f"  {mirror_name} {kind} {key}: {mirror[key]!r} != canonical {canonical[key]!r}")
+    return problems
+
+
+def main() -> int:
+    canon_file, canon_step = CANONICAL
+    canon_env, canon_sec = (normalize(d) for d in extract_cloudbuild(REPO_ROOT / canon_file, canon_step))
+    print(f"canonical ({canon_file}): {len(canon_env)} env vars, {len(canon_sec)} secrets")
+
+    problems = []
+    for mirror, step_id in MIRRORS.items():
+        env, sec = (normalize(d) for d in extract_cloudbuild(REPO_ROOT / mirror, step_id))
+        print(f"checking {mirror}: {len(env)} env vars, {len(sec)} secrets")
+        problems += diff("env var", canon_env, env, mirror)
+        problems += diff("secret", canon_sec, sec, mirror)
+
+    if problems:
+        print("\nCONFIG DRIFT DETECTED:")
+        print("\n".join(problems))
+        print(f"\nFix: make the mirror(s) byte-identical to {CANONICAL[0]} (the single deployment authority).")
+        return 1
+    print("OK: all deploy pipelines carry identical Cloud Run runtime config.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes P0-1 from `docs/RELIABILITY_BACKLOG.md` (#46 / PR #50), amended per review to eliminate the dual-deployer architecture rather than just patch the drift.

**Canonical Cloud Run runtime config: 19 env vars, 15 secrets** (defined in `cloudbuild.yaml`, step `deploy-api`; counts asserted automatically by the parity check below — this PR body intentionally states them only once).

## Problem — verified live
`deploy-api.yml` auto-deployed on push to main with its own stale copy of the runtime config (14 env vars / 6 secrets). Cloud Run's `--set-env-vars`/`--set-secrets` **replace** the full set (no merge), so its Jun 28 auto-runs pushed stripped-config revisions. The pinned traffic on revision `suchi-api-00408-v7n` shielded serving traffic from the config wipe, but left the service template stale and production code frozen at PR #44 — PR #45's whatsapp-navigator fix sat undeployed in revision 00409 (0% traffic) for a week.

Production was restored out-of-band on 2026-07-05: revision `suchi-api-00410-xnr` (PR #45 image + full canonical config, generated by parsing `cloudbuild.yaml`) now serves 100% traffic — verified via `gcloud run services describe`, `/v1/health` 200, a KB-grounded Gemini chat smoke test (5 citations, GREEN confidence), and a received Langfuse trace.

## Change: one deployment owner
- **`deploy-api.yml` no longer deploys.** Renamed to "API build verification": it builds the API Docker image (not pushed) and runs the config-parity check, on PRs and pushes touching `apps/api/`, `kb/`, either Cloud Build file, or itself. GCP credentials, migration job, and deploy steps removed.
- **Cloud Build (`cloudbuild.yaml`) is the single deployment authority.** Deploys are a manual human decision (`gcloud builds submit`), consistent with the guidance merged in `AGENTS.md`/`docs/OPERATIONS_RUNBOOK.md` (#50).
- **Automated parity check**: `scripts/check_deploy_config_parity.py` fails CI on any env/secret drift between `cloudbuild.yaml` (step `deploy-api`) and `cloudbuild.gated.yaml` (step `deploy-candidate`) — replacing the previous "keep these in sync" comment with enforcement. Verified green on the current pipelines and verified to detect injected drift (missing var, extra secret, changed value).

## Human decisions still open
- If a Cloud Build *trigger* (auto-deploy on merge) is ever added, it inherits single-owner status cleanly; until then all deploys are manual.
- `GCP_SA_KEY_JSON` GitHub secret is no longer used by this workflow and can be revoked/rotated at your discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)