### PR TITLE
fix(eval): repoint the judge at a live provider so checks stop silently skipping

### DIFF
--- a/.github/workflows/eval-tier1.yml
+++ b/.github/workflows/eval-tier1.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: eval
         env:
           EVAL_API_BASE_URL: ${{ github.event.inputs.api_url || 'https://suchi-api-lxiveognla-uc.a.run.app/v1' }}
-          EVAL_LLM_PROVIDER: ${{ secrets.EVAL_LLM_PROVIDER || 'deepseek' }}
+          EVAL_LLM_PROVIDER: ${{ secrets.EVAL_LLM_PROVIDER || 'vertex_ai' }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT || 'gen-lang-client-0202543132' }}

--- a/.github/workflows/eval-tier1.yml
+++ b/.github/workflows/eval-tier1.yml
@@ -68,6 +68,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The judge runs on Vertex AI (EVAL_LLM_PROVIDER below), which needs
+      # Application Default Credentials. Without this step the Vertex client
+      # raises GoogleAuthError for every case and the run reports "21 of 21
+      # eval cases failed" — an infrastructure failure wearing the costume of a
+      # quality failure. This action writes a credentials file and exports
+      # GOOGLE_APPLICATION_CREDENTIALS for the steps that follow.
+      #
+      # Secret referenced by NAME only (AGENTS.md §1.4). The service account
+      # needs roles/aiplatform.user on gen-lang-client-0202543132.
+      - name: Authenticate to Google Cloud (judge ADC)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/eval/config/default-config.test.ts
+++ b/eval/config/default-config.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Guards on the judge configuration in default.json.
+ *
+ * Regression (2026-09-05): the judge was silently inactive for months.
+ * `llmProvider` and `fallbackLlmProvider` were BOTH "deepseek", so when the
+ * DeepSeek credential was rejected the "fallback" re-called the same dead
+ * credential, every judge check came back `skipped`, and calculateScore() —
+ * which normalizes over only the checks that ran — reported 20/21 passing on a
+ * set that scores 6/21 with the judge actually running. A green nightly was
+ * reporting on checks that never executed.
+ */
+
+import config from "./default.json";
+
+describe("eval default config — the judge must be able to run", () => {
+  // NOTE: primary and fallback are both vertex_ai. That is deliberate — there is
+  // no second judge credential in this project (OpenAI unset, DeepSeek retired
+  // and unrotated), so a distinct fallback would be fiction. The real defect a
+  // same-provider fallback exposed was not the duplication but that a failing
+  // judge marks checks `skipped` and calculateScore() then normalizes them away,
+  // turning a broken judge into a higher score. That is tracked separately; a
+  // judge failure must fail the run, not inflate it.
+
+  it("names a Vertex judge model that is not retired", () => {
+    // gemini-2.0-flash-001 was withdrawn from Vertex; requests against it fail
+    // and take the whole judge down with them.
+    const RETIRED = ["gemini-2.0-flash-001", "gemini-1.5-flash", "gemini-1.5-pro"];
+    expect(RETIRED).not.toContain(config.vertexAiConfig.model);
+  });
+
+  it("does not default either provider slot to deepseek", () => {
+    // deepseek-chat was retired 2026-07-24 and the key is unrotated after an
+    // artifact leak; nothing in this repo should silently route the judge there.
+    expect(config.llmProvider).not.toBe("deepseek");
+    expect(config.fallbackLlmProvider).not.toBe("deepseek");
+  });
+});

--- a/eval/config/default.json
+++ b/eval/config/default.json
@@ -1,11 +1,11 @@
 {
   "apiBaseUrl": "https://suchi-api-lxiveognla-uc.a.run.app/v1",
   "llmProvider": "vertex_ai",
-  "fallbackLlmProvider": "deepseek",
+  "fallbackLlmProvider": "vertex_ai",
   "vertexAiConfig": {
     "project": "gen-lang-client-0202543132",
     "location": "us-central1",
-    "model": "gemini-2.0-flash-001"
+    "model": "gemini-2.5-flash"
   },
   "openAiConfig": {
     "model": "gpt-4o",
@@ -21,4 +21,3 @@
   "parallel": false,
   "maxConcurrency": 5
 }
-


### PR DESCRIPTION
## What

The Tier1 LLM judge has been inactive, and the failure mode **inflated** scores rather than reporting them.

`eval/config/default.json` named vertex model `gemini-2.0-flash-001` (retired on Vertex) and set `fallbackLlmProvider: "deepseek"`, while `.github/workflows/eval-tier1.yml:115` defaulted `EVAL_LLM_PROVIDER` to `deepseek` too. The DeepSeek credential is invalid, so the judge failed, the "fallback" re-called the same dead credential, and every judge check came back `skipped`. `calculateScore()` normalizes over only the checks that actually ran — so **skipping the hard checks raised the score**.

## Measured

`cases/tier1/retrieval_quality.yaml` (21 cases) against prod `suchi-api-00411-9mk`:

| | pass | avg score |
|---|---|---|
| judge skipped (what the nightly reported) | **20/21** | — |
| judge active (this change) | **6/21** | 83.9% |

The 20/21 reproduces the historical nightly figure exactly. Every "no regressions" claim resting on a Tier1 pass rate from before this commit rests on checks that never executed.

## What the judge actually surfaces

With it live, the dominant failures are rubric/prompt defects, not model defects — and they reproduce identically on `gemini-2.5-flash` and `gemini-2.5-flash-lite`:

- `citation_format_valid` — fails 17/21. This is issue #54: the rubric demands citation markers the product deliberately hides from users.
- `doctor_questions` — fails 18/21.

## Not fixed here

`default-config.test.ts` guards the two config mistakes but deliberately does **not** assert a distinct fallback provider — there is no second judge credential in this project (OpenAI unset, DeepSeek retired and unrotated), so that invariant would be fiction.

The deeper defect is left tracked rather than silently patched: **a failing judge should fail the run, not inflate it.** Skipped checks dropping out of the denominator is the same orphaned-weight mechanic as the `safe_choice_handling` finding on #59, at whole-suite scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)