### PR TITLE
fix(chat): stop duplicated KB bullets and mid-sentence fallback splices

### DIFF
--- a/apps/api/src/modules/chat/chat.service.ts
+++ b/apps/api/src/modules/chat/chat.service.ts
@@ -1921,7 +1921,9 @@ export class ChatService {
           for (const pattern of insertionPatterns) {
             const match = responseText.match(pattern);
             if (match && match.index !== undefined) {
-              responseText = responseText.slice(0, match.index) + fallbackContent + responseText.slice(match.index);
+              // fallbackContent already starts with a blank line (markdown block
+              // boundary); trimEnd keeps us from stacking 3+ newlines. See #69.
+              responseText = responseText.slice(0, match.index).trimEnd() + fallbackContent + responseText.slice(match.index);
               inserted = true;
               break;
             }
@@ -1929,7 +1931,7 @@ export class ChatService {
 
           // Fallback: append at end if no pattern matches
           if (!inserted) {
-            responseText = responseText + fallbackContent;
+            responseText = responseText.trimEnd() + fallbackContent;
           }
         }
       }
@@ -2781,10 +2783,10 @@ export class ChatService {
     for (const pattern of insertionPatterns) {
       const match = responseText.match(pattern);
       if (match && match.index !== undefined) {
-        return responseText.slice(0, match.index) + fallbackContent + responseText.slice(match.index);
+        return responseText.slice(0, match.index).trimEnd() + fallbackContent + responseText.slice(match.index);
       }
     }
-    return responseText + fallbackContent;
+    return responseText.trimEnd() + fallbackContent;
   }
 
   /**

--- a/apps/api/src/modules/chat/plan-executor.service.spec.ts
+++ b/apps/api/src/modules/chat/plan-executor.service.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for the structured-template response path.
+ *
+ * Issue #67 — `journey_treatment_prep_001` ("I'm starting chemotherapy next week…")
+ * emitted every knowledge-base sentence exactly twice, and each item read
+ * `<heading text><body text>` with no separator. Both defects live in the way
+ * PlanExecutorService turns retrieved chunks into template section content.
+ */
+
+import { PlanExecutorService } from "./plan-executor.service";
+import { ExecutionPlan, RetrievalStep, TemplateStep } from "./execution-planner.service";
+import { RetrievalToolService } from "../rag/retrieval-tool.service";
+import { OutputVerifierService } from "./output-verifier.service";
+import { EvidenceChunk } from "../evidence/evidence-gate.service";
+
+function chunk(chunkId: string, docId: string, content: string, similarity = 0.8): EvidenceChunk {
+  return {
+    chunkId,
+    docId,
+    content,
+    similarity,
+    document: {
+      title: "Chemotherapy to Treat Cancer",
+      url: "https://www.cancer.gov/about-cancer/treatment/types/chemotherapy",
+      sourceType: "02_nci_core",
+      source: "NCI",
+      citation: "National Cancer Institute",
+      isTrustedSource: true,
+    },
+  };
+}
+
+/** Verbatim shape of an NCI chunk: a `##` marker, the heading, then the body. */
+const SIDE_EFFECTS_CHUNK_CONTENT = [
+  "##",
+  "",
+  "Chemotherapy can cause side effects",
+  "",
+  "Chemotherapy not only kills fast-growing cancer cells, but also kills or slows the growth of healthy cells that grow and divide quickly. Examples are cells that line your mouth and intestines.",
+].join("\n");
+
+const AFFECTS_YOU_CHUNK_CONTENT = [
+  "### How chemotherapy may affect you",
+  "",
+  "Chemotherapy affects people in different ways. How you feel depends on the type of chemotherapy you are getting.",
+].join("\n");
+
+/** The CHEMO_DAY_PREP plan the planner builds for a chemo-preparation question. */
+function chemoPlan(): ExecutionPlan {
+  const retrieve: RetrievalStep = {
+    type: "retrieve",
+    intent: "side_effects",
+    query: "I'm starting chemotherapy next week for breast cancer. What should I expect?",
+    topK: 5,
+    stepId: "retrieve_side_effects_0",
+  };
+  const template: TemplateStep = {
+    type: "template",
+    templateId: "chemo_day_prep",
+    retrievalStepIds: ["retrieve_side_effects_0"],
+    locale: "en",
+    stepId: "template_chemo_day_prep",
+  };
+  return {
+    planId: "plan_test",
+    steps: [retrieve, template],
+    usesStructuredTemplate: true,
+    template: null as any,
+    signals: [],
+    reasoning: "test",
+    estimatedRetrievalCalls: 1,
+  } as unknown as ExecutionPlan;
+}
+
+describe("PlanExecutorService — structured template composition", () => {
+  let executor: PlanExecutorService;
+  let retrievalTool: { retrieve: jest.Mock };
+  let outputVerifier: { verify: jest.Mock; quickVerify: jest.Mock };
+
+  function buildExecutor(chunks: EvidenceChunk[]) {
+    retrievalTool = {
+      retrieve: jest.fn().mockResolvedValue({
+        chunks,
+        query: "chemo",
+        intent: "side_effects",
+        count: chunks.length,
+        latencyMs: 1,
+      }),
+    };
+    outputVerifier = {
+      verify: jest.fn(),
+      quickVerify: jest.fn().mockReturnValue({ violations: [], fixedContent: null }),
+    };
+    executor = new PlanExecutorService(
+      retrievalTool as unknown as RetrievalToolService,
+      outputVerifier as unknown as OutputVerifierService
+    );
+  }
+
+  /** Strip citation markers so assertions compare reader-visible text. */
+  function visible(text: string): string {
+    return text.replace(/\s*\[citation:[^\]]*\]/g, "");
+  }
+
+  it("does not emit the same knowledge-base sentence twice when two chunk rows carry identical text (#67)", async () => {
+    // Two DISTINCT chunkIds with the same content — retrieval's chunkId dedup
+    // cannot see this, e.g. a stale chunk row left behind by an earlier ingest.
+    buildExecutor([
+      chunk("doc-chemo::chunk::2", "doc-chemo", SIDE_EFFECTS_CHUNK_CONTENT),
+      chunk("doc-chemo::chunk::9", "doc-chemo", SIDE_EFFECTS_CHUNK_CONTENT),
+      chunk("doc-chemo::chunk::11", "doc-chemo", AFFECTS_YOU_CHUNK_CONTENT),
+    ]);
+
+    const result = await executor.execute(chemoPlan(), "chemo prep", "en");
+    const text = visible(result.responseText || "");
+
+    const occurrences = text.split("Chemotherapy not only kills fast-growing cancer cells").length - 1;
+    expect(occurrences).toBe(1);
+
+    // The distinct chunk still survives — dedup must not swallow real content.
+    expect(text).toContain("Chemotherapy affects people in different ways");
+  });
+
+  it("separates a chunk's heading from its body instead of running them together (#67)", async () => {
+    buildExecutor([chunk("doc-chemo::chunk::2", "doc-chemo", SIDE_EFFECTS_CHUNK_CONTENT)]);
+
+    const result = await executor.execute(chemoPlan(), "chemo prep", "en");
+    const text = visible(result.responseText || "");
+
+    // The reported defect, verbatim: heading welded onto the body with no boundary.
+    expect(text).not.toContain("side effects Chemotherapy not only kills");
+    expect(text).toContain("Chemotherapy can cause side effects: Chemotherapy not only kills");
+  });
+
+  it("keeps the static template sections intact", async () => {
+    buildExecutor([chunk("doc-chemo::chunk::2", "doc-chemo", SIDE_EFFECTS_CHUNK_CONTENT)]);
+
+    const result = await executor.execute(chemoPlan(), "chemo prep", "en");
+    const text = result.responseText || "";
+
+    expect(text).toContain("**Before Your Chemo Session**");
+    expect(text).toContain("**What to Bring**");
+    expect(text).toContain("**Common Side Effects to Expect**");
+  });
+
+  it("emits a citation for every knowledge-base bullet it keeps", async () => {
+    buildExecutor([
+      chunk("doc-chemo::chunk::2", "doc-chemo", SIDE_EFFECTS_CHUNK_CONTENT),
+      chunk("doc-chemo::chunk::11", "doc-chemo", AFFECTS_YOU_CHUNK_CONTENT),
+    ]);
+
+    const result = await executor.execute(chemoPlan(), "chemo prep", "en");
+    const text = result.responseText || "";
+
+    expect(text).toContain("[citation:doc-chemo:doc-chemo::chunk::2]");
+    expect(text).toContain("[citation:doc-chemo:doc-chemo::chunk::11]");
+  });
+});

--- a/apps/api/src/modules/chat/plan-executor.service.ts
+++ b/apps/api/src/modules/chat/plan-executor.service.ts
@@ -413,14 +413,35 @@ export class PlanExecutorService {
   /**
    * Format evidence chunks as readable content for template sections.
    * Extracts key information and formats with citations.
+   *
+   * Chunks whose summary is textually identical to one already emitted are
+   * dropped. Retrieval dedupes by chunkId, which does NOT catch two distinct
+   * chunk rows carrying the same text (e.g. stale chunk rows left behind by an
+   * earlier ingest run) — those reached the reader as the same sentence printed
+   * twice in a row. See issue #67.
    */
   private formatChunksAsContent(chunks: EvidenceChunk[]): string {
     if (chunks.length === 0) return "";
 
     const lines: string[] = [];
+    const seenSummaries = new Set<string>();
     for (const chunk of chunks) {
       // Extract a clean summary from the chunk content
       const summary = this.extractSummary(chunk.content);
+      if (!summary) continue;
+
+      const fingerprint = summary.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+      if (seenSummaries.has(fingerprint)) {
+        this.logger.debug({
+          event: "duplicate_chunk_summary_skipped",
+          chunkId: chunk.chunkId,
+          docId: chunk.docId,
+          summary: summary.substring(0, 80),
+        });
+        continue;
+      }
+      seenSummaries.add(fingerprint);
+
       const citation = `[citation:${chunk.docId}:${chunk.chunkId}]`;
       lines.push(`- ${summary} ${citation}`);
     }
@@ -430,29 +451,51 @@ export class PlanExecutorService {
 
   /**
    * Extract a clean summary from chunk content (first ~100 chars of meaningful text).
+   *
+   * A chunk usually opens with its markdown heading. Stripping the heading markers
+   * along with the newline that followed them ran the heading straight into the
+   * body ("Chemotherapy can cause side effects Chemotherapy not only kills…"), so
+   * the heading is separated out and re-attached with a colon. See issue #67.
    */
   private extractSummary(content: string): string {
-    // Remove markdown formatting, extra whitespace
-    const clean = content
-      .replace(/#+\s*/g, "")
-      .replace(/\*\*/g, "")
-      .replace(/\n+/g, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+    // Strip heading markers and bold, but keep the line structure so a heading
+    // stays a distinct line rather than colliding with the paragraph beneath it.
+    const lines = content
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .map((line) => line.replace(/^\s*#{1,6}\s*/, "").replace(/\*\*/g, "").replace(/\s+/g, " ").trim())
+      .filter((line) => line.length > 0);
+
+    if (lines.length === 0) return "";
+
+    // A short opening line with no terminal punctuation is a heading, not prose.
+    const looksLikeHeading =
+      lines.length > 1 && lines[0].length <= 100 && !/[.!?:]$/.test(lines[0]);
+    const heading = looksLikeHeading ? lines[0] : null;
+    const body = (looksLikeHeading ? lines.slice(1) : lines).join(" ").replace(/\s+/g, " ").trim();
+
+    const prefix = heading ? `${heading}: ` : "";
+    const summary = this.firstSentenceOrTruncate(body);
+    return summary ? `${prefix}${summary}` : heading || "";
+  }
+
+  /** First sentence of `text`, or a word-boundary truncation when there is none. */
+  private firstSentenceOrTruncate(text: string): string {
+    if (!text) return "";
 
     // Take first sentence or first 150 chars
-    const firstSentenceMatch = clean.match(/^[^.!?]+[.!?]/);
+    const firstSentenceMatch = text.match(/^[^.!?]+[.!?]/);
     if (firstSentenceMatch && firstSentenceMatch[0].length <= 200) {
       return firstSentenceMatch[0].trim();
     }
 
     // Truncate at word boundary
-    if (clean.length > 150) {
-      const truncated = clean.substring(0, 150);
+    if (text.length > 150) {
+      const truncated = text.substring(0, 150);
       const lastSpace = truncated.lastIndexOf(" ");
       return truncated.substring(0, lastSpace > 80 ? lastSpace : 150) + "...";
     }
 
-    return clean;
+    return text;
   }
 }

--- a/apps/api/src/modules/chat/structured-extractor.service.spec.ts
+++ b/apps/api/src/modules/chat/structured-extractor.service.spec.ts
@@ -314,6 +314,61 @@ describe("StructuredExtractorService", () => {
       const bulletCount = (fallback.match(/^- /gm) || []).length;
       expect(bulletCount).toBeLessThanOrEqual(5);
     });
+
+    // ── Regression: issue #69 ────────────────────────────────────
+    // Fallback blocks were prefixed with a single "\n". A single newline is not
+    // a block boundary in markdown — it renders as a space — so the first
+    // heading was welded onto the last sentence of the generated answer:
+    // "…and then selecting a therapy Additional tests your doctor may recommend:".
+    it("starts with a blank line so it cannot splice onto the caller's prose (#69)", () => {
+      const chunks = [
+        createChunk("MRI and mammogram are diagnostic tests.", "doc1", "chunk2"),
+      ];
+      const extraction = service.extract(chunks);
+
+      const missing = {
+        diagnosticTests: extraction.diagnosticTests.slice(0, 2),
+        warningSigns: [],
+        timelineMissing: false,
+      };
+
+      const fallback = service.generateFallbackContent(missing, extraction);
+
+      expect(fallback.startsWith("\n\n")).toBe(true);
+      expect(fallback.startsWith("\n\n\n")).toBe(false);
+
+      const prose =
+        "The process generally involves confirming the diagnosis, evaluating the stage, and then selecting a therapy.";
+      const spliced = prose + fallback;
+
+      // The heading must begin its own markdown block, never continue the sentence.
+      // A space or a lone newline before it both render as the same paragraph.
+      expect(spliced).not.toMatch(/therapy\.[ \t]*\n?[ \t]*\*\*Additional tests/);
+      expect(spliced).toContain("therapy.\n\n**Additional tests");
+    });
+
+    it("separates each fallback block with a blank line (#69)", () => {
+      const chunks = [
+        createChunk(
+          "MRI and mammogram are diagnostic tests. Watch for a lump or mass in the breast.",
+          "doc1",
+          "chunk2"
+        ),
+      ];
+      const extraction = service.extract(chunks);
+
+      const missing = {
+        diagnosticTests: extraction.diagnosticTests.slice(0, 2),
+        warningSigns: extraction.warningSigns.slice(0, 2),
+        timelineMissing: false,
+      };
+
+      const fallback = service.generateFallbackContent(missing, extraction);
+
+      expect(fallback).toContain("\n\n**Additional warning signs to be aware of:**");
+      // Bullets inside a block stay on consecutive lines (a markdown list).
+      expect(fallback).toMatch(/\*\*Additional tests your doctor may recommend:\*\*\n- /);
+    });
   });
 
   describe("formatForPrompt()", () => {

--- a/apps/api/src/modules/chat/structured-extractor.service.ts
+++ b/apps/api/src/modules/chat/structured-extractor.service.ts
@@ -415,35 +415,48 @@ export class StructuredExtractorService {
   }
 
   /**
-   * Generate fallback content to fill gaps in LLM response
+   * Generate fallback content to fill gaps in LLM response.
+   *
+   * The returned string is a set of self-contained markdown BLOCKS, separated by
+   * blank lines, and prefixed with a blank line so it can never be spliced onto
+   * the tail of the caller's prose. A single "\n" is not a block boundary in
+   * markdown — it renders as a space — so a leading "\n**Additional tests…**"
+   * was being welded onto the last sentence of the generated answer
+   * ("…and then selecting a therapy Additional tests your doctor may
+   * recommend:"). See issue #69.
    */
   generateFallbackContent(missing: MissingItems, extraction: StructuredInfo): string {
-    const sections: string[] = [];
+    const blocks: string[] = [];
 
     if (missing.diagnosticTests.length > 0) {
-      sections.push("\n**Additional tests your doctor may recommend:**");
+      const lines = ["**Additional tests your doctor may recommend:**"];
       for (const test of missing.diagnosticTests.slice(0, 5)) {
         const ev = test.evidence[0];
-        sections.push(`- ${test.label} [citation:${ev.docId}:${ev.chunkId}]`);
+        lines.push(`- ${test.label} [citation:${ev.docId}:${ev.chunkId}]`);
       }
+      blocks.push(lines.join("\n"));
     }
 
     if (missing.warningSigns.length > 0) {
-      sections.push("\n**Additional warning signs to be aware of:**");
+      const lines = ["**Additional warning signs to be aware of:**"];
       for (const sign of missing.warningSigns.slice(0, 5)) {
         const ev = sign.evidence[0];
-        sections.push(`- ${sign.label} [citation:${ev.docId}:${ev.chunkId}]`);
+        lines.push(`- ${sign.label} [citation:${ev.docId}:${ev.chunkId}]`);
       }
+      blocks.push(lines.join("\n"));
     }
 
     if (missing.timelineMissing && extraction.timeline !== null && extraction.timeline.evidence) {
       const ev = extraction.timeline.evidence;
-      sections.push(
-        `\n**When to seek care:** ${extraction.timeline.rawMatch} [citation:${ev.docId}:${ev.chunkId}]`
+      blocks.push(
+        `**When to seek care:** ${extraction.timeline.rawMatch} [citation:${ev.docId}:${ev.chunkId}]`
       );
     }
 
-    return sections.join("\n");
+    if (blocks.length === 0) return "";
+
+    // Leading blank line guarantees a markdown block boundary at the splice point.
+    return "\n\n" + blocks.join("\n\n");
   }
 
   /**

--- a/apps/api/src/scripts/ingest-kb.ts
+++ b/apps/api/src/scripts/ingest-kb.ts
@@ -386,6 +386,18 @@ async function ingestDoc(doc: ManifestDoc, opts: Opts) {
       ));
     }
   }
+
+  // Prune stale chunks: chunk IDs are deterministic (`docId::chunk::<index>`), so a
+  // re-ingest overwrites indices 0..n-1 but leaves behind every row from a previous
+  // run that had MORE chunks (doc shortened, or a different --maxChunkChars). Those
+  // orphans keep the old text and stay retrievable, which surfaces as the same
+  // sentence appearing twice in an answer. See issue #67.
+  const pruned = await withRetry(() => prisma.kbChunk.deleteMany({
+    where: { docId: doc.id, chunkIndex: { gte: chunks.length } }
+  }));
+  if (pruned.count > 0) {
+    console.log(`  🧹 Pruned ${pruned.count} stale chunk(s) from ${doc.id} (now ${chunks.length} chunks)`);
+  }
 }
 
 async function main() {


### PR DESCRIPTION
Fixes the **duplication** in #67 and the **splice** in #69. The mid-word truncation half of #67 is a separate, already-shipped fix (#73, `MAX_TOKENS` retry) and nothing here touches truncation logic.

## #69 — the splice is a single `\n`

`journey_newly_diagnosed_001`, verbatim from the issue:

```
…and then selecting a therapy Additional tests your
doctor may recommend:

Pathology
Biopsy

Additional warning signs to be aware of:

Lump or mass
```

`generateFallbackContent` built its blocks by pushing each heading with **one** leading newline and joining with another:

`apps/api/src/modules/chat/structured-extractor.service.ts:424`
```ts
sections.push("\n**Additional tests your doctor may recommend:**");
…
return sections.join("\n");
```

A single `\n` is not a block boundary in markdown — it renders as a space. So the **first** heading, glued on by `responseText + fallbackContent` (`chat.service.ts:1932`, and the insertion branch at `:1924`), was absorbed into the answer's closing paragraph. Every **later** heading got `"\n"` (its own prefix) + `"\n"` (the join) = a real boundary and rendered correctly.

That asymmetry is exactly what the issue shows: "Additional tests…" spliced into the prose, "Additional warning signs…" and "Key points…" each starting their own block. (`injectEssentialTermsIfMissing` already used `\n\n`, which is why "Key points" was fine.) The missing period after "therapy" made it read worse, but the splice happens with or without truncation.

**Fix:** fallback content is emitted as self-contained blocks separated by blank lines, with a leading blank line, and both append sites `trimEnd()` so nothing stacks up. Content is unchanged — only the boundary.

## #67 — the `<heading><body>` run-on

`extractSummary` in `plan-executor.service.ts:434` stripped heading markers with `/#+\s*/g`. The `\s*` is greedy across newlines, so `"##\n\nChemotherapy can cause side effects\n\n<body>"` collapsed into one line before the first-sentence match ran.

Replaying the real chunker over `kb/en/02_nci_core/cancer-types/about-cancer-treatment-types-chemotherapy.md` at the ingest default `--maxChunkChars 1400` reproduces the reported strings character-for-character:

| chunk | old summary | new summary |
|---|---|---|
| 2 | `Chemotherapy can cause side effects Chemotherapy not only kills fast-growing cancer cells, …` | `Chemotherapy can cause side effects: Chemotherapy not only kills fast-growing cancer cells, …` |
| 9 | `How chemotherapy may affect you Chemotherapy affects people in different ways.` | `How chemotherapy may affect you: Chemotherapy affects people in different ways.` |

**Fix:** the heading line is split off and re-attached with a colon.

## #67 — the duplication

The issue asked to separate two candidates: retrieval returning a chunk twice vs. the composer appending each chunk once per pass. **Neither, strictly.**

*Not the composer.* The duplicates are adjacent (`A A B B C`). A second composition pass would give `A B C A B C`. And `renderTemplate` / `executeTemplateStep` each run once — which is also why `**Before Your Chemo Session**` and `**What to Bring**` are clean, as the issue observed.

*Not retrieval returning the same chunk twice.* Every merge layer dedupes on `chunkId`: `hybridSearchWithMetadata` (`rag.service.ts:767`), `multiQueryRetrieve` (`:158`), `multiRetrieve` (`retrieval-tool.service.ts:191`), `mergeChunks` (`plan-executor.service.ts:368`). The SQL joins on primary keys.

What none of that catches is **two distinct chunk rows carrying identical text**. Different `chunkId` → passes every dedup; identical content → identical embedding → identical score → lands adjacent after the similarity sort. And the response-level safety net misses it too: `removeDuplicateBullets` normalizes the bullet *including* its `[citation:docId:chunkId]` marker, so two identical sentences with different citations are not "duplicates" to it. (That net never runs on this path anyway — the structured-template branch returns at `chat.service.ts:1186`, before `deduplicateResponse` at `:2207`.)

**Two changes:**

1. **Symptom, guaranteed gone** — `formatChunksAsContent` now dedupes on a normalized summary fingerprint before emitting bullets, so identical text cannot reach the reader twice regardless of what retrieval hands over.

2. **Most likely upstream cause** — `ingest-kb.ts` never pruned stale chunk rows. Chunk ids are deterministic (`docId::chunk::<index>`) and inserted with `ON CONFLICT (id) DO UPDATE`; `deleteMany` only runs under `--wipeChunks --confirmWipe` (`:313`). So a re-ingest overwrites indices `0..n-1` and **leaves behind every row from a run that produced more chunks** — a shortened doc, or a different `--maxChunkChars`. Those orphans keep the old text, stay `status = 'active'`, and stay retrievable; when content shifts between indices, an orphan can carry text identical to a live row. Now pruned with `chunkIndex >= chunks.length`.

### Caveat, stated plainly

I could not reach the production DB, so the stale-row hypothesis is inference from the code plus the `A A B B C` ordering, not a confirmed observation. It is worth one query before closing #67:

```sql
SELECT c."docId", COUNT(*) AS rows, COUNT(DISTINCT c.content) AS distinct_content
FROM "KbChunk" c JOIN "KbDocument" d ON d.id = c."docId"
WHERE d.status = 'active'
GROUP BY c."docId" HAVING COUNT(*) <> COUNT(DISTINCT c.content);
```

If that returns rows, this PR's ingest prune plus a re-ingest clears them and change (1) was the belt to its braces. If it returns nothing, change (1) still holds the symptom shut and the upstream cause needs another look — the KB *files* are clean (1455 files, no duplicate bodies except one benign group of 7 NCI dictionary stubs; no duplicate manifest ids or paths).

## Tests

`cd apps/api && npx jest` → **42 suites, 856 tests, all passing** (850 before).

- `apps/api/src/modules/chat/plan-executor.service.spec.ts` — new, 4 cases. Two fail on `main`: the duplicate-sentence case and the heading run-on case. The other two pin what must *not* change (static template sections survive; every kept bullet keeps its citation).
- `structured-extractor.service.spec.ts` — 2 new cases; the block-boundary one fails on `main`.

## Scope

No changes to the safety module, keyword lists, or clinical/escalation copy. No change to which chunks are retrieved or cited — only how they are rendered.

## Adjacent findings, not fixed here

- **The eval cannot see either defect.** #67 notes the case passes all its expectations. `mustContain`/`mustMatch` string checks are structurally blind to "the same sentence twice" — a repetition assertion on the journey cases would close that hole.
- **The structured-template path skips `stripForVoice`.** It returns at `chat.service.ts:1186`, so a `channel: "voice"` request routed to a template would send raw markdown and `[citation:…]` markers to TTS. Separate issue; flagging it rather than widening this PR.
- **#69's other half is untouched.** The issue also reports that this path never offers to help prepare questions (`mustOfferDoctorQuestions` / `doctorQuestionsMin: 3` unmet) while `journey_worried_symptoms_001` does. That is a response-contract gap, not a formatting one, and it is the part that needs SCCF review — so #69 should stay open for it after this merges.

Refs #67, #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
