### PR TITLE
fix(chat): strip truncated citation markers and their punctuation debris

### DIFF
--- a/apps/api/src/modules/chat/chat.controller.ts
+++ b/apps/api/src/modules/chat/chat.controller.ts
@@ -2,13 +2,7 @@ import { Body, Controller, GatewayTimeoutException, InternalServerErrorException
 import { Throttle } from "@nestjs/throttler";
 import { ChatDto } from "./dto";
 import { ChatService } from "./chat.service";
-
-/** Pattern to match [citation:docId:chunkId] markers */
-const CITATION_MARKER_PATTERN = /\[citation:[^\]]+\]/g;
-/** Pattern to match numbered references like [1], [2] left over from LLM output */
-const NUMBERED_REF_PATTERN = /\s*\[\d{1,3}\]/g;
-/** Pattern to match the raw "**Sources:** [citation:...]" section appended by citation repair */
-const RAW_SOURCES_SECTION_PATTERN = /\n\n\*\*Sources:\*\*\s*(\[citation:[^\]]+\]\s*)+/g;
+import { cleanResponseForDisplay } from "./display-text-cleaner";
 
 @Controller("chat")
 export class ChatController {
@@ -16,24 +10,6 @@ export class ChatController {
   private readonly REQUEST_TIMEOUT_MS = 55000; // 55 seconds — aligned with bounded LLM budget so timeout fallback returns before Cloud Run cap
 
   constructor(private readonly chat: ChatService) {}
-
-  /**
-   * Clean response text for user display.
-   * Strips raw citation markers, numbered refs, and raw sources sections
-   * so the user sees clean, readable text. The structured citations data
-   * is still returned separately in the response for the frontend to render.
-   */
-  private cleanResponseForDisplay(text: string): string {
-    return text
-      .replace(RAW_SOURCES_SECTION_PATTERN, "")
-      .replace(CITATION_MARKER_PATTERN, "")
-      .replace(NUMBERED_REF_PATTERN, "")
-      // Clean up any leftover double-spaces from removed markers
-      .replace(/  +/g, " ")
-      // Clean up any leftover empty bold markers like "** **"
-      .replace(/\*\*\s*\*\*/g, "")
-      .trim();
-  }
 
   @Post()
   @Throttle({ default: { limit: 20, ttl: 60 } })
@@ -58,7 +34,7 @@ export class ChatController {
       // Clean the response text for display (strip citation markers, numbered refs)
       // The raw text is preserved in the database for evaluation purposes
       if (result && result.responseText) {
-        result.responseText = this.cleanResponseForDisplay(result.responseText);
+        result.responseText = cleanResponseForDisplay(result.responseText);
       }
 
       return result;

--- a/apps/api/src/modules/chat/display-text-cleaner.spec.ts
+++ b/apps/api/src/modules/chat/display-text-cleaner.spec.ts
@@ -1,0 +1,152 @@
+import { cleanResponseForDisplay } from './display-text-cleaner';
+
+describe('cleanResponseForDisplay', () => {
+  describe('complete citation markers', () => {
+    it('strips a complete marker and keeps the sentence', () => {
+      const out = cleanResponseForDisplay(
+        'Screening can find cancer early [citation:kb_en_nci_screening_v1:kb_chunk_3]. Talk to your doctor.',
+      );
+      expect(out).not.toContain('citation:');
+      expect(out).not.toContain('kb_en_nci_screening_v1');
+      expect(out).toBe('Screening can find cancer early. Talk to your doctor.');
+    });
+
+    it('strips several markers in one response', () => {
+      const out = cleanResponseForDisplay(
+        'Fact one [citation:doc1:chunk1] and fact two [citation:doc2:chunk2] together.',
+      );
+      expect(out).not.toContain('[');
+      expect(out).toBe('Fact one and fact two together.');
+    });
+  });
+
+  describe('unterminated citation markers (issue #68)', () => {
+    it('strips a marker whose closing bracket never arrived at end of text', () => {
+      // Observed on the live service: generation stopped inside the marker.
+      const out = cleanResponseForDisplay(
+        'Biomarker tests might be effective [citation:kb_en_nci_types_breast_diagnosis_breast_cancer_biomarker_tests_v1:kb_',
+      );
+      expect(out).not.toContain('citation');
+      expect(out).not.toContain('kb_en_nci_types_breast_diagnosis');
+      expect(out).not.toContain('[');
+      expect(out).toBe('Biomarker tests might be effective');
+    });
+
+    it('strips a bare unterminated opener', () => {
+      expect(cleanResponseForDisplay('Some grounded fact [citation:')).toBe('Some grounded fact');
+    });
+
+    it('strips a marker truncated inside the "[citation:" prefix itself', () => {
+      expect(cleanResponseForDisplay('Some grounded fact [cita')).toBe('Some grounded fact');
+      expect(cleanResponseForDisplay('Some grounded fact [citation')).toBe('Some grounded fact');
+    });
+
+    it('does not swallow prose that follows an unterminated marker mid-text', () => {
+      const out = cleanResponseForDisplay(
+        'First claim [citation:doc1 then the answer continues [citation:doc2:chunk2] to the end.',
+      );
+      expect(out).not.toContain('citation:');
+      expect(out).toContain('then the answer continues');
+      expect(out).toBe('First claim then the answer continues to the end.');
+    });
+  });
+
+  describe('numbered references', () => {
+    it('strips numbered refs left over from LLM output', () => {
+      const out = cleanResponseForDisplay('Chemotherapy is one option [1]. Radiation is another [23].');
+      expect(out).toBe('Chemotherapy is one option. Radiation is another.');
+    });
+
+    it('strips a numbered ref truncated at end of text', () => {
+      expect(cleanResponseForDisplay('Chemotherapy is one option [1')).toBe('Chemotherapy is one option');
+    });
+
+    it('leaves legitimate bracketed prose alone', () => {
+      const text = 'Call 112 (or 108 in some states) for an ambulance.';
+      expect(cleanResponseForDisplay(text)).toBe(text);
+    });
+  });
+
+  describe('raw Sources section', () => {
+    it('strips the appended sources section', () => {
+      const out = cleanResponseForDisplay(
+        'Body of the answer.\n\n**Sources:** [citation:doc1:chunk1] [citation:doc2:chunk2]',
+      );
+      expect(out).toBe('Body of the answer.');
+    });
+
+    it('strips a sources section that was truncated mid-marker', () => {
+      const out = cleanResponseForDisplay(
+        'Body of the answer.\n\n**Sources:** [citation:doc1:chunk1] [citation:doc2:ch',
+      );
+      expect(out).not.toContain('Sources:');
+      expect(out).not.toContain('citation');
+      expect(out).toBe('Body of the answer.');
+    });
+
+    it('strips a sources header left dangling with no complete marker at all', () => {
+      const out = cleanResponseForDisplay('Body of the answer.\n\n**Sources:** [citation:doc1');
+      expect(out).toBe('Body of the answer.');
+    });
+
+    it('keeps a "Sources:" header that still has body text under it', () => {
+      const text = 'Body of the answer.\n\n**Sources:** National Cancer Institute';
+      expect(cleanResponseForDisplay(text)).toBe(text);
+    });
+  });
+
+  describe('Devanagari punctuation debris (issue #81, finding 3)', () => {
+    it('removes the orphaned ", ।" left where markers were stripped', () => {
+      const raw =
+        'संक्रमण का खतरा बढ़ सकता है [citation:kb_hi_chemo_v1:kb_c1], [citation:kb_hi_chemo_v1:kb_c2]। डेक्सामेथासोन एक स्टेरॉयड है।';
+      const out = cleanResponseForDisplay(raw);
+
+      expect(out).not.toContain(', ।');
+      expect(out).not.toContain(' ।');
+      expect(out).not.toContain('citation');
+      expect(out).toBe('संक्रमण का खतरा बढ़ सकता है। डेक्सामेथासोन एक स्टेरॉयड है।');
+    });
+
+    it('cleans the artifact even when it arrives already stripped', () => {
+      const out = cleanResponseForDisplay('संक्रमण का खतरा बढ़ सकता है , । डेक्सामेथासोन एक स्टेरॉयड है।');
+      expect(out).toBe('संक्रमण का खतरा बढ़ सकता है। डेक्सामेथासोन एक स्टेरॉयड है।');
+    });
+
+    it('preserves legitimate Devanagari commas, dandas and words', () => {
+      const text =
+        'अपने डॉक्टर, नर्स या अस्पताल के स्टाफ से बात करें। यह जानकारी केवल शिक्षा के लिए है॥';
+      expect(cleanResponseForDisplay(text)).toBe(text);
+    });
+
+    it('preserves a Devanagari list where commas separate real items', () => {
+      const text = 'लक्षणों में थकान, बुखार, और वजन कम होना शामिल हो सकते हैं।';
+      expect(cleanResponseForDisplay(text)).toBe(text);
+    });
+
+    it('handles a Hindi answer truncated mid-marker', () => {
+      const out = cleanResponseForDisplay(
+        'कीमोथेरेपी के दौरान संक्रमण का खतरा बढ़ सकता है [citation:kb_hi_chemo_v1:kb_',
+      );
+      expect(out).toBe('कीमोथेरेपी के दौरान संक्रमण का खतरा बढ़ सकता है');
+      expect(out).not.toContain('kb_hi_chemo_v1');
+    });
+  });
+
+  describe('legitimate text is preserved', () => {
+    it('leaves English punctuation and markdown untouched', () => {
+      const text =
+        '**Important:** If you have symptoms, see a doctor. Call 1800-22-1951 for guidance.\n\n1. Talk to a doctor\n2. Ask about screening';
+      expect(cleanResponseForDisplay(text)).toBe(text);
+    });
+
+    it('preserves an ellipsis', () => {
+      const text = 'I am still thinking ... please wait.';
+      expect(cleanResponseForDisplay(text)).toBe(text);
+    });
+
+    it('handles empty and whitespace-only input', () => {
+      expect(cleanResponseForDisplay('')).toBe('');
+      expect(cleanResponseForDisplay('   ')).toBe('');
+    });
+  });
+});

--- a/apps/api/src/modules/chat/display-text-cleaner.ts
+++ b/apps/api/src/modules/chat/display-text-cleaner.ts
@@ -1,0 +1,109 @@
+/**
+ * Clean assistant response text for user display.
+ *
+ * Citations are for auditors, not readers: the structured citation data is
+ * returned separately in the API response and the raw text is preserved in the
+ * database for evaluation, so anything that looks like a citation marker in the
+ * display string is an artifact and is stripped.
+ *
+ * Stripping is the fail-CLOSED direction. A citation the reader was never meant
+ * to see costs nothing when removed; a raw knowledge-base identifier that
+ * reaches the reader costs trust (issue #68).
+ */
+
+/**
+ * A complete `[citation:docId:chunkId]` marker.
+ *
+ * Marker content excludes `[`, `]` and newlines. A real marker never contains
+ * them, and excluding `[` means this pattern cannot start on an *unterminated*
+ * marker and run forward into a later complete one, swallowing the legitimate
+ * prose in between.
+ */
+const CITATION_MARKER_PATTERN = /\[citation:[^[\]\n]*\]/g;
+
+/**
+ * An UNTERMINATED marker — the generation stopped inside it, so the closing
+ * bracket never arrived (issue #68):
+ *
+ *   ...might be effective [citation:kb_en_nci_types_breast_diagnosis_..._v1:kb_
+ *
+ * Applied after complete markers have already been removed, so any remaining
+ * `[citation:` opener is unterminated by definition. Content is restricted to
+ * the characters real document/chunk ids use, so the strip stops at the first
+ * space and can never eat prose that follows a malformed marker mid-text.
+ */
+const UNTERMINATED_CITATION_MARKER_PATTERN = /\[citation:[A-Za-z0-9_.:-]*/g;
+
+/**
+ * The generation can also stop inside the literal `[citation:` prefix itself,
+ * leaving e.g. `[cita` at the very end of the text. Anchored to end-of-text so
+ * a legitimate `[c...` anywhere else is untouched.
+ */
+const TRUNCATED_CITATION_PREFIX_PATTERN = /\[c(?:i(?:t(?:a(?:t(?:i(?:o(?:n)?)?)?)?)?)?)?$/;
+
+/** Numbered references like [1], [2] left over from LLM output. */
+const NUMBERED_REF_PATTERN = /\s*\[\d{1,3}\]/g;
+
+/** A numbered reference truncated at end-of-text, e.g. a trailing `[12`. */
+const TRUNCATED_NUMBERED_REF_PATTERN = /\s*\[\d{1,3}$/;
+
+/** The raw "**Sources:** [citation:...]" section appended by citation repair. */
+const RAW_SOURCES_SECTION_PATTERN = /\n\n\*\*Sources:\*\*\s*(?:\[citation:[^[\]\n]*\]\s*)+/g;
+
+/**
+ * A "**Sources:**" header left dangling at the end because every marker under
+ * it was stripped (which happens when the section itself was truncated).
+ */
+const DANGLING_SOURCES_HEADER_PATTERN = /\n*[ \t]*\*\*Sources:\*\*[ \t]*$/;
+
+/** Leftover empty bold markers like "** **". */
+const EMPTY_BOLD_PATTERN = /\*\*\s*\*\*/g;
+
+/**
+ * Punctuation orphaned by a removed marker (issue #81, finding 3).
+ *
+ * A marker sitting between a clause and its terminator leaves debris behind:
+ *
+ *   ...बढ़ सकता है [citation:a:b], [citation:c:d]। डेक्सामेथासोन...
+ *   ...बढ़ सकता है , । डेक्सामेथासोन...        <- what the reader saw
+ *
+ * These rules match on the punctuation characters themselves — including the
+ * Devanagari danda `।` and double danda `॥`. They deliberately do NOT use `\b`:
+ * JavaScript word boundaries are ASCII-only and are meaningless against
+ * Devanagari, a bug this project has shipped before.
+ */
+/** Horizontal whitespace stranded before punctuation: " ।" -> "।", " ," -> ",". */
+const SPACE_BEFORE_PUNCTUATION_PATTERN = /[ \t]+([,;:।॥!?]|\.(?!\.))/g;
+/** A separator left dangling in front of a terminator: ", ।" -> "।", ",." -> ".". */
+const SEPARATOR_BEFORE_TERMINATOR_PATTERN = /[,;:]+[ \t]*(?=[।॥.!?])/g;
+/** Punctuation duplicated by a strip: "।।" -> "।", ", ," -> ",". */
+const REPEATED_PUNCTUATION_PATTERN = /([,;:।॥])[ \t]*(?=\1)/g;
+
+/**
+ * Strip citation artifacts and the punctuation debris they leave behind.
+ *
+ * The structured citations data is still returned separately in the API
+ * response for the frontend to render.
+ */
+export function cleanResponseForDisplay(text: string): string {
+  if (!text) return text;
+
+  return (
+    text
+      // ── Citation artifacts ────────────────────────────────────────────
+      .replace(RAW_SOURCES_SECTION_PATTERN, "")
+      .replace(CITATION_MARKER_PATTERN, "")
+      .replace(UNTERMINATED_CITATION_MARKER_PATTERN, "")
+      .replace(TRUNCATED_CITATION_PREFIX_PATTERN, "")
+      .replace(NUMBERED_REF_PATTERN, "")
+      .replace(TRUNCATED_NUMBERED_REF_PATTERN, "")
+      .replace(DANGLING_SOURCES_HEADER_PATTERN, "")
+      // ── Debris left behind by the strips ──────────────────────────────
+      .replace(EMPTY_BOLD_PATTERN, "")
+      .replace(/  +/g, " ")
+      .replace(SPACE_BEFORE_PUNCTUATION_PATTERN, "$1")
+      .replace(SEPARATOR_BEFORE_TERMINATOR_PATTERN, "")
+      .replace(REPEATED_PUNCTUATION_PATTERN, "")
+      .trim()
+  );
+}

--- a/apps/web/src/utils/__tests__/citationParser.test.ts
+++ b/apps/web/src/utils/__tests__/citationParser.test.ts
@@ -86,6 +86,50 @@ describe('citationParser', () => {
       const result = removeCitationMarkers('');
       expect(result).toBe('');
     });
+
+    // Issue #68 — the strip used to require a closing bracket, so a generation
+    // that stopped mid-marker leaked a raw KB identifier to the reader.
+    it('removes an unterminated marker at end of text', () => {
+      const text =
+        'Biomarker tests might be effective [citation:kb_en_nci_types_breast_diagnosis_breast_cancer_biomarker_tests_v1:kb_';
+      const result = removeCitationMarkers(text);
+
+      expect(result).not.toContain('citation');
+      expect(result).not.toContain('kb_en_nci_types_breast_diagnosis');
+      expect(result).toBe('Biomarker tests might be effective ');
+    });
+
+    it('removes a marker truncated inside the "[citation:" prefix', () => {
+      expect(removeCitationMarkers('Some grounded fact [cita')).toBe('Some grounded fact ');
+      expect(removeCitationMarkers('Some grounded fact [citation:')).toBe('Some grounded fact ');
+    });
+
+    it('does not swallow prose that follows an unterminated marker mid-text', () => {
+      const text = 'First claim [citation:doc1 then the answer continues [citation:doc2:chunk2] to the end.';
+      const result = removeCitationMarkers(text);
+
+      expect(result).not.toContain('citation:');
+      expect(result).toContain('then the answer continues');
+      expect(result).toBe('First claim  then the answer continues  to the end.');
+    });
+
+    it('leaves legitimate bracketed prose alone', () => {
+      const text = 'Call 112 (or 108 in some states) for an ambulance [1].';
+      expect(removeCitationMarkers(text)).toBe(text);
+    });
+
+    it('leaves Devanagari text and its punctuation intact', () => {
+      const text = 'अपने डॉक्टर, नर्स या अस्पताल के स्टाफ से बात करें।';
+      expect(removeCitationMarkers(text)).toBe(text);
+    });
+
+    it('removes a marker truncated mid-id in a Hindi answer', () => {
+      const text = 'संक्रमण का खतरा बढ़ सकता है [citation:kb_hi_chemo_v1:kb_';
+      const result = removeCitationMarkers(text);
+
+      expect(result).not.toContain('kb_hi_chemo_v1');
+      expect(result).toBe('संक्रमण का खतरा बढ़ सकता है ');
+    });
   });
 
   describe('splitTextWithCitations', () => {
@@ -152,6 +196,44 @@ describe('citationParser', () => {
       expect(result).toHaveLength(2);
       expect(result[0].type).toBe('citation');
       expect(result[1].type).toBe('citation');
+    });
+
+    // Issue #68 — an unterminated marker is not a parsed citation, so it used
+    // to fall through into a plain-text part and get rendered verbatim.
+    it('never renders an unterminated marker as text', () => {
+      const text = 'Grounded claim [citation:d1:c1] and then [citation:kb_en_nci_screening_v1:kb_';
+      const parts = splitTextWithCitations(text);
+
+      const rendered = parts
+        .filter((p) => p.type === 'text')
+        .map((p) => p.content)
+        .join('');
+
+      expect(rendered).not.toContain('citation');
+      expect(rendered).not.toContain('kb_en_nci_screening_v1');
+      expect(rendered).toContain('and then');
+    });
+
+    it('never renders a truncated "[citation:" prefix as text', () => {
+      const parts = splitTextWithCitations('Grounded claim [citation:d1:c1] tail [citat');
+      const rendered = parts
+        .filter((p) => p.type === 'text')
+        .map((p) => p.content)
+        .join('');
+
+      expect(rendered).not.toContain('[citat');
+      expect(rendered).toContain('tail');
+    });
+
+    it('keeps a truncated Hindi answer readable', () => {
+      const parts = splitTextWithCitations('संक्रमण का खतरा बढ़ सकता है [citation:kb_hi_chemo_v1:kb_');
+      const rendered = parts
+        .filter((p) => p.type === 'text')
+        .map((p) => p.content)
+        .join('');
+
+      expect(rendered).not.toContain('kb_hi_chemo_v1');
+      expect(rendered).toContain('संक्रमण का खतरा बढ़ सकता है');
     });
   });
 

--- a/apps/web/src/utils/citationParser.ts
+++ b/apps/web/src/utils/citationParser.ts
@@ -1,6 +1,37 @@
 import { CitationData } from "../components/Citation";
 
-const CITATION_PATTERN = /\[citation:([^:]+):([^\]]+)\]/g;
+/**
+ * A COMPLETE `[citation:docId:chunkId]` marker.
+ *
+ * The id groups exclude `[`, `]` and newlines. A real marker never contains
+ * them, and excluding `[` means this pattern cannot start on an *unterminated*
+ * marker and run forward into a later complete one, swallowing the legitimate
+ * prose in between.
+ */
+const CITATION_PATTERN = /\[citation:([^:[\]\n]+):([^[\]\n]+)\]/g;
+
+/**
+ * Citation debris that must never be rendered (issue #68).
+ *
+ * The server already strips markers before display, but the client must fail
+ * closed too: when a generation stops *inside* a marker there is no closing
+ * bracket, `CITATION_PATTERN` does not match, and the raw knowledge-base
+ * identifier would otherwise fall through `splitTextWithCitations` into a
+ * plain-text part and be rendered verbatim.
+ *
+ * Three alternatives, in order:
+ *   1. a complete marker,
+ *   2. an UNTERMINATED marker — content restricted to the characters real
+ *      document/chunk ids use, so the strip stops at the first space and can
+ *      never eat prose that follows a malformed marker mid-text,
+ *   3. a marker truncated inside the literal `[citation:` prefix itself
+ *      (e.g. a trailing `[cita`), anchored to end-of-text.
+ *
+ * Stripping is the safe direction: a citation the reader was never meant to
+ * see costs nothing when removed.
+ */
+const CITATION_DEBRIS_PATTERN =
+  /\[citation:[^[\]\n]*\]|\[citation:[A-Za-z0-9_.:-]*|\[c(?:i(?:t(?:a(?:t(?:i(?:o(?:n)?)?)?)?)?)?)?$/g;
 
 export interface ParsedCitation {
   citationText: string;
@@ -30,10 +61,12 @@ export function parseCitations(text: string): ParsedCitation[] {
 }
 
 /**
- * Remove citation markers from text for display
+ * Remove citation markers from text for display.
+ *
+ * Removes unterminated/truncated markers too — see CITATION_DEBRIS_PATTERN.
  */
 export function removeCitationMarkers(text: string): string {
-  return text.replace(CITATION_PATTERN, "");
+  return text.replace(CITATION_DEBRIS_PATTERN, "");
 }
 
 /**
@@ -53,7 +86,9 @@ export function splitTextWithCitations(text: string): TextPart[] {
   citations.forEach((citation) => {
     // Add text before citation
     if (citation.position > lastIndex) {
-      const textContent = text.substring(lastIndex, citation.position);
+      // Scrub debris: an unterminated marker is not a parsed citation, so
+      // without this it would be rendered verbatim as plain text (#68).
+      const textContent = removeCitationMarkers(text.substring(lastIndex, citation.position));
       if (textContent) {
         parts.push({ type: "text", content: textContent });
       }
@@ -71,7 +106,7 @@ export function splitTextWithCitations(text: string): TextPart[] {
 
   // Add remaining text
   if (lastIndex < text.length) {
-    const remainingText = text.substring(lastIndex);
+    const remainingText = removeCitationMarkers(text.substring(lastIndex));
     if (remainingText) {
       parts.push({ type: "text", content: remainingText });
     }
@@ -79,7 +114,7 @@ export function splitTextWithCitations(text: string): TextPart[] {
 
   // If no citations, return whole text as single part
   if (parts.length === 0) {
-    parts.push({ type: "text", content: text });
+    parts.push({ type: "text", content: removeCitationMarkers(text) });
   }
 
   return parts;


### PR DESCRIPTION
Fixes #68. Addresses finding 3 of #81.

## The failure mode

Citation markers are stripped before display (the "citations are for auditors, not readers" decision from #54). Every strip pattern — server and client — required a **closing bracket**:

```js
/\[citation:[^\]]+\]/g        // chat.controller.ts
/\[citation:([^:]+):([^\]]+)\]/g  // apps/web/src/utils/citationParser.ts
```

When a generation stops *inside* a marker there is no `]`, nothing matches, and the raw knowledge-base identifier reaches the reader. Observed on the live service:

```
...might be effective [citation:kb_en_nci_types_breast_diagnosis_breast_cancer_biomarker_tests_v1:kb_
```

The client had the same gap independently: an unterminated marker is not a parsed citation, so `splitTextWithCitations` dropped it into a plain-text part and `ReactMarkdown` rendered it verbatim. Both sides now fail **closed** — a citation the reader was never meant to see costs nothing when removed.

## What changed

**API** — the display cleanup moves out of `ChatController` into a pure, testable `apps/api/src/modules/chat/display-text-cleaner.ts` (same shape as the existing `voice-output-stripper.ts` next to it). It now also strips:

- an **unterminated** marker. Content is restricted to the characters real doc/chunk ids use (`[A-Za-z0-9_.:-]`), so the strip stops at the first space and can never eat prose that follows a malformed marker mid-text.
- a marker truncated inside the literal `[citation:` prefix itself, e.g. a trailing `[cita` — anchored to end-of-text.
- a truncated numbered ref (`[12` at end of text).
- a `**Sources:**` header left dangling when every marker under it was stripped.

**Latent data-loss bug closed along the way:** marker content in the complete-marker patterns now excludes `[` as well as `]`. Previously `[citation:doc1 …prose… [citation:doc2:chunk2]` matched as *one* marker from the first opener to the first `]`, silently deleting the legitimate sentence in between. There is a regression test for this.

**#81 finding 3 — Devanagari punctuation debris.** A marker sitting between a clause and its terminator left visible debris in Hindi replies:

```
संक्रमण का खतरा बढ़ सकता है [citation:a:b], [citation:c:d]। डेक्सामेथासोन…
संक्रमण का खतरा बढ़ सकता है , । डेक्सामेथासोन…      <- what the reader saw
संक्रमण का खतरा बढ़ सकता है। डेक्सामेथासोन…          <- after this PR
```

Three narrow rules run after the strips: horizontal whitespace stranded before punctuation, a separator left dangling in front of a terminator, and punctuation duplicated by a strip. They cover the Devanagari danda `।` and double danda `॥`, and they match on the **punctuation characters themselves** — deliberately never `\b`, since JavaScript word boundaries are ASCII-only and are meaningless against Devanagari (a bug this repo has shipped before, see the Hindi safety remediation work).

**Web** — `CITATION_PATTERN` tightened the same way, plus a `CITATION_DEBRIS_PATTERN` used by `removeCitationMarkers` and by `splitTextWithCitations` to scrub every plain-text part before it is rendered.

## Tests

21 new API cases in `display-text-cleaner.spec.ts` and 9 new web cases, covering each shape the issue names — a complete marker, an unterminated marker at end-of-text, a numbered ref, the Sources section, and Devanagari text with an orphaned `, ।`. Every case asserts **both** that the artifact is gone **and** that legitimate text and punctuation survive (Hindi commas and dandas, English ellipses, `Call 112 (or 108)`, markdown lists, a `**Sources:**` header that still has body text under it).

- `cd apps/api && npx jest` → **872 passed / 43 suites**
- `cd apps/web && npm run test:run` → **155 passed / 9 suites**
- `tsc --noEmit` clean on both apps

## Out of scope (deliberately not touched)

- **#81 findings 1 and 2** — the Hinglish red-flag miss (P0) and the Hindi Pap-smear over-abstention. Both need safety-keyword / KB changes that require SCCF medical review per AGENTS.md §1.3.
- **Voice** has the same fail-open gap (`voice-output-stripper.ts:44`, `voice.service.ts:235-236`, `voice-response-condenser.service.ts:17` all require `]`), as do `copilot/services/patch-executor.service.ts` and `eval-bridge.service.ts`. Left alone to keep this PR to the two surfaces #68 names; worth a follow-up — a truncated id read aloud by TTS is the same trust failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
