### PR TITLE
ci: run API checks on every PR so they can be required

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -18,25 +18,16 @@
 # a behavioral regression could reach a manual Cloud Build deploy unchallenged.
 name: API build verification
 
+# Deliberately NOT path-filtered. Both jobs below are required status checks on
+# main, and GitHub blocks a PR forever on "Expected - waiting for status" when a
+# required check is filtered out of that PR. A docs- or eval-only PR would never
+# become mergeable. The whole workflow runs in about a minute, so it runs on
+# everything rather than being conditionally skipped.
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'kb/**'
-      - 'cloudbuild.yaml'
-      - 'cloudbuild.gated.yaml'
-      - 'scripts/check_deploy_config_parity.py'
-      - '.github/workflows/deploy-api.yml'
   push:
     branches: [main]
-    paths:
-      - 'apps/api/**'
-      - 'kb/**'
-      - 'cloudbuild.yaml'
-      - 'cloudbuild.gated.yaml'
-      - 'scripts/check_deploy_config_parity.py'
-      - '.github/workflows/deploy-api.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Prerequisite for enabling branch protection on `main`.

Both jobs in `deploy-api.yml` are about to become **required status checks**. GitHub blocks a PR indefinitely on *"Expected — waiting for status to be reported"* when a required check is filtered out of that PR — so with the existing `paths:` filter, any eval-only or docs-only PR (#74 and #59 today) would never become mergeable.

Removing the filter makes both checks report on every PR. The workflow runs in ~1 minute, so running it unconditionally is cheaper than the alternative of maintaining skip-shim jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)