### PR TITLE
feat(ops): KB duplicate-row guard + dry-run cleanup plan (#86)

### DIFF
--- a/apps/api/src/modules/analytics/ops-metrics.service.spec.ts
+++ b/apps/api/src/modules/analytics/ops-metrics.service.spec.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for OpsMetricsService — Ops Center collectors for issues
- * #61 (active_users_7d), #62 (review_queue_size), #64 (safety_events_30d).
+ * #61 (active_users_7d), #62 (review_queue_size), #64 (safety_events_30d),
+ * and the #86 KB duplicate-row guard (kbIndexIntegrity).
  *
  * Contract:
  *  - every query excludes eval traffic (Session.isEval = false)
@@ -26,6 +27,7 @@ interface Counts {
   flaggedTotal?: number;
   safetyTotal?: number;
   safetyByType?: Array<{ type: string; _count: { _all: number } }>;
+  kb?: { total_rows: number; non_deterministic_id_rows: number; duplicate_position_rows: number };
 }
 
 function makePrisma(c: Counts = {}) {
@@ -46,6 +48,11 @@ function makePrisma(c: Counts = {}) {
       count: jest.fn().mockResolvedValue(c.safetyTotal ?? 0),
       groupBy: jest.fn().mockResolvedValue(c.safetyByType ?? []),
     },
+    // #86 — the single-row aggregate over KbChunk. Prisma hands back what the
+    // SQL casts to int; the healthy shape is all zeros except total_rows.
+    $queryRaw: jest.fn().mockResolvedValue([
+      c.kb ?? { total_rows: 0, non_deterministic_id_rows: 0, duplicate_position_rows: 0 },
+    ]),
   };
 }
 
@@ -168,6 +175,53 @@ describe("OpsMetricsService", () => {
     expect(m.activeUsers7d.basis.distinctWhatsappContacts).toBe(2);
   });
 
+  it("reports KB duplicate rows and flags the index unhealthy (#86)", async () => {
+    // The exact production state measured on 2026-09-06.
+    const { service, prisma } = makeService({
+      kb: { total_rows: 73802, non_deterministic_id_rows: 25065, duplicate_position_rows: 25065 },
+    });
+
+    const m = await service.collect(NOW);
+
+    expect(m.kbIndexIntegrity.value).toBe(25065);
+    expect(m.kbIndexIntegrity.basis).toEqual({ totalRows: 73802, nonDeterministicIdRows: 25065 });
+    expect(m.kbIndexIntegrity.healthy).toBe(false);
+    expect(m.kbIndexIntegrity.caveat).toMatch(/docId::chunk::N/);
+    // A single aggregate query, no per-row fetch and no content hashing.
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    const sql = String(prisma.$queryRaw.mock.calls[0][0]);
+    expect(sql).toMatch(/FROM "KbChunk"/);
+    expect(sql).not.toMatch(/md5|content\b/);
+  });
+
+  it("marks the KB index healthy only when both duplicate signals are zero (#86)", async () => {
+    const clean = await makeService({
+      kb: { total_rows: 48737, non_deterministic_id_rows: 0, duplicate_position_rows: 0 },
+    }).service.collect(NOW);
+    expect(clean.kbIndexIntegrity.healthy).toBe(true);
+    expect(clean.kbIndexIntegrity.value).toBe(0);
+
+    // A stray legacy-id row with no positional twin is still unhealthy: the next
+    // ingest cannot upsert over it, so it is a duplicate waiting to happen.
+    const legacyId = await makeService({
+      kb: { total_rows: 48738, non_deterministic_id_rows: 1, duplicate_position_rows: 0 },
+    }).service.collect(NOW);
+    expect(legacyId.kbIndexIntegrity.healthy).toBe(false);
+  });
+
+  it("coerces bigint aggregates to numbers (#86)", async () => {
+    const { service } = makeService({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      kb: { total_rows: BigInt(10) as any, non_deterministic_id_rows: BigInt(2) as any, duplicate_position_rows: BigInt(2) as any },
+    });
+
+    const m = await service.collect(NOW);
+
+    expect(m.kbIndexIntegrity.value).toBe(2);
+    expect(m.kbIndexIntegrity.basis.totalRows).toBe(10);
+    expect(typeof m.kbIndexIntegrity.value).toBe("number");
+  });
+
   it("is read-only — exposes no write methods to Prisma", async () => {
     const prisma = makePrisma();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -175,8 +229,10 @@ describe("OpsMetricsService", () => {
 
     await service.collect(NOW);
 
-    // The mock defines only count/groupBy; any write attempt would throw.
+    // The mock defines only count/groupBy/$queryRaw; any write attempt would throw.
     expect(Object.keys(prisma.session)).toEqual(["count"]);
     expect(Object.keys(prisma.safetyEvent).sort()).toEqual(["count", "groupBy"]);
+    // And the one raw query is a SELECT, not $executeRaw.
+    expect(String(prisma.$queryRaw.mock.calls[0][0]).trim()).toMatch(/^SELECT/);
   });
 });

--- a/apps/api/src/modules/analytics/ops-metrics.service.ts
+++ b/apps/api/src/modules/analytics/ops-metrics.service.ts
@@ -2,7 +2,8 @@ import { Injectable, Logger } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 
 /**
- * Ops Center instrumentation metrics (GitHub issues #61, #62, #64).
+ * Ops Center instrumentation metrics (GitHub issues #61, #62, #64) plus the
+ * KB index integrity guard from issue #86.
  *
  * These are the three Suchi figures the Bodh AI Ops scorecard renders as
  * "unavailable" because no collector exists. They are deliberately thin:
@@ -38,7 +39,32 @@ export interface OpsMetrics {
     value: number;
     byType: Array<{ type: string; count: number }>;
   };
+  /**
+   * #86 kb_duplicate_rows — KbChunk rows that share a (docId, chunkIndex) with
+   * another row. Healthy is exactly 0. A non-zero value means an ingest run
+   * wrote alongside an earlier run instead of upserting over it (Jan 2026:
+   * 25,065 such rows, 34% of the index, from a uuid-id run followed by a
+   * deterministic-id run).
+   */
+  kbIndexIntegrity: {
+    value: number;
+    basis: { totalRows: number; nonDeterministicIdRows: number };
+    healthy: boolean;
+    caveat: string;
+  };
 }
+
+/**
+ * One sequential pass over KbChunk (~74k rows). Deliberately avoids hashing
+ * `content`: the byte-identical-content check is the expensive offline audit
+ * (scripts/sql/kb_duplicate_cleanup.sql); this is the cheap always-on signal.
+ * Prisma returns bigint for aggregates, so every value is cast to int in SQL.
+ */
+type KbIntegrityRow = {
+  total_rows: number;
+  non_deterministic_id_rows: number;
+  duplicate_position_rows: number;
+};
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -59,6 +85,7 @@ export class OpsMetricsService {
       flaggedTotal,
       safetyTotal,
       safetyByType,
+      kbIntegrityRows,
     ] = await Promise.all([
       // #61 — sessions started in the window, excluding eval traffic.
       this.prisma.session.count({
@@ -84,16 +111,43 @@ export class OpsMetricsService {
         where: { createdAt: { gte: since30d }, session: { isEval: false } },
         _count: { _all: true },
       }),
+      // #86 — duplicate KB chunk rows. ingest-kb.ts upserts on the deterministic id
+      // `docId::chunk::N`, so a healthy index has one row per (docId, chunkIndex)
+      // and no row with any other id shape.
+      this.prisma.$queryRaw<KbIntegrityRow[]>`
+        SELECT
+          count(*)::int AS total_rows,
+          (count(*) FILTER (WHERE id NOT LIKE '%::chunk::%'))::int AS non_deterministic_id_rows,
+          (count(*) - count(DISTINCT ("docId", "chunkIndex")))::int AS duplicate_position_rows
+        FROM "KbChunk"
+      `,
     ]);
 
     const byType = ((safetyByType ?? []) as Array<{ type: string; _count: { _all: number } }>)
       .map((row) => ({ type: row.type, count: row._count._all }))
       .sort((a, b) => b.count - a.count);
 
+    const kb = (kbIntegrityRows as KbIntegrityRow[])[0] ?? {
+      total_rows: 0,
+      non_deterministic_id_rows: 0,
+      duplicate_position_rows: 0,
+    };
+    const duplicatePositionRows = Number(kb.duplicate_position_rows);
+    const nonDeterministicIdRows = Number(kb.non_deterministic_id_rows);
+    const kbHealthy = duplicatePositionRows === 0 && nonDeterministicIdRows === 0;
+
     this.logger.log(
       `ops-metrics: sessions7d=${nonEvalSessions} waContacts7d=${distinctWhatsappContacts} ` +
-        `reviewQueue=${unreviewedFlagged} safety30d=${safetyTotal}`,
+        `reviewQueue=${unreviewedFlagged} safety30d=${safetyTotal} ` +
+        `kbDuplicateRows=${duplicatePositionRows} kbNonDeterministicIds=${nonDeterministicIdRows}`,
     );
+    if (!kbHealthy) {
+      this.logger.warn(
+        `ops-metrics: KB index has ${duplicatePositionRows} duplicate (docId, chunkIndex) rows and ` +
+          `${nonDeterministicIdRows} non-deterministic-id rows — see issue #86 and ` +
+          `scripts/sql/kb_duplicate_cleanup.sql`,
+      );
+    }
 
     return {
       generatedAt: now.toISOString(),
@@ -113,6 +167,15 @@ export class OpsMetricsService {
       safetyEvents30d: {
         value: safetyTotal,
         byType,
+      },
+      kbIndexIntegrity: {
+        value: duplicatePositionRows,
+        basis: { totalRows: Number(kb.total_rows), nonDeterministicIdRows },
+        healthy: kbHealthy,
+        caveat:
+          "Counts rows beyond the first per (docId, chunkIndex) and rows whose id is not the " +
+          "deterministic `docId::chunk::N` shape ingest-kb.ts upserts on. Both must be 0 after " +
+          "any ingest. Does not hash content, so genuine in-document repeats are not counted.",
       },
     };
   }

--- a/apps/api/src/scripts/ops-metrics.ts
+++ b/apps/api/src/scripts/ops-metrics.ts
@@ -1,6 +1,7 @@
 /**
  * Ops Center collector — emits the four Suchi figures the Bodh AI Ops scorecard
- * cannot currently produce (GitHub issues #61, #62, #63, #64).
+ * cannot currently produce (GitHub issues #61, #62, #63, #64), plus the KB
+ * duplicate-row guard from issue #86.
  *
  * Usage:
  *   cd apps/api && npm run ops:metrics            # human-readable + JSON block
@@ -50,7 +51,7 @@ async function collectDbMetrics(prisma: PrismaClient, now: Date) {
   const since7d = new Date(now.getTime() - 7 * DAY_MS);
   const since30d = new Date(now.getTime() - 30 * DAY_MS);
 
-  const [sessions7d, waContacts7d, unreviewed, safetyTotal, safetyByType] = await Promise.all([
+  const [sessions7d, waContacts7d, unreviewed, safetyTotal, safetyByType, kbRows] = await Promise.all([
     prisma.session.count({ where: { createdAt: { gte: since7d }, isEval: false } }),
     prisma.whatsAppContact.count({ where: { lastActiveAt: { gte: since7d } } }),
     prisma.session.count({ where: { reviewFlagged: true, reviewedAt: null, isEval: false } }),
@@ -60,9 +61,24 @@ async function collectDbMetrics(prisma: PrismaClient, now: Date) {
       where: { createdAt: { gte: since30d }, session: { isEval: false } },
       _count: { _all: true },
     }),
+    // #86 — duplicate KB chunk rows (same query as OpsMetricsService.kbIndexIntegrity).
+    prisma.$queryRaw<
+      Array<{ total_rows: number; non_deterministic_id_rows: number; duplicate_position_rows: number }>
+    >`
+      SELECT
+        count(*)::int AS total_rows,
+        (count(*) FILTER (WHERE id NOT LIKE '%::chunk::%'))::int AS non_deterministic_id_rows,
+        (count(*) - count(DISTINCT ("docId", "chunkIndex")))::int AS duplicate_position_rows
+      FROM "KbChunk"
+    `,
   ]);
 
+  const kb = kbRows[0] ?? { total_rows: 0, non_deterministic_id_rows: 0, duplicate_position_rows: 0 };
+
   return {
+    kbTotalRows: Number(kb.total_rows),
+    kbDuplicateRows: Number(kb.duplicate_position_rows),
+    kbNonDeterministicIdRows: Number(kb.non_deterministic_id_rows),
     sessions7d,
     waContacts7d,
     unreviewed,
@@ -152,6 +168,15 @@ async function main() {
     };
   }
 
+  if (db) {
+    entries.kb_duplicate_rows = {
+      value: db.kbDuplicateRows,
+      as_of: asOf,
+      source: `Suchi DB: KbChunk rows beyond the first per (docId, chunkIndex); ${db.kbNonDeterministicIdRows} rows with a non-deterministic id, ${db.kbTotalRows} rows total. Healthy = 0 (issue #86)`,
+      by,
+    };
+  }
+
   const tier1 = collectTier1Status();
   if (tier1) {
     entries.tier1_eval_status = {
@@ -172,6 +197,7 @@ async function main() {
       "review_queue_size",
       "tier1_eval_status",
       "safety_events_30d",
+      "kb_duplicate_rows",
     ],
     ...entries,
   };
@@ -185,10 +211,14 @@ async function main() {
       console.error(`  review_queue_size   ${db.unreviewed} unreviewed`);
       console.error(`  safety_events_30d   ${db.safetyTotal}`);
       for (const t of db.safetyByType) console.error(`                        ${t.type}: ${t.count}`);
+      console.error(
+        `  kb_duplicate_rows   ${db.kbDuplicateRows}${db.kbDuplicateRows === 0 && db.kbNonDeterministicIdRows === 0 ? " (healthy)" : ` — UNHEALTHY, ${db.kbNonDeterministicIdRows} legacy-id rows of ${db.kbTotalRows}; see issue #86`}`,
+      );
     } else {
       console.error("  active_users_7d     unavailable (no DB)");
       console.error("  review_queue_size   unavailable (no DB)");
       console.error("  safety_events_30d   unavailable (no DB)");
+      console.error("  kb_duplicate_rows   unavailable (no DB)");
     }
     console.error(`  tier1_eval_status   ${tier1 ? tier1.value : "unavailable (gh unreachable)"}`);
     console.error("=".repeat(60));

--- a/scripts/sql/kb_duplicate_cleanup.sql
+++ b/scripts/sql/kb_duplicate_cleanup.sql
@@ -1,0 +1,154 @@
+-- =============================================================================
+-- KB chunk duplicate-row audit and cleanup plan  (GitHub issue #86)
+-- =============================================================================
+--
+-- STATE MEASURED 2026-09-06 against suchi-db (read-only):
+--   73,802 KbChunk rows, 1,439 docs, all rows embedded.
+--   25,065 rows are from a 2025-12-31/2026-01-01 ingest run that wrote rows with
+--   UUID ids; the 2026-01-02 run wrote deterministic ids (`docId::chunk::N`),
+--   so ingest-kb.ts's `ON CONFLICT ("id")` upsert never matched and a full
+--   second copy was inserted for 511 of the 1,433 NCI docs. Every one of those
+--   25,065 rows has a deterministic-id twin with the same docId, the same
+--   chunkIndex and byte-identical content and embedding.
+--   A further 243 same-content rows at DIFFERENT chunkIndex are genuine
+--   in-document repetition (NCI PDQ boilerplate such as "### Current Clinical
+--   Trials"); they are NOT ingest damage and are left alone here.
+--
+-- WHICH ROW SURVIVES: the deterministic-id row. Do NOT "keep the lowest
+-- chunkIndex / earliest createdAt" (the first proposal in #86): under that rule
+-- the UUID row wins the tie on 24,876 groups, and the very next `npm run
+-- kb:ingest` would insert the deterministic ids again and recreate every
+-- duplicate.
+--
+-- HOW TO USE:
+--   Sections 1-3 are read-only and are what this file is for. Section 4 is the
+--   DELETE, left inside a comment block. A human runs it, inside an explicit
+--   transaction, only after sections 1-3 report the expected numbers.
+--
+-- COST NOTE: suchi-db is a db-f1-micro. A GROUP BY over KbChunk took ~3 min
+-- under load; expect minutes, not seconds, for sections 2-3 and the DELETE.
+-- Nothing here is safe to run from a request path.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Cheap health signal (the same query OpsMetricsService.kbIndexIntegrity runs).
+--    Healthy index: duplicate_position_rows = 0 AND non_deterministic_id_rows = 0.
+--    Measured 2026-09-06: 73802 | 25065 | 25065
+-- ---------------------------------------------------------------------------
+SELECT
+  count(*)::int                                                       AS total_rows,
+  (count(*) FILTER (WHERE id NOT LIKE '%::chunk::%'))::int            AS non_deterministic_id_rows,
+  (count(*) - count(DISTINCT ("docId", "chunkIndex")))::int           AS duplicate_position_rows
+FROM "KbChunk";
+
+-- ---------------------------------------------------------------------------
+-- 2. DRY RUN — exactly the rows section 4 would delete.
+--    A stale row is: non-deterministic id, in a doc that also has deterministic
+--    rows. Expected 2026-09-06: 25065.
+-- ---------------------------------------------------------------------------
+WITH mixed_docs AS (
+  SELECT "docId"
+  FROM "KbChunk"
+  GROUP BY "docId"
+  HAVING bool_or(id LIKE '%::chunk::%') AND bool_or(id NOT LIKE '%::chunk::%')
+)
+SELECT count(*) AS rows_delete_would_remove
+FROM "KbChunk" k
+JOIN mixed_docs m ON m."docId" = k."docId"
+WHERE k.id NOT LIKE '%::chunk::%';
+
+-- ---------------------------------------------------------------------------
+-- 3. SAFETY INVARIANT — every row section 4 would delete has a surviving twin
+--    with the same docId, the same chunkIndex and byte-identical content.
+--    Both columns MUST be equal (expected 25065 = 25065). If they differ, STOP:
+--    some stale row carries content the deterministic run did not re-ingest.
+--    (Verified offline 2026-09-06: 25065/25065. Slow on f1-micro.)
+-- ---------------------------------------------------------------------------
+WITH mixed_docs AS (
+  SELECT "docId"
+  FROM "KbChunk"
+  GROUP BY "docId"
+  HAVING bool_or(id LIKE '%::chunk::%') AND bool_or(id NOT LIKE '%::chunk::%')
+),
+stale AS (
+  SELECT k.*
+  FROM "KbChunk" k
+  JOIN mixed_docs m ON m."docId" = k."docId"
+  WHERE k.id NOT LIKE '%::chunk::%'
+)
+SELECT
+  count(*)                                                     AS stale_rows,
+  count(*) FILTER (WHERE EXISTS (
+    SELECT 1 FROM "KbChunk" t
+    WHERE t."docId" = stale."docId"
+      AND t."chunkIndex" = stale."chunkIndex"
+      AND t.id LIKE '%::chunk::%'
+      AND t.content = stale.content))                          AS stale_rows_with_identical_twin
+FROM stale;
+
+-- Optional: MessageCitation rows that reference a to-be-deleted chunk id.
+-- MessageCitation.chunkId is a plain text column with no FK, and nothing in the
+-- API resolves a stored chunkId back to KbChunk at read time (citationText is
+-- stored on the citation row), so these become inert strings, not errors.
+WITH mixed_docs AS (
+  SELECT "docId" FROM "KbChunk" GROUP BY "docId"
+  HAVING bool_or(id LIKE '%::chunk::%') AND bool_or(id NOT LIKE '%::chunk::%')
+)
+SELECT count(*) AS citations_pointing_at_stale_rows
+FROM "MessageCitation" mc
+JOIN "KbChunk" k ON k.id = mc."chunkId"
+JOIN mixed_docs m ON m."docId" = k."docId"
+WHERE k.id NOT LIKE '%::chunk::%';
+
+-- ---------------------------------------------------------------------------
+-- 4. THE DELETE — *** NOT RUN. NOT TO BE RUN BY AN AGENT. ***
+--    Human-only, after sections 1-3 match expectations, in one transaction,
+--    with the row count checked before COMMIT. Wrapped in a comment so this
+--    file can never be piped into psql by accident.
+-- ---------------------------------------------------------------------------
+/*
+BEGIN;
+
+WITH mixed_docs AS (
+  SELECT "docId"
+  FROM "KbChunk"
+  GROUP BY "docId"
+  HAVING bool_or(id LIKE '%::chunk::%') AND bool_or(id NOT LIKE '%::chunk::%')
+)
+DELETE FROM "KbChunk" k
+USING mixed_docs m
+WHERE m."docId" = k."docId"
+  AND k.id NOT LIKE '%::chunk::%';
+-- psql prints "DELETE <n>". n MUST equal section 2's count (25065 on 2026-09-06).
+-- If it does not: ROLLBACK;
+
+-- Post-check inside the same transaction: both must be 0.
+SELECT
+  (count(*) FILTER (WHERE id NOT LIKE '%::chunk::%'))::int  AS non_deterministic_id_rows,
+  (count(*) - count(DISTINCT ("docId", "chunkIndex")))::int AS duplicate_position_rows
+FROM "KbChunk";
+
+COMMIT;   -- or ROLLBACK;
+
+-- Afterwards (autovacuum will get there, but the HNSW index is 182 MB on a
+-- 0.6 GB instance, so reclaiming it promptly matters for cache hit rate):
+VACUUM (VERBOSE, ANALYZE) "KbChunk";
+*/
+
+-- ---------------------------------------------------------------------------
+-- 5. What is deliberately NOT cleaned here
+--    243 rows: identical content at different chunkIndex within one run —
+--    NCI PDQ boilerplate ("### Current Clinical Trials ...", reference lists).
+--    They are what the source document says; removing them is a content /
+--    chunker decision (filter boilerplate at ingest), not a DB repair.
+--    List them with:
+-- ---------------------------------------------------------------------------
+-- WITH g AS (
+--   SELECT "docId", md5(content) h
+--   FROM "KbChunk"
+--   WHERE id LIKE '%::chunk::%'
+--   GROUP BY 1, 2 HAVING count(*) > 1)
+-- SELECT k."docId", count(*) copies, array_agg(k."chunkIndex" ORDER BY k."chunkIndex") idxs,
+--        left(k.content, 80) snippet
+-- FROM "KbChunk" k JOIN g ON g."docId" = k."docId" AND g.h = md5(k.content)
+-- GROUP BY k."docId", k.content ORDER BY copies DESC;


### PR DESCRIPTION
Evidence and plan for issue #86; the findings comment on that issue has the numbers. This PR is the two things that are safe to merge before anyone touches the production index:

## 1. Permanent guard — `kbIndexIntegrity` in `OpsMetricsService`

One aggregate over `KbChunk`, alongside the #61/#62/#64 collectors that #85 landed:

```sql
SELECT count(*)::int                                              AS total_rows,
       (count(*) FILTER (WHERE id NOT LIKE '%::chunk::%'))::int   AS non_deterministic_id_rows,
       (count(*) - count(DISTINCT ("docId", "chunkIndex")))::int  AS duplicate_position_rows
FROM "KbChunk"
```

`ingest-kb.ts` upserts on the deterministic id `docId::chunk::N`, so a healthy index has exactly one row per `(docId, chunkIndex)` and no row with any other id shape. Both signals must be 0. Production today: **73802 / 25065 / 25065** — the second run in Jan 2026 used deterministic ids, the first used uuids, so `ON CONFLICT ("id")` never matched and a full second copy was written for 511 docs.

Surfaces in `GET /v1/admin/ops-metrics` (`kbIndexIntegrity.value`, `.healthy`, `.basis`) and in `npm run ops:metrics` as `kb_duplicate_rows`, with a `WARN` log line when unhealthy. Deliberately does not hash `content`: that is the offline audit, not an always-on signal. Timed at ~2 min on the `db-f1-micro` while other heavy queries were running; the endpoint is admin-only and hand-invoked.

## 2. `scripts/sql/kb_duplicate_cleanup.sql` — read-only audit + the plan

- the cheap signal above
- a **dry-run count** of exactly the rows a cleanup would remove (expected 25065)
- the **twin invariant** that must hold first: every stale row has a deterministic-id twin with the same `docId`, same `chunkIndex`, byte-identical `content` (verified offline 25065/25065)
- the `DELETE`, **inside a comment block, not run, human-only**, with the row-count check before `COMMIT`
- the 243 genuine in-document repeats (NCI PDQ boilerplate) that are deliberately *not* touched

Survivor rule matters: keep the deterministic-id row. The rule first proposed in #86 (lowest `chunkIndex`, earliest `createdAt`) would keep the **uuid** row on 24,876 of 24,895 groups, and the next `npm run kb:ingest` would recreate every duplicate.

## Not in this PR (on purpose)

- No DB write, no migration, no deploy.
- The strongest permanent guard — `@@unique([docId, chunkIndex])` on `KbChunk` — must wait until after the cleanup, because the migration would fail against today's data and break the gated pipeline.

## Verified

- `npx tsc --noEmit -p tsconfig.json` clean; script typechecks standalone
- 46 suites / 896 tests passing (3 new in `ops-metrics.service.spec.ts`)
- Run from an agent worktree with `--testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='<rootDir>/dist/'` (see the jest gotcha in #85)

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)