### PR TITLE
ci: run the apps/api Jest suite in CI

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -8,8 +8,14 @@
 # History: this workflow used to auto-deploy on push to main with its own
 # copy of the Cloud Run env/secret config. Because --set-env-vars/--set-secrets
 # REPLACE the full set (no merge), its stale copy wiped production config on
-# 2026-06-28 (see PR #51). It now only verifies that the API image builds and
-# that the two Cloud Build pipelines carry identical runtime config.
+# 2026-06-28 (see PR #51). It now verifies that the API unit suite passes, that
+# the image builds, and that the two Cloud Build pipelines carry identical
+# runtime config.
+#
+# The `test` job below is the repo's only automated gate on API behavior. Before
+# it existed the apps/api Jest suite ran in no workflow at all: the specs were
+# written and passing locally, but nothing enforced them on a PR or on main, so
+# a behavioral regression could reach a manual Cloud Build deploy unchallenged.
 name: API build verification
 
 on:
@@ -33,7 +39,37 @@ on:
       - '.github/workflows/deploy-api.yml'
 
 jobs:
+  test:
+    name: API unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/api/package-lock.json
+
+      - name: Install dependencies
+        working-directory: apps/api
+        run: npm ci
+
+      # The Prisma client is generated, not committed, and prisma.service.ts
+      # imports it — ts-jest cannot compile the suite without this. Reads the
+      # schema only; no database connection is involved.
+      - name: Generate Prisma client
+        working-directory: apps/api
+        run: npx prisma generate
+
+      - name: Run Jest
+        working-directory: apps/api
+        run: npm run test:ci
+
   verify:
+    name: Build + config parity
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "nest start --watch",
     "build": "nest build",
+    "test": "jest",
+    "test:ci": "jest --ci --runInBand",
     "start": "node dist/main.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",


### PR DESCRIPTION
## The gap

The 835-test `apps/api` suite **ran in no workflow at all.** `apps/api/package.json` had no `test` script, and no workflow invoked jest — the specs were written, passing locally, and enforcing nothing.

Combined with:
- `main` is not a protected branch
- zero required status checks on the repo
- `cloudbuild.yaml` (the documented deploy path) has no test step

…the repo had **no automated gate on API behavior anywhere**. A behavioral regression could reach a manual Cloud Build deploy completely unchallenged.

For contrast, this was specifically an API hole: `apps/web` is already covered (`e2e-tests.yml:41` runs vitest, plus Playwright), and `eval` runs its own tests via `eval-tier1.yml:88`.

## The change

- `test` (`jest`) and `test:ci` (`jest --ci --runInBand`) scripts on `apps/api`
- An **API unit tests** job on the existing verification workflow, which already triggers on `apps/api/**` for PRs and pushes to `main`

`prisma generate` runs before jest: the client is generated rather than committed and `prisma.service.ts` imports it, so ts-jest cannot compile the suite without it. It reads the schema only — no database is involved, and the suite needs no running services.

## Verification

Ran the exact CI sequence against a clean `npm ci` tree:

```
npm ci            -> exit 0
npx prisma generate -> ok
npm run test:ci   -> 41 suites, 835 tests passed, 10.5s
```

## Not done here

Making this a **required status check** on `main`. That's a repo setting rather than a file, and it needs a deliberate decision about what should block a merge. Right now the job will report but cannot prevent anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)