### PR TITLE
feat(ops): Ops Center metric collectors + first Capability Ledger (#61–#65)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",
+    "ops:metrics": "ts-node src/scripts/ops-metrics.ts",
     "kb:dry": "ts-node src/scripts/ingest-kb.ts --dryRun",
     "kb:ingest": "ts-node src/scripts/ingest-kb.ts --resume",
     "kb:ingest:fresh": "ts-node src/scripts/ingest-kb.ts --wipeChunks --confirmWipe",

--- a/apps/api/src/modules/admin/admin.controller.ts
+++ b/apps/api/src/modules/admin/admin.controller.ts
@@ -4,6 +4,7 @@ import { BasicAuthGuard } from "../../common/guards/basic-auth.guard";
 import { SchedulerOidcGuard } from "../../common/guards/scheduler-oidc.guard";
 import { AdminService } from "./admin.service";
 import { DailyReportService } from "../analytics/daily-report.service";
+import { OpsMetricsService } from "../analytics/ops-metrics.service";
 import { EmailService } from "../email/email.service";
 import { generateMarkdownReport } from "../analytics/report-generator";
 import { NavigatorApproveService, HospitalUpdates } from "./navigator-approve.service";
@@ -36,6 +37,7 @@ export class AdminController {
     private readonly reviewQueue: ReviewQueueService,
     private readonly analyticsAdmin: AnalyticsAdminService,
     private readonly learningNote: LearningNoteService,
+    private readonly opsMetrics: OpsMetricsService,
   ) {}
 
   @UseGuards(BasicAuthGuard)
@@ -511,6 +513,16 @@ ${noteHtml}
   @Get("analytics/languages")
   async getLanguages(@Query("since") since?: string) {
     return this.analyticsAdmin.getLanguages(since);
+  }
+
+  // ─── Ops Center metrics (issues #61 active users / #62 review queue / #64 safety events) ───
+  // Read-only aggregate counts for the Bodh AI Ops scorecard. Anonymised: counts
+  // and safety-event types only, never message text or contact identifiers.
+
+  @UseGuards(BasicAuthGuard)
+  @Get("ops-metrics")
+  async getOpsMetrics() {
+    return this.opsMetrics.collect();
   }
 
   // ─── Learning Note (FR-LEARN-001) — first Monday of each month ───────────

--- a/apps/api/src/modules/analytics/analytics.module.ts
+++ b/apps/api/src/modules/analytics/analytics.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
 import { AnalyticsService } from "./analytics.service";
 import { DailyReportService } from "./daily-report.service";
+import { OpsMetricsService } from "./ops-metrics.service";
 
 @Module({
-  providers: [AnalyticsService, DailyReportService],
-  exports: [AnalyticsService, DailyReportService],
+  providers: [AnalyticsService, DailyReportService, OpsMetricsService],
+  exports: [AnalyticsService, DailyReportService, OpsMetricsService],
 })
 export class AnalyticsModule {}

--- a/apps/api/src/modules/analytics/ops-metrics.service.spec.ts
+++ b/apps/api/src/modules/analytics/ops-metrics.service.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for OpsMetricsService — Ops Center collectors for issues
+ * #61 (active_users_7d), #62 (review_queue_size), #64 (safety_events_30d).
+ *
+ * Contract:
+ *  - every query excludes eval traffic (Session.isEval = false)
+ *  - the 7d and 30d windows are computed from the injected `now`
+ *  - review queue counts flagged AND not-yet-reviewed sessions only
+ *  - safety events are metadata only (type + count, never message text)
+ *  - the service issues no writes
+ *
+ * PrismaService is mocked — no DB. `now` is injected for deterministic windows.
+ */
+
+import { OpsMetricsService } from "./ops-metrics.service";
+
+const NOW = new Date("2026-09-05T00:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SINCE_7D = new Date(NOW.getTime() - 7 * DAY_MS);
+const SINCE_30D = new Date(NOW.getTime() - 30 * DAY_MS);
+
+interface Counts {
+  sessions7d?: number;
+  waContacts7d?: number;
+  unreviewed?: number;
+  flaggedTotal?: number;
+  safetyTotal?: number;
+  safetyByType?: Array<{ type: string; _count: { _all: number } }>;
+}
+
+function makePrisma(c: Counts = {}) {
+  const sessionCount = jest.fn().mockImplementation(({ where }) => {
+    if (where.reviewFlagged === true && where.reviewedAt === null) {
+      return Promise.resolve(c.unreviewed ?? 0);
+    }
+    if (where.reviewFlagged === true) {
+      return Promise.resolve(c.flaggedTotal ?? 0);
+    }
+    return Promise.resolve(c.sessions7d ?? 0);
+  });
+
+  return {
+    session: { count: sessionCount },
+    whatsAppContact: { count: jest.fn().mockResolvedValue(c.waContacts7d ?? 0) },
+    safetyEvent: {
+      count: jest.fn().mockResolvedValue(c.safetyTotal ?? 0),
+      groupBy: jest.fn().mockResolvedValue(c.safetyByType ?? []),
+    },
+  };
+}
+
+function makeService(c: Counts = {}) {
+  const prisma = makePrisma(c);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const service = new OpsMetricsService(prisma as any);
+  return { service, prisma };
+}
+
+describe("OpsMetricsService", () => {
+  it("collects all three Ops Center metrics", async () => {
+    const { service } = makeService({
+      sessions7d: 4,
+      waContacts7d: 2,
+      unreviewed: 3,
+      flaggedTotal: 11,
+      safetyTotal: 6,
+      safetyByType: [
+        { type: "emergency", _count: { _all: 1 } },
+        { type: "hard_refusal", _count: { _all: 5 } },
+      ],
+    });
+
+    const m = await service.collect(NOW);
+
+    expect(m.generatedAt).toBe(NOW.toISOString());
+    expect(m.windows).toEqual({ activeUsersDays: 7, safetyEventsDays: 30 });
+    expect(m.activeUsers7d.value).toBe(4);
+    expect(m.activeUsers7d.basis).toEqual({ nonEvalSessions: 4, distinctWhatsappContacts: 2 });
+    expect(m.reviewQueueSize.value).toBe(3);
+    expect(m.reviewQueueSize.basis.flaggedTotal).toBe(11);
+    expect(m.safetyEvents30d.value).toBe(6);
+  });
+
+  it("reports zero honestly rather than omitting a metric", async () => {
+    const { service } = makeService();
+
+    const m = await service.collect(NOW);
+
+    expect(m.activeUsers7d.value).toBe(0);
+    expect(m.reviewQueueSize.value).toBe(0);
+    expect(m.safetyEvents30d.value).toBe(0);
+    expect(m.safetyEvents30d.byType).toEqual([]);
+  });
+
+  it("excludes eval traffic from every query", async () => {
+    const { service, prisma } = makeService();
+
+    await service.collect(NOW);
+
+    for (const call of prisma.session.count.mock.calls) {
+      expect(call[0].where.isEval).toBe(false);
+    }
+    expect(prisma.safetyEvent.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ session: { isEval: false } }) }),
+    );
+    expect(prisma.safetyEvent.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ session: { isEval: false } }) }),
+    );
+  });
+
+  it("computes the 7d and 30d windows from the injected now", async () => {
+    const { service, prisma } = makeService();
+
+    await service.collect(NOW);
+
+    const activeUsersCall = prisma.session.count.mock.calls.find(
+      (call) => call[0].where.createdAt !== undefined,
+    );
+    expect(activeUsersCall?.[0].where.createdAt.gte).toEqual(SINCE_7D);
+    expect(prisma.whatsAppContact.count).toHaveBeenCalledWith({
+      where: { lastActiveAt: { gte: SINCE_7D } },
+    });
+    expect(prisma.safetyEvent.count.mock.calls[0][0].where.createdAt.gte).toEqual(SINCE_30D);
+  });
+
+  it("counts only unreviewed sessions for the review queue", async () => {
+    const { service, prisma } = makeService({ unreviewed: 3, flaggedTotal: 11 });
+
+    const m = await service.collect(NOW);
+
+    expect(prisma.session.count).toHaveBeenCalledWith({
+      where: { reviewFlagged: true, reviewedAt: null, isEval: false },
+    });
+    // The queue is the unreviewed subset, never the flagged total.
+    expect(m.reviewQueueSize.value).toBe(3);
+    expect(m.reviewQueueSize.value).not.toBe(m.reviewQueueSize.basis.flaggedTotal);
+  });
+
+  it("returns safety events as type metadata only, sorted by frequency", async () => {
+    const { service } = makeService({
+      safetyTotal: 8,
+      safetyByType: [
+        { type: "emergency", _count: { _all: 2 } },
+        { type: "hard_refusal", _count: { _all: 5 } },
+        { type: "safe_redirect", _count: { _all: 1 } },
+      ],
+    });
+
+    const m = await service.collect(NOW);
+
+    expect(m.safetyEvents30d.byType).toEqual([
+      { type: "hard_refusal", count: 5 },
+      { type: "emergency", count: 2 },
+      { type: "safe_redirect", count: 1 },
+    ]);
+    // No message text, detail, or session id leaves the collector.
+    for (const row of m.safetyEvents30d.byType) {
+      expect(Object.keys(row).sort()).toEqual(["count", "type"]);
+    }
+  });
+
+  it("labels active users as sessions, not distinct humans", async () => {
+    const { service } = makeService({ sessions7d: 4, waContacts7d: 2 });
+
+    const m = await service.collect(NOW);
+
+    expect(m.activeUsers7d.caveat).toMatch(/not distinct humans/i);
+    expect(m.activeUsers7d.basis.distinctWhatsappContacts).toBe(2);
+  });
+
+  it("is read-only — exposes no write methods to Prisma", async () => {
+    const prisma = makePrisma();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = new OpsMetricsService(prisma as any);
+
+    await service.collect(NOW);
+
+    // The mock defines only count/groupBy; any write attempt would throw.
+    expect(Object.keys(prisma.session)).toEqual(["count"]);
+    expect(Object.keys(prisma.safetyEvent).sort()).toEqual(["count", "groupBy"]);
+  });
+});

--- a/apps/api/src/modules/analytics/ops-metrics.service.ts
+++ b/apps/api/src/modules/analytics/ops-metrics.service.ts
@@ -1,0 +1,119 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { PrismaService } from "../prisma/prisma.service";
+
+/**
+ * Ops Center instrumentation metrics (GitHub issues #61, #62, #64).
+ *
+ * These are the three Suchi figures the Bodh AI Ops scorecard renders as
+ * "unavailable" because no collector exists. They are deliberately thin:
+ * three read-only aggregate counts, no new tables, no scheduler, no
+ * time-series storage. At current traffic (~10 real human users in 30 days
+ * against ~700 eval-runner requests) anything heavier would be
+ * instrumentation theatre.
+ *
+ * Rule inherited from the Ops Center: a metric with no collector reads
+ * "unavailable", never 0. So every value here is a real measurement, and the
+ * caveats that limit its meaning travel with it rather than being dropped.
+ *
+ * Eval traffic is excluded everywhere via Session.isEval.
+ * READ-ONLY: this service issues no writes and no DDL.
+ */
+
+export interface OpsMetrics {
+  generatedAt: string;
+  windows: { activeUsersDays: number; safetyEventsDays: number };
+  /** #61 active_users_7d */
+  activeUsers7d: {
+    value: number;
+    basis: { nonEvalSessions: number; distinctWhatsappContacts: number };
+    caveat: string;
+  };
+  /** #62 review_queue_size */
+  reviewQueueSize: {
+    value: number;
+    basis: { flaggedTotal: number };
+  };
+  /** #64 safety_events_30d */
+  safetyEvents30d: {
+    value: number;
+    byType: Array<{ type: string; count: number }>;
+  };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class OpsMetricsService {
+  private readonly logger = new Logger(OpsMetricsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async collect(now: Date = new Date()): Promise<OpsMetrics> {
+    const since7d = new Date(now.getTime() - 7 * DAY_MS);
+    const since30d = new Date(now.getTime() - 30 * DAY_MS);
+
+    const [
+      nonEvalSessions,
+      distinctWhatsappContacts,
+      unreviewedFlagged,
+      flaggedTotal,
+      safetyTotal,
+      safetyByType,
+    ] = await Promise.all([
+      // #61 — sessions started in the window, excluding eval traffic.
+      this.prisma.session.count({
+        where: { createdAt: { gte: since7d }, isEval: false },
+      }),
+      // #61 — the one channel with a durable per-person identifier.
+      this.prisma.whatsAppContact.count({
+        where: { lastActiveAt: { gte: since7d } },
+      }),
+      // #62 — flagged for human review and not yet reviewed.
+      this.prisma.session.count({
+        where: { reviewFlagged: true, reviewedAt: null, isEval: false },
+      }),
+      this.prisma.session.count({
+        where: { reviewFlagged: true, isEval: false },
+      }),
+      // #64 — safety events in the window, metadata only (no message text).
+      this.prisma.safetyEvent.count({
+        where: { createdAt: { gte: since30d }, session: { isEval: false } },
+      }),
+      this.prisma.safetyEvent.groupBy({
+        by: ["type"],
+        where: { createdAt: { gte: since30d }, session: { isEval: false } },
+        _count: { _all: true },
+      }),
+    ]);
+
+    const byType = ((safetyByType ?? []) as Array<{ type: string; _count: { _all: number } }>)
+      .map((row) => ({ type: row.type, count: row._count._all }))
+      .sort((a, b) => b.count - a.count);
+
+    this.logger.log(
+      `ops-metrics: sessions7d=${nonEvalSessions} waContacts7d=${distinctWhatsappContacts} ` +
+        `reviewQueue=${unreviewedFlagged} safety30d=${safetyTotal}`,
+    );
+
+    return {
+      generatedAt: now.toISOString(),
+      windows: { activeUsersDays: 7, safetyEventsDays: 30 },
+      activeUsers7d: {
+        value: nonEvalSessions,
+        basis: { nonEvalSessions, distinctWhatsappContacts },
+        caveat:
+          "Sessions, not distinct humans: web/PWA visitors carry no durable identity, " +
+          "so one person across two visits counts twice. distinctWhatsappContacts is the " +
+          "only true per-person count. Eval traffic (Session.isEval) is excluded.",
+      },
+      reviewQueueSize: {
+        value: unreviewedFlagged,
+        basis: { flaggedTotal },
+      },
+      safetyEvents30d: {
+        value: safetyTotal,
+        byType,
+      },
+    };
+  }
+}

--- a/apps/api/src/scripts/ops-metrics.ts
+++ b/apps/api/src/scripts/ops-metrics.ts
@@ -1,0 +1,209 @@
+/**
+ * Ops Center collector — emits the four Suchi figures the Bodh AI Ops scorecard
+ * cannot currently produce (GitHub issues #61, #62, #63, #64).
+ *
+ * Usage:
+ *   cd apps/api && npm run ops:metrics            # human-readable + JSON block
+ *   cd apps/api && npm run ops:metrics -- --json  # JSON block only (pipeable)
+ *
+ * The DB metrics need a reachable Postgres. Against prod, run the Cloud SQL
+ * proxy first and export the prod DATABASE_URL (see CLAUDE.md):
+ *   cloud-sql-proxy gen-lang-client-0202543132:us-central1:suchi-db \
+ *     --credentials-file ~/.config/gcloud/legacy_credentials/<sa>/adc.json --port 5432
+ *   export DATABASE_URL="$(gcloud secrets versions access latest --secret=database-url)"
+ *
+ * `tier1_eval_status` comes from the GitHub Actions API via `gh`, not the DB.
+ *
+ * Output is shaped for `~/bodh-ai-ops/manual/suchi.json`, which `ops.py
+ * collect_usage()` reads directly — that file is the only transport the Ops
+ * Center has today (it reads local checkouts and git only, and cannot call an
+ * HTTP endpoint). Paste the emitted block in, or:
+ *   npm run ops:metrics -- --json > ~/bodh-ai-ops/manual/suchi.json
+ *
+ * Ops Center rule 2: a metric with no collector reads "unavailable", never 0.
+ * Any query that fails is therefore OMITTED from the JSON block rather than
+ * emitted as a zero — a missing key returns the metric to "unavailable".
+ *
+ * READ-ONLY: SELECT/count only. No writes, no DDL, no migrations.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { execFileSync } from "child_process";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const GH_REPO = "gautamgauri/suchi-cancer-bot";
+const EVAL_WORKFLOW = "eval-tier1.yml";
+
+type Entry = { value: number | string; as_of: string; source: string; by: string };
+
+const isoDate = (d: Date) => d.toISOString().split("T")[0];
+
+/** Prisma errors lead with blank lines; surface the first line that says something. */
+const firstLine = (e: unknown) =>
+  String((e as Error)?.message ?? e)
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0) ?? "unknown error";
+
+/** #61, #62, #64 — three read-only aggregates, eval traffic excluded. */
+async function collectDbMetrics(prisma: PrismaClient, now: Date) {
+  const since7d = new Date(now.getTime() - 7 * DAY_MS);
+  const since30d = new Date(now.getTime() - 30 * DAY_MS);
+
+  const [sessions7d, waContacts7d, unreviewed, safetyTotal, safetyByType] = await Promise.all([
+    prisma.session.count({ where: { createdAt: { gte: since7d }, isEval: false } }),
+    prisma.whatsAppContact.count({ where: { lastActiveAt: { gte: since7d } } }),
+    prisma.session.count({ where: { reviewFlagged: true, reviewedAt: null, isEval: false } }),
+    prisma.safetyEvent.count({ where: { createdAt: { gte: since30d }, session: { isEval: false } } }),
+    prisma.safetyEvent.groupBy({
+      by: ["type"],
+      where: { createdAt: { gte: since30d }, session: { isEval: false } },
+      _count: { _all: true },
+    }),
+  ]);
+
+  return {
+    sessions7d,
+    waContacts7d,
+    unreviewed,
+    safetyTotal,
+    safetyByType: safetyByType
+      .map((r) => ({ type: r.type, count: r._count._all }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
+/** #63 — latest Tier-1 eval conclusion from GitHub Actions. Not a DB metric. */
+function collectTier1Status(): { value: string; detail: string } | null {
+  try {
+    const raw = execFileSync(
+      "gh",
+      [
+        "run",
+        "list",
+        "--repo",
+        GH_REPO,
+        "--workflow",
+        EVAL_WORKFLOW,
+        "--limit",
+        "1",
+        "--json",
+        "conclusion,status,createdAt,displayTitle,url",
+      ],
+      { encoding: "utf-8", timeout: 30_000 },
+    );
+    const runs = JSON.parse(raw) as Array<{
+      conclusion: string | null;
+      status: string;
+      createdAt: string;
+      displayTitle: string;
+      url: string;
+    }>;
+    if (!runs.length) return null;
+    const run = runs[0];
+    // An in-flight run has no conclusion yet — report the status, never guess.
+    const value = run.conclusion || run.status || "unknown";
+    return { value, detail: `${run.createdAt} — ${run.displayTitle} — ${run.url}` };
+  } catch (e) {
+    console.error(`[warn] tier1_eval_status unavailable: ${firstLine(e)}`);
+    return null;
+  }
+}
+
+async function main() {
+  const jsonOnly = process.argv.includes("--json");
+  const now = new Date();
+  const asOf = isoDate(now);
+  const by = process.env.USER || "unknown";
+
+  const entries: Record<string, Entry> = {};
+  let db: Awaited<ReturnType<typeof collectDbMetrics>> | null = null;
+
+  const prisma = new PrismaClient();
+  try {
+    db = await collectDbMetrics(prisma, now);
+  } catch (e) {
+    console.error(`[warn] DB metrics unavailable: ${firstLine(e)}`);
+    console.error("[warn] active_users_7d / review_queue_size / safety_events_30d omitted.");
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  if (db) {
+    entries.active_users_7d = {
+      value: db.sessions7d,
+      as_of: asOf,
+      source: `Suchi DB: non-eval Session rows created in the last 7d (sessions, not distinct humans; ${db.waContacts7d} distinct WhatsApp contacts active)`,
+      by,
+    };
+    entries.review_queue_size = {
+      value: db.unreviewed,
+      as_of: asOf,
+      source: "Suchi DB: Session where reviewFlagged=true AND reviewedAt IS NULL, non-eval",
+      by,
+    };
+    entries.safety_events_30d = {
+      value: db.safetyTotal,
+      as_of: asOf,
+      source: `Suchi DB: SafetyEvent rows in the last 30d, non-eval (${
+        db.safetyByType.map((t) => `${t.type}:${t.count}`).join(", ") || "none"
+      })`,
+      by,
+    };
+  }
+
+  const tier1 = collectTier1Status();
+  if (tier1) {
+    entries.tier1_eval_status = {
+      value: tier1.value,
+      as_of: asOf,
+      source: `GitHub Actions ${EVAL_WORKFLOW} latest run — ${tier1.detail}`,
+      by,
+    };
+  }
+
+  const block = {
+    _how_to:
+      'Add a key per metric: {"value": 12, "as_of": "2026-08-18", "source": "where you read it", "by": "who"}. Entries older than manual_stale_days are flagged stale, not silently trusted. Delete a key to return the metric to \'unavailable\'.',
+    _generated_by: "suchi_repo apps/api: npm run ops:metrics",
+    _generated_at: now.toISOString(),
+    _metrics_available: [
+      "active_users_7d",
+      "review_queue_size",
+      "tier1_eval_status",
+      "safety_events_30d",
+    ],
+    ...entries,
+  };
+
+  if (!jsonOnly) {
+    console.error("");
+    console.error("Suchi — Ops Center metrics");
+    console.error("=".repeat(60));
+    if (db) {
+      console.error(`  active_users_7d     ${db.sessions7d} sessions (${db.waContacts7d} WhatsApp contacts)`);
+      console.error(`  review_queue_size   ${db.unreviewed} unreviewed`);
+      console.error(`  safety_events_30d   ${db.safetyTotal}`);
+      for (const t of db.safetyByType) console.error(`                        ${t.type}: ${t.count}`);
+    } else {
+      console.error("  active_users_7d     unavailable (no DB)");
+      console.error("  review_queue_size   unavailable (no DB)");
+      console.error("  safety_events_30d   unavailable (no DB)");
+    }
+    console.error(`  tier1_eval_status   ${tier1 ? tier1.value : "unavailable (gh unreachable)"}`);
+    console.error("=".repeat(60));
+    console.error("Paste the JSON below into ~/bodh-ai-ops/manual/suchi.json");
+    console.error("");
+  }
+
+  // stdout carries only the JSON, so `-- --json > manual/suchi.json` is safe.
+  console.log(JSON.stringify(block, null, 2));
+
+  // Exit non-zero only if nothing at all could be measured.
+  if (!db && !tier1) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/docs/CAPABILITY_LEDGER.md
+++ b/docs/CAPABILITY_LEDGER.md
@@ -1,0 +1,170 @@
+# Capability Ledger
+
+**The living record of what Suchi actually does, and the proof.**
+
+| | |
+| :-- | :-- |
+| Status | Living document — refresh every release |
+| Verified against | **Repo `main` @ `8d15e3f`. NO PRODUCTION VERIFICATION was performed for this first edition** — no deploy, no `/v1/version` check, no prod DB read, no prod run IDs. Every row below is therefore **L1 (static/CI) at most**. Read nothing here as evidence about the deployed `suchi-api` service. |
+| Test evidence | **859 tests across 43 suites, all passing; `nest build` clean.** Reproduce: `cd apps/api && npx jest`. |
+| Eval evidence | `eval/cases/case-manifest.json` — **601 cases across 25 files**, manifest generated 2026-07-05. Tier-1 nightly is enforcing (a true eval failure fails CI). |
+| Requirements baseline | `docs/REQUIREMENTS.md` (131 reqs) + `docs/REQUIREMENTS_TRACEABILITY_MATRIX.md` (105 implemented / 7 partial / 18 not started, reconciled against source 2026-06-24) |
+| Created | 2026-09-05, closing issue [#65](https://github.com/gautamgauri/suchi-cancer-bot/issues/65) |
+
+> **Why this doc exists.** Suchi's intent is spread across `REQUIREMENTS.md`, `SUCHI_SAFETY_CONTRACT.md` and `SUCHI_ANSWER_POLICY.md`; its verification status lives in the traceability matrix; its release history lives in git and in memory. None of those answers *"what is built and working right now, and how do we know?"* in one place — so that claim decays into handoff notes and chat, and ends up being made from memory in a grant narrative or a deploy decision. This ledger is the single evidence-backed answer.
+>
+> **Its one rule:** a capability is only `Proven` if it points at something executable — **a test, an eval score, or a prod run ID**. If it cannot, it is `Partial` at best.
+
+## Status legend
+
+| Status | Meaning |
+| :-- | :-- |
+| ✅ **Proven** | Verified against a test, an eval, or a real prod run (evidence cited). |
+| 🟡 **Partial** | Code exists and is plausibly working, but not verified end-to-end under the *current* pipeline this cycle. |
+| 🟠 **Built, unverified** | Endpoints/services exist; no recent evidence it works. |
+| ⛔ **Absent / dead** | Referenced somewhere but not wired, or schema with no live code. |
+
+## Verification levels
+
+The **Level** column states what class of evidence backs the row. It exists so nobody reads a green unit test as a production proof.
+
+| Level | Meaning | Ceiling |
+| :-- | :-- | :-- |
+| **L1** | Static / CI — jest, `nest build`, `prisma validate` | Proves the code contract, never runtime behaviour in prod |
+| **L2** | Local runtime — API on :3001, exercised with curl | Proves local behaviour only |
+| **L3** | Prod read-only — health, GET endpoints, SELECT via cloud-sql-proxy | May prove deployment, availability, isolation, read-only behaviour — nothing mutating |
+| **L4** | Prod mutation — only under explicit per-campaign authorisation | Functional production evidence |
+
+**No row in this edition is above L1.** Raising a row to L2/L3/L4 requires a `testing` agent campaign, reviewed by a *separate* `evidence-reviewer` (separation of duties: the agent that produced evidence never approves its own status change).
+
+---
+
+## 1. Safety & refusal
+
+The non-negotiable layer. Per `AGENTS.md` §1.3, none of this may be changed without SCCF medical review.
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Safety gate runs before RAG/LLM; `safe_redirect` / `hard_refusal` terminate the pipeline | ✅ Proven | L1 | `modules/safety/safety.service.spec.ts`; pipeline ordering asserted in `modules/chat/chat.service.spec.ts` (Phase 2 precedes retrieval) |
+| Emergency fast path | ✅ Proven | L1 | `modules/safety/emergency-fast-path.spec.ts` |
+| Hindi / Hinglish safety detection (the `\b`-on-Devanagari class of bug) | ✅ Proven | L1 | `modules/safety/hindi-safety-regression.spec.ts` — a dedicated regression suite, written after a real escape |
+| Input normalisation before keyword matching (romanised / mixed script) | ✅ Proven | L1 | `modules/safety/text-normalizer.spec.ts`, `modules/chat/intent-classifier.romanized.spec.ts` |
+| Disclaimer injection by response class | ✅ Proven | L1 | `modules/safety/disclaimer-engine.spec.ts` |
+| Refusal templates are specific, not generic boilerplate | 🟡 Partial | L1 | `modules/chat/response-templates.spec.ts`. The matching eval regression fixture is **not in `main`** — it rides on PR [#59](https://github.com/gautamgauri/suchi-cancer-bot/pull/59), still open. |
+| Safety events persisted to `SafetyEvent` | 🟡 Partial | L1 | Table + write path exist (`safety.service.ts`); the persistence path itself has no dedicated spec (matrix FR-CHAT-006: "No test"). Counts are now readable — see §8. |
+| Refusal behaviour holds under real prod traffic | 🟠 Built, unverified | — | **Never measured in prod.** No prod safety-event review has been recorded in this repo. |
+
+## 2. Answer grounding
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Evidence gate — minimum evidence thresholds before an answer is allowed | ✅ Proven | L1 | `modules/evidence/evidence-gate.service.spec.ts` |
+| Abstention when evidence is insufficient; safe template, no medical content | ✅ Proven | L1 | `modules/abstention/abstention.service.spec.ts` |
+| LLM provider failure degrades to abstention, never throws | ✅ Proven | L1 | `modules/llm/llm.service.spec.ts` (provider-failure → safe fallback) |
+| Citation repair / minimum citation count | ✅ Proven | L1 | `modules/citations/citation.service.spec.ts` |
+| Output verification against retrieved evidence | ✅ Proven | L1 | `modules/chat/output-verifier.service.spec.ts` |
+| Citations are for auditors, not users — never rendered inline in prose | 🟡 Partial | Manual | Frontend renders a collapsible section; matrix FR-CHAT-013 is "Manual only". Note the open contradiction with the `citation_format_valid` rubric — issue [#54](https://github.com/gautamgauri/suchi-cancer-bot/issues/54). |
+| Retrieval quality against the gold pack | 🟡 Partial | eval | Tier-1 nightly enforcing over 601 cases. **Currently expected RED** on `RQ-LUNG-02` — a known, tracked failure (issue [#53](https://github.com/gautamgauri/suchi-cancer-bot/issues/53), bounded zero-evidence response for `SYMPTOMATIC_PATIENT`, blocked on SCCF medical review). A red nightly here is correct behaviour, not drift. |
+
+## 3. Conversation & language
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| 9-phase chat pipeline, no phase skipped | ✅ Proven | L1 | `modules/chat/chat.service.spec.ts` |
+| Agentic intent routing (6 product intent categories) | ✅ Proven | L1 | `modules/chat/agentic-intent-router.spec.ts`, `modules/chat/intent-classifier.spec.ts` |
+| Greeting / patient-context flow | ✅ Proven | L1 | `modules/chat/greeting-flow.service.spec.ts` |
+| Empathy + emotional-state detection | ✅ Proven | L1 | `modules/chat/empathy-detector.spec.ts`, `modules/chat/mode-detector.spec.ts` |
+| Cross-lingual (Hindi/Hinglish) query expansion | ✅ Proven | L1 | `modules/rag/cross-lingual.service.spec.ts` |
+| Response language selection | ✅ Proven | L1 | `modules/chat/utils/response-language.spec.ts` |
+| Query decomposition | ✅ Proven | L1 | `modules/rag/query-decomposer.service.spec.ts` |
+| Structured output templates / extraction | ✅ Proven | L1 | `modules/chat/structured-output-templates.spec.ts`, `modules/chat/structured-extractor.service.spec.ts` |
+
+## 4. Channels
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Web / PWA chat (`/v1/chat`, `/v1/sessions`) | 🟡 Partial | L1 | Pipeline specs green; the HTTP surface itself has no controller spec. Both endpoints require `channel: "web"`. |
+| Voice output stripping (markdown + citation markers before TTS) | ✅ Proven | L1 | `modules/chat/voice-output-stripper.spec.ts` |
+| Google STT v2 provider | ✅ Proven | L1 | `modules/voice/providers/google-stt-v2.provider.spec.ts` |
+| Voice WebSocket gateway | ✅ Proven | L1 | `modules/voice-ws/voice-ws.gateway.spec.ts` |
+| WhatsApp inbound/outbound + formatting | ✅ Proven | L1 | `modules/whatsapp/whatsapp.service.spec.ts`, `whatsapp.controller.spec.ts`, `whatsapp-format.spec.ts` |
+| WhatsApp durable inbound record before webhook ack + cross-instance wamid de-dup | ✅ Proven | L1 | `modules/whatsapp/whatsapp.controller.spec.ts` (PR #80, `8d15e3f`) |
+| WhatsApp navigator (hospital search over WA) | ✅ Proven | L1 | `modules/whatsapp-navigator/whatsapp-navigator.{controller,service}.spec.ts` |
+| WhatsApp **live send** to real users | ⛔ Absent | — | Code complete, blocked on Meta provisioning (issue #29). Never exercised against a live number. |
+
+## 5. Content, distribution & navigator pipelines
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Article approval / rejection with one-click links | ✅ Proven | L1 | `modules/admin/content-approve.service.spec.ts` |
+| Draft expiry (reminder → archive, reminder-once) | ✅ Proven | L1 | `modules/admin/draft-expiry.service.spec.ts` |
+| Social post safety hard-block; unconfigured platforms omitted | ✅ Proven | L1 | `modules/admin/social-post.service.spec.ts` |
+| Distribution controller (approve/reject API) | ✅ Proven | L1 | `modules/distribution/distribution.controller.spec.ts` |
+| Navigator hospital batch approval + dedup | ✅ Proven | L1 | `modules/admin/navigator-approve.service.spec.ts` |
+| Hospital directory lookup | ✅ Proven | L1 | `modules/chat/hospital-directory.service.spec.ts`, `modules/chat/execution-planner.service.spec.ts` |
+| Automated article publish (git push + deploy from API) | ⛔ Absent | — | Deliberately deferred — OD-001. Notify endpoint exists; publishing is manual at 1–2 articles/month. |
+| Any of these pipelines end-to-end **in production** | 🟠 Built, unverified | — | No prod run of the content, distribution or navigator pipeline is recorded in this repo. |
+
+## 6. Admin, review & privacy
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Human review queue (flag → list → mark reviewed) | 🟡 Partial | L1 | `review-queue.service.ts` + `modules/review/review.service.spec.ts`, `review-checks.spec.ts`. Queue *size* is now instrumented (§8); the flag→review→outcome loop has never been exercised on real flagged traffic. |
+| Retention: >90d conversation data deleted, eval sessions preserved, FK-safe order, batched | ✅ Proven | L1 | `modules/admin/retention.service.spec.ts` — see `docs/PRIVACY_RETENTION.md` |
+| Admin endpoints gated (`BasicAuthGuard`) / scheduler endpoints gated (`SchedulerOidcGuard`) | 🟡 Partial | L1 | Guards applied consistently in `admin.controller.ts`; no dedicated fail-closed spec for the admin guard itself. |
+| Daily report metrics + email | 🟠 Built, unverified | — | `analytics/daily-report.service.ts` + `scripts/generate-daily-report.ts`; no spec, and no recorded prod send. |
+
+## 7. Eval & quality engine
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Tier-1 eval suite, CI-enforcing | ✅ Proven | L1 | `.github/workflows/eval-tier1.yml`; eval-vs-notification status split is itself regression-tested (`eval/ci/eval-status.test.js`, issue #47 / PR #49) |
+| Case-manifest disappearance guard | ✅ Proven | L1 | Manifest pins 601 cases across 25 files; the workflow hard-fails if cases vanish |
+| Per-case records + failure-cluster report + `eval-result.json` artifact | ✅ Proven | L1 | PR #52 (merged) |
+| Regression fixtures for fixed P0 failures | ✅ Proven | L1 | `eval/cases/regression/p0_2026_03_26_zero_citation_stomach.yaml`, `p0_2026_07_05_lung_retrieval_miss.yaml` |
+| Secret redaction in eval report artifacts | ⛔ **Not in `main`** | — | **PR [#59](https://github.com/gautamgauri/suchi-cancer-bot/pull/59) is still OPEN.** Until it merges, nightly eval artifacts still leak the DeepSeek key, and the judge model is unpinned. **Two open owner actions: merge #59, and rotate the exposed DeepSeek key.** |
+| Autoresearch quality engine (failure miner → patcher → gatekeeper → archivist) | 🟠 Built, unverified | — | `eval/autoresearch/` exists; no recorded end-to-end autoresearch cycle with an accepted patch. |
+
+## 8. Ops instrumentation
+
+Closes issues [#61](https://github.com/gautamgauri/suchi-cancer-bot/issues/61), [#62](https://github.com/gautamgauri/suchi-cancer-bot/issues/62), [#63](https://github.com/gautamgauri/suchi-cancer-bot/issues/63), [#64](https://github.com/gautamgauri/suchi-cancer-bot/issues/64).
+
+| Capability | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| `active_users_7d` collector | ✅ Proven | L1 | `modules/analytics/ops-metrics.service.spec.ts`. **Reported as sessions, not distinct humans** — web/PWA carries no durable identity, so the caveat ships with the number; `distinctWhatsappContacts` is the only true per-person count. |
+| `review_queue_size` collector | ✅ Proven | L1 | Same spec — asserts the queue is the *unreviewed* subset, never the flagged total |
+| `safety_events_30d` collector | ✅ Proven | L1 | Same spec — type + count only; no message text, detail or session id leaves the collector |
+| `tier1_eval_status` collector | 🟡 Partial | L1 | `scripts/ops-metrics.ts` reads the latest `eval-tier1.yml` conclusion via `gh`. Not unit-tested (it shells out); degrades to *unavailable*, never to a green. |
+| Eval traffic excluded from every figure | ✅ Proven | L1 | Spec asserts `isEval: false` on every query. This matters more than the numbers: ~86% of `/v1/chat` traffic is the eval runner. |
+| Collector reachable **in production** | 🟠 Built, unverified | — | `GET /v1/admin/ops-metrics` is **inert until deployed**. And the Ops Center's `collect_usage()` reads `~/bodh-ai-ops/manual/suchi.json` only — it has no HTTP transport — so today the script fills that file and the endpoint is the durable path for later. |
+
+## 9. Build, deploy & schema
+
+| Item | Status | Level | Evidence |
+| :-- | :-- | :-- | :-- |
+| Jest suite | ✅ Proven | L1 | 859 tests / 43 suites passing |
+| `nest build` | ✅ Proven | L1 | Clean |
+| API checks run on every PR | ✅ Proven | L1 | `e083d6e` (PR #76) |
+| Single deployment authority — Cloud Build only | ✅ Proven | L1 | `deploy-api.yml` is build-verification only; `scripts/check_deploy_config_parity.py` fails CI on env/secret drift between the two cloudbuild files (PR #51) |
+| **Prisma migration history is diverged from the live schema** | ⛔ **Known-broken** | — | **9 migrations in `apps/api/prisma/migrations/`, but the DB records only the second-oldest as applied; several tables were created out-of-band via `psql`.** Adding a migration is therefore unsafe until the history is reconciled. This is the single most load-bearing "looks wrong, is wrong" fact about this repo — it constrains every schema change. |
+| Deployed revision ↔ repo SHA correspondence | 🟠 Built, unverified | — | Not checked for this edition. Traffic is pinned to a named revision, so "latest revision" ≠ "serving revision" — always verify with `/v1/version` before citing prod. |
+
+## 10. What is explicitly NOT proven
+
+Listing these is the point of the ledger. None may be cited as a capability.
+
+1. **Nothing is production-proven.** This edition has no prod run ID, no `/v1/version` check, no prod DB read. Every ✅ above means "a test passes", not "it works for a user".
+2. **Real-user behaviour is essentially unmeasured.** Measured 2026-09-05: `/v1/chat` served **808 requests in 30 days, of which 697 (86%) were the eval runner and roughly 10 were real humans.** Any claim about user experience, satisfaction or safety-in-the-wild rests on ~10 conversations.
+3. **The safety layer has never been reviewed against real prod safety events.** §1 is CI-proven and prod-unproven.
+4. **WhatsApp has never sent a message to a real user** (Meta provisioning, issue #29).
+5. **The review loop has never been run on real flagged traffic** — only its unit contracts are proven.
+6. **Tier-1 is currently expected RED** on `RQ-LUNG-02` (issue #53), pending SCCF medical review.
+7. **Eval artifacts still leak a secret.** PR #59 (redaction + judge-model pin) is open, not merged; the exposed DeepSeek key has not been rotated.
+
+## How to update this ledger
+
+1. A `testing` agent runs a campaign and produces an evidence table (level, commands, artifacts, verdict). It does **not** edit this file.
+2. A **separate** `evidence-reviewer` agent approves / downgrades / rejects each proposed status change.
+3. Only approved changes are applied here, with the evidence string cited inline and the header's "Verified against" line updated.
+
+Never raise a status without citing something executable. A row that cannot cite a test, an eval score, or a prod run ID is `Partial` at best — that rule is the only thing that keeps this document worth reading.


### PR DESCRIPTION
Addresses the five `ops-instrumentation` issues: #61, #62, #63, #64, #65.

## Scoping first

A reality check shaped this heavily. `/v1/chat` served **808 requests in 30 days — 697 (86%) the eval runner, ~10 real humans.** And `ops.py collect_usage()` reads *only* `~/bodh-ai-ops/manual/suchi.json`; there is no automated collector transport, so an HTTP endpoint alone closes nothing.

So this is deliberately small: **three read-only SQL counts, one `gh` read, one document.** No new tables, no migration, no scheduler, no time-series storage, no dashboard.

## What landed

**#61 / #62 / #64** — `OpsMetricsService` in the existing analytics module, exposed at `GET /v1/admin/ops-metrics` on the existing admin controller behind the existing `BasicAuthGuard`. Every query excludes `Session.isEval` — which matters more than the numbers do, given 86% of traffic is the eval runner.

**#63** — addressed, but deliberately *not* in the API. `tier1_eval_status` is a GitHub Actions conclusion, not a DB metric, and an API server should not poll GitHub. It lives in `apps/api/src/scripts/ops-metrics.ts` (`npm run ops:metrics`), emitting all four in `manual/suchi.json` shape. Exercised end-to-end: returned a live `failure`, correctly matching the known-RED issue #53. A failed query is **omitted rather than reported as `0`**, so the scorecard falls back to "unavailable" instead of silently showing a wrong zero.

**#65** — `docs/CAPABILITY_LEDGER.md`, 61 rows, in the format the `testing` / `evidence-reviewer` agents expect, with glyphs `ops.py collect_capability()` parses (verified by simulating that parser: 44 proven / 9 partial / 7 built-unverified / 5 absent).

Added an explicit **L1–L4 evidence-level column**: the funding-bot legend would let a green unit test read as `Proven`, while the agents' own rule caps CI evidence at L1. **No row is above L1** — no deploy, no prod run, no prod DB read — and the header says so rather than implying production proof.

## Three things writing the ledger disproved

Forcing verification is the point of the exercise:

1. **PR #59 is still OPEN, not merged.** So nightly eval artifacts *still* leak the DeepSeek key (rotation still outstanding — see #79 OPS-1), the judge model is still unpinned on `main`, and `refusal_template_specificity.yaml` is not in `main`. A row citing that fixture was deleted.
2. Repo HEAD is `8d15e3f` (PR #80), so no claim is made about the serving revision.
3. The migration-history NULL rows are recorded as known-constrained for future schema changes.

## Verified

- **43 suites / 859 tests passing** (8 new)
- `nest build` clean, script typechecks
- Read-only queries only; no migration, no deploy, no safety/clinical changes

## Handoff — will not close #65 on the scorecard by itself

`~/bodh-ai-ops/registry.json` must set `"ledger": "suchi_repo/docs/CAPABILITY_LEDGER.md"` for the suchi system (currently `null`). That file is hand-maintained in a different repo and was not touched. Same for `manual/suchi.json` — the script prints the block but does not write into the ops checkout.

## Gotcha worth recording

`apps/api/jest.config.js` ignores any path containing `/.claude/`, so **jest cannot run inside an agent worktree** without `--testPathIgnorePatterns` / `--modulePathIgnorePatterns` overrides. It silently reports "no tests found" rather than erroring — an intentional guard against duplicate spec files in worktrees, but a trap for future agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)