### PR TITLE
fix(rag): restore KbChunk.content_tsv and make a dead FTS arm loud (#92)

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -40,6 +40,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.5.8",
         "@nestjs/cli": "^10.4.0",
         "@nestjs/testing": "^10.4.22",
         "@types/geoip-lite": "^1.4.4",
@@ -874,6 +875,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.8.tgz",
+      "integrity": "sha512-n9tsbUOhwx2epK1V0ZG9Ar4SHWUju04dhmzZXiSBXwBoleOvIfals33NAaWgagQVAL4Rbvx/Ptsu3P+pA09f6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -5987,6 +5995,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -53,6 +53,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.8",
     "@nestjs/cli": "^10.4.0",
     "@nestjs/testing": "^10.4.22",
     "@types/geoip-lite": "^1.4.4",

--- a/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
+++ b/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
@@ -1,0 +1,60 @@
+-- Restore full-text search on KbChunk (issue #92).
+--
+-- HISTORY
+--   20260120163141_add_fts_to_kbchunk  added `content_tsv` as a STORED generated
+--                                      column over to_tsvector('english', content)
+--                                      plus the GIN index kb_chunk_content_tsv_idx.
+--   20260218000000_fts_simple_config   rebuilt the same column with the 'simple'
+--                                      text-search config so Hindi/Hinglish content
+--                                      tokenises too (no language-specific stemming).
+--   20260606000000_phase2_...          DROPPED the index and the column. That drop was
+--                                      collateral from a schema-diff: `content_tsv` is a
+--                                      generated column Prisma cannot represent, so the
+--                                      diff emitted a DROP for it. The lexical arm of
+--                                      hybrid retrieval (RagService.fullTextSearchWithMetadata)
+--                                      kept querying c.content_tsv and has been failing
+--                                      silently — inside a catch that returned [] — ever
+--                                      since, costing long queries 45% and short queries
+--                                      20% of their retrieval scoring weight.
+--
+-- This migration restores the 2026-02-18 definition exactly: a STORED generated column
+-- over to_tsvector('simple', content), matching websearch_to_tsquery('simple', ...) in
+-- src/modules/rag/kb-fts.sql.ts, plus the GIN index the query plan needs.
+--
+-- Safe to re-run. The DO block rebuilds the column when it exists in any shape other
+-- than "STORED generated, 'simple' config" — which covers three real states:
+--   * the 2026-01-20 'english' generated column (a DB that never got 20260218), and
+--   * a plain, never-populated `content_tsv tsvector` column, which is what
+--     `prisma migrate diff` emits from schema.prisma (Prisma cannot express GENERATED),
+--     i.e. what a freshly `db push`-ed database would have.
+-- Rebuilding is cheap: the column is derived from `content`, so nothing is lost.
+
+DO $$
+DECLARE
+  needs_rebuild boolean;
+BEGIN
+  SELECT NOT (
+      a.attgenerated = 's'
+      AND pg_get_expr(d.adbin, d.adrelid) LIKE '%''simple''%'
+    )
+    INTO needs_rebuild
+  FROM pg_attribute a
+  LEFT JOIN pg_attrdef d
+    ON d.adrelid = a.attrelid
+   AND d.adnum = a.attnum
+  WHERE a.attrelid = to_regclass('"KbChunk"')
+    AND a.attname = 'content_tsv'
+    AND NOT a.attisdropped;
+
+  IF needs_rebuild THEN
+    RAISE NOTICE 'KbChunk.content_tsv exists but is not a STORED generated tsvector over the ''simple'' config — rebuilding it.';
+    DROP INDEX IF EXISTS kb_chunk_content_tsv_idx;
+    ALTER TABLE "KbChunk" DROP COLUMN content_tsv;
+  END IF;
+END$$;
+
+ALTER TABLE "KbChunk"
+  ADD COLUMN IF NOT EXISTS content_tsv tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED;
+
+CREATE INDEX IF NOT EXISTS kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (content_tsv);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -164,12 +164,32 @@ model KbChunk {
   chunkIndex Int
   content    String
   embedding  Unsupported("vector(768)")? // pgvector for semantic search
+
+  /// Full-text search vector for the lexical arm of hybrid retrieval.
+  ///
+  /// DO NOT REMOVE. In the database this is a STORED GENERATED column
+  /// (`GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED`), created by raw
+  /// migration SQL — Prisma cannot express generated columns, so it is declared here
+  /// as Unsupported() purely so a schema diff sees it and does not emit a DROP.
+  ///
+  /// It was invisible to Prisma before, and migration 20260606000000 duly dropped it;
+  /// `RagService.fullTextSearchWithMetadata` then failed silently for three months
+  /// (issue #92). Migration 20260908000000_restore_kb_chunk_fts restored it and also
+  /// repairs the shape a Prisma-generated schema would produce, because
+  /// `prisma migrate diff` renders this field as a plain, never-populated
+  /// `content_tsv tsvector`. `KbFtsHealthService` verifies at boot that the live
+  /// column really is generated on the 'simple' config.
+  content_tsv Unsupported("tsvector")?
+
   createdAt  DateTime @default(now())
 
   document KbDocument @relation(fields: [docId], references: [id])
 
   @@index([docId])
   @@index([content])
+  /// GIN index over content_tsv. Named to match the raw-SQL index so a diff does not
+  /// try to recreate or drop it.
+  @@index([content_tsv], map: "kb_chunk_content_tsv_idx", type: Gin)
 }
 
 model VoiceInteraction {

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, HttpException, HttpStatus } from "@nestjs/common";
 import { HealthService } from "./health.service";
 
 @Controller("health")
@@ -8,6 +8,24 @@ export class HealthController {
   @Get()
   async check() {
     return this.healthService.check();
+  }
+
+  /**
+   * Retrieval readiness (issue #92).
+   *
+   * Returns 503 while the lexical (FTS) arm of hybrid retrieval is unavailable,
+   * so a dropped `KbChunk.content_tsv` column shows up as a failing probe instead
+   * of an error line nobody reads. Kept separate from GET /v1/health on purpose —
+   * the deploy health gate must stay green on a degradation that is survivable
+   * (vector-only retrieval still answers, just with worse ranking).
+   */
+  @Get("retrieval")
+  async checkRetrieval() {
+    const result = await this.healthService.checkRetrieval();
+    if (result.fullTextSearch.status === "unavailable") {
+      throw new HttpException(result, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+    return result;
   }
 }
 

--- a/apps/api/src/modules/health/health.module.ts
+++ b/apps/api/src/modules/health/health.module.ts
@@ -1,8 +1,12 @@
 import { Module } from "@nestjs/common";
 import { HealthController } from "./health.controller";
 import { HealthService } from "./health.service";
+import { RagModule } from "../rag/rag.module";
 
 @Module({
+  // RagModule is imported for KbFtsHealthService: retrieval readiness (issue #92)
+  // is reported by the module that owns the query, not re-derived here.
+  imports: [RagModule],
   controllers: [HealthController],
   providers: [HealthService]
 })

--- a/apps/api/src/modules/health/health.service.ts
+++ b/apps/api/src/modules/health/health.service.ts
@@ -1,11 +1,15 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
+import { KbFtsHealthService, KbFtsHealth } from "../rag/kb-fts-health.service";
 
 @Injectable()
 export class HealthService {
   private readonly logger = new Logger(HealthService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly kbFts: KbFtsHealthService
+  ) {}
 
   async check() {
     try {
@@ -14,7 +18,15 @@ export class HealthService {
       return {
         status: "ok",
         timestamp: new Date().toISOString(),
-        database: "connected"
+        database: "connected",
+        // Retrieval sub-status is reported here but deliberately does NOT change the
+        // top-level `status`: the Cloud Build health gate (cloudbuild.gated.yaml,
+        // `curl -fsS $candidate_url/v1/health`) only checks for a 2xx, and a degraded
+        // lexical arm must not block a deploy that might be the fix. Alerting reads
+        // `retrieval.fullTextSearch.status` / GET /v1/health/retrieval instead.
+        retrieval: {
+          fullTextSearch: this.kbFts.getHealth()
+        }
       };
     } catch (error) {
       this.logger.error(`Health check failed: ${error.message}`);
@@ -24,6 +36,20 @@ export class HealthService {
         database: "disconnected"
       };
     }
+  }
+
+  /**
+   * Retrieval readiness (issue #92). Re-probes the FTS schema so the answer is
+   * live rather than a cached boot verdict, and reports whether the lexical arm
+   * of hybrid retrieval is actually contributing.
+   */
+  async checkRetrieval(): Promise<{ status: string; timestamp: string; fullTextSearch: KbFtsHealth }> {
+    const fullTextSearch = await this.kbFts.probe();
+    return {
+      status: fullTextSearch.status === "ok" ? "ok" : fullTextSearch.status,
+      timestamp: new Date().toISOString(),
+      fullTextSearch
+    };
   }
 }
 

--- a/apps/api/src/modules/rag/__test-utils__/pglite-client.ts
+++ b/apps/api/src/modules/rag/__test-utils__/pglite-client.ts
@@ -1,0 +1,129 @@
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import * as path from "path";
+import * as readline from "readline";
+
+/**
+ * Client for the out-of-process Postgres used by kb-fts.spec.ts.
+ * See pglite-server.js for why the engine cannot run inside Jest's VM.
+ */
+export class PgliteSqlError extends Error {
+  /** Postgres SQLSTATE, e.g. 42703 (undefined_column). */
+  readonly code: string | null;
+
+  constructor(message: string, code: string | null) {
+    super(message);
+    this.name = "PgliteSqlError";
+    this.code = code;
+  }
+}
+
+interface Pending {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+}
+
+export class PgliteProcess {
+  private readonly pending = new Map<number, Pending>();
+  private nextId = 1;
+  private child: ChildProcessWithoutNullStreams;
+
+  private constructor(child: ChildProcessWithoutNullStreams) {
+    this.child = child;
+    readline.createInterface({ input: child.stdout }).on("line", (line) => {
+      if (!line.trim()) return;
+      const response = JSON.parse(line);
+      const pending = this.pending.get(response.id);
+      if (!pending) return;
+      this.pending.delete(response.id);
+      if (response.error) {
+        pending.reject(new PgliteSqlError(response.error.message, response.error.code ?? null));
+      } else {
+        pending.resolve(response);
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      const text = String(chunk).trim();
+      if (text) process.stderr.write(`[pglite] ${text}\n`);
+    });
+  }
+
+  static start(): PgliteProcess {
+    const child = spawn(process.execPath, [path.join(__dirname, "pglite-server.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+    return new PgliteProcess(child);
+  }
+
+  private request(payload: Record<string, unknown>): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(JSON.stringify({ id, ...payload }) + "\n");
+    });
+  }
+
+  async createDatabase(): Promise<PgliteDatabase> {
+    const { handle } = await this.request({ op: "create" });
+    return new PgliteDatabase(this, handle);
+  }
+
+  /** @internal */
+  exec(handle: number, sql: string): Promise<void> {
+    return this.request({ op: "exec", handle, sql });
+  }
+
+  /** @internal */
+  async query<T>(handle: number, sql: string, params: unknown[] = []): Promise<T[]> {
+    const { rows } = await this.request({ op: "query", handle, sql, params });
+    return rows as T[];
+  }
+
+  /** @internal */
+  close(handle: number): Promise<void> {
+    return this.request({ op: "close", handle });
+  }
+
+  async stop(): Promise<void> {
+    try {
+      await this.request({ op: "shutdown" });
+    } catch {
+      /* the child exits as it answers; a lost reply is fine */
+    }
+    this.child.kill();
+  }
+}
+
+export class PgliteDatabase {
+  constructor(private readonly proc: PgliteProcess, private readonly handle: number) {}
+
+  exec(sql: string): Promise<void> {
+    return this.proc.exec(this.handle, sql);
+  }
+
+  query<T = Record<string, any>>(sql: string, params: unknown[] = []): Promise<T[]> {
+    return this.proc.query<T>(this.handle, sql, params);
+  }
+
+  close(): Promise<void> {
+    return this.proc.close(this.handle);
+  }
+
+  /**
+   * A PrismaService stand-in that sends the service's real SQL to this real
+   * database. Only `$queryRawUnsafe` is implemented — that is the single entry
+   * point the lexical arm and the FTS probe use.
+   *
+   * Fidelity note: rows arrive as JSON, so `timestamp` columns come back as ISO
+   * strings rather than the `Date` objects Prisma would hydrate. No assertion in
+   * kb-fts.spec.ts depends on that, and the lexical arm passes those fields
+   * straight through.
+   */
+  asPrisma(): any {
+    return {
+      $queryRawUnsafe: (sql: string, ...params: unknown[]) => this.query(sql, params),
+      $queryRaw: () => {
+        throw new Error("unexpected tagged-template query — the FTS path must use $queryRawUnsafe");
+      },
+    };
+  }
+}

--- a/apps/api/src/modules/rag/__test-utils__/pglite-server.js
+++ b/apps/api/src/modules/rag/__test-utils__/pglite-server.js
@@ -1,0 +1,94 @@
+/* eslint-disable */
+/**
+ * Out-of-process Postgres for tests (see kb-fts.spec.ts).
+ *
+ * PGlite is a real Postgres compiled to WebAssembly, but its emscripten glue uses
+ * `import()`, which Jest's CJS VM cannot service without `--experimental-vm-modules`.
+ * Rather than change how the whole suite is invoked (`npx jest` / `npm run test:ci`),
+ * the engine runs in a plain Node child process and speaks newline-delimited JSON
+ * over stdio: one request per line, one response per line, matched by `id`.
+ *
+ * Protocol (request -> response):
+ *   {id, op:"create"}                  -> {id, handle}
+ *   {id, op:"exec",  handle, sql}      -> {id, ok:true}
+ *   {id, op:"query", handle, sql, params} -> {id, rows}
+ *   {id, op:"close", handle}           -> {id, ok:true}
+ *   any failure                        -> {id, error:{message, code}}   (code = SQLSTATE)
+ *
+ * Requests are executed strictly in arrival order so DDL replay stays deterministic.
+ */
+const readline = require("readline");
+const { PGlite } = require("@electric-sql/pglite");
+
+const databases = new Map();
+let nextHandle = 1;
+let chain = Promise.resolve();
+
+function send(payload) {
+  process.stdout.write(JSON.stringify(payload) + "\n");
+}
+
+function dbFor(handle) {
+  const db = databases.get(handle);
+  if (!db) throw new Error(`unknown database handle: ${handle}`);
+  return db;
+}
+
+async function handle(request) {
+  switch (request.op) {
+    case "create": {
+      const db = await PGlite.create();
+      const id = nextHandle++;
+      databases.set(id, db);
+      return { handle: id };
+    }
+    case "exec":
+      await dbFor(request.handle).exec(request.sql);
+      return { ok: true };
+    case "query": {
+      const result = await dbFor(request.handle).query(request.sql, request.params || []);
+      return { rows: result.rows };
+    }
+    case "close": {
+      const db = databases.get(request.handle);
+      if (db) {
+        databases.delete(request.handle);
+        await db.close();
+      }
+      return { ok: true };
+    }
+    case "shutdown":
+      for (const db of databases.values()) {
+        try {
+          await db.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      send({ id: request.id, ok: true });
+      process.exit(0);
+      return { ok: true };
+    default:
+      throw new Error(`unknown op: ${request.op}`);
+  }
+}
+
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  if (!line.trim()) return;
+  const request = JSON.parse(line);
+  chain = chain.then(async () => {
+    try {
+      const result = await handle(request);
+      send({ id: request.id, ...result });
+    } catch (error) {
+      send({
+        id: request.id,
+        error: {
+          message: String((error && error.message) || error),
+          // SQLSTATE, when Postgres gave us one — the test asserts on it.
+          code: (error && error.code) || null,
+        },
+      });
+    }
+  });
+});

--- a/apps/api/src/modules/rag/kb-fts-health.service.ts
+++ b/apps/api/src/modules/rag/kb-fts-health.service.ts
@@ -54,6 +54,11 @@ const LOG_THROTTLE_MS = 60_000;
 export class KbFtsHealthService implements OnModuleInit {
   private readonly logger = new Logger(KbFtsHealthService.name);
 
+  /** Minimum gap between re-probes triggered by query success. */
+  private static readonly REPROBE_THROTTLE_MS = 30_000;
+
+  private reprobeInFlight = false;
+  private lastReprobeAt = 0;
   private status: KbFtsStatus = "unknown";
   private detail = "not probed yet";
   private checkedAt: string | null = null;
@@ -192,15 +197,52 @@ export class KbFtsHealthService implements OnModuleInit {
     }
   }
 
-  /** A lexical query completed. Clears a stale `unavailable` verdict. */
+  /**
+   * A lexical query completed without throwing.
+   *
+   * Execution success is NOT evidence that the schema is repaired. A plain,
+   * non-generated `content_tsv` column — what `prisma migrate diff` emits, and
+   * precisely what the restore migration exists to repair — satisfies this
+   * query, returns zero rows, and throws nothing. Clearing an `unavailable`
+   * verdict on that basis would report a dead lexical arm as healthy, which is
+   * the exact masking this service exists to prevent.
+   *
+   * So a success never sets `ok` directly. It only schedules a re-probe, which
+   * checks `attgenerated` and the generation expression and is the sole
+   * authority on the verdict. Throttled and never awaited, so the retrieval
+   * path is not slowed.
+   */
   recordQuerySuccess(): void {
-    if (this.status === "unavailable" || this.status === "unknown") {
-      this.set("ok", "lexical query executed successfully");
-      this.logger.log({
-        event: "kb_fts_recovered",
-        message: "Lexical retrieval arm is answering again",
-      });
+    // Hot path: nothing to reconsider unless we are currently carrying a
+    // negative or unproven verdict.
+    if (this.status !== "unavailable" && this.status !== "unknown") return;
+
+    const now = Date.now();
+    if (
+      this.reprobeInFlight ||
+      now - this.lastReprobeAt < KbFtsHealthService.REPROBE_THROTTLE_MS
+    ) {
+      return;
     }
+
+    this.reprobeInFlight = true;
+    this.lastReprobeAt = now;
+
+    void this.probe()
+      .then((health) => {
+        if (health.status === "ok") {
+          this.logger.log({
+            event: "kb_fts_recovered",
+            message: "Lexical retrieval arm is answering again — schema re-probe confirms it",
+          });
+        }
+      })
+      .catch(() => {
+        // probe() sets and logs its own verdict on failure; nothing to add.
+      })
+      .finally(() => {
+        this.reprobeInFlight = false;
+      });
   }
 
   getHealth(): KbFtsHealth {

--- a/apps/api/src/modules/rag/kb-fts-health.service.ts
+++ b/apps/api/src/modules/rag/kb-fts-health.service.ts
@@ -1,0 +1,252 @@
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { PrismaService } from "../prisma/prisma.service";
+import {
+  KB_FTS_COLUMN,
+  KB_FTS_CONFIG,
+  KB_FTS_INDEX,
+  KB_FTS_OWNERSHIP_NOTE,
+  KB_FTS_PROBE_SQL,
+  KB_FTS_TABLE,
+  KbFtsProbeRow,
+} from "./kb-fts.sql";
+
+/**
+ * Health of the lexical (FTS) arm of hybrid retrieval.
+ *
+ * - `ok`            — column exists, is a STORED generated tsvector on the expected config, index present.
+ * - `degraded`      — queryable but not in the expected shape (e.g. GIN index missing → slow but correct).
+ * - `unavailable`   — the column/table the query needs is missing, or present but not generated
+ *                     (always NULL). The lexical arm contributes nothing.
+ * - `unknown`       — the probe could not run (DB unreachable at boot). Not a verdict.
+ */
+export type KbFtsStatus = "ok" | "degraded" | "unavailable" | "unknown";
+
+export interface KbFtsHealth {
+  status: KbFtsStatus;
+  detail: string;
+  checkedAt: string | null;
+  /** Queries that failed because the schema does not match the query. Should stay 0. */
+  schemaFailureCount: number;
+  /** Queries that failed for other reasons (timeouts, pool exhaustion, …). */
+  queryFailureCount: number;
+  lastError: string | null;
+}
+
+const LOG_THROTTLE_MS = 60_000;
+
+/**
+ * Keeps the state of the FTS arm observable.
+ *
+ * Issue #92: `content_tsv` was dropped by a migration in June 2026 and the FTS
+ * query kept failing inside a `catch { logger.error(...); return []; }`. One
+ * error line per chat turn, buried in a wall of retrieval logs, with the caller
+ * unable to tell "no lexical matches" from "the lexical arm is dead" — so nobody
+ * noticed for three months. This service exists so that the distinction is
+ * explicit, checked once at boot, counted per query, and reported on /v1/health.
+ *
+ * Deliberate non-goal: this does NOT abort boot when the column is missing.
+ * Vector-only retrieval still answers correctly (just with degraded ranking), so
+ * refusing to start would turn a ranking regression into a full chat outage for
+ * patients. The escalation path is the boot-time ERROR log plus
+ * `GET /v1/health/retrieval`, which returns 503 while the arm is dead.
+ */
+@Injectable()
+export class KbFtsHealthService implements OnModuleInit {
+  private readonly logger = new Logger(KbFtsHealthService.name);
+
+  private status: KbFtsStatus = "unknown";
+  private detail = "not probed yet";
+  private checkedAt: string | null = null;
+  private schemaFailureCount = 0;
+  private queryFailureCount = 0;
+  private lastError: string | null = null;
+  private lastSchemaLogAt = 0;
+  private lastQueryLogAt = 0;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit(): Promise<void> {
+    // Never let the probe block or break startup — it is diagnostics, not a gate.
+    await this.probe();
+  }
+
+  /**
+   * Checks the FTS objects against the database and logs the verdict loudly
+   * enough to be noticed. Safe to call at any time (e.g. from a health check).
+   */
+  async probe(): Promise<KbFtsHealth> {
+    try {
+      const rows = await this.prisma.$queryRawUnsafe<KbFtsProbeRow[]>(KB_FTS_PROBE_SQL);
+      const row = rows?.[0];
+
+      if (!row || !row.tablePresent) {
+        this.set(
+          "unavailable",
+          `table "${KB_FTS_TABLE}" not found — the knowledge base schema is not migrated`
+        );
+        this.logUnavailable();
+        return this.getHealth();
+      }
+
+      if (!row.columnPresent) {
+        this.set(
+          "unavailable",
+          `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" is missing — run migration 20260908000000_restore_kb_chunk_fts`
+        );
+        this.logUnavailable();
+        return this.getHealth();
+      }
+
+      if (!row.columnGenerated) {
+        this.set(
+          "unavailable",
+          `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" exists but is not a STORED GENERATED column, so it is ` +
+            `always NULL and every lexical query returns zero rows. This is what a schema built by ` +
+            `\`prisma migrate diff\`/\`db push\` produces. Run migration 20260908000000_restore_kb_chunk_fts.`
+        );
+        this.logUnavailable();
+        return this.getHealth();
+      }
+
+      const expr = row.generationExpr ?? "";
+      if (!expr.includes(`'${KB_FTS_CONFIG}'`)) {
+        this.set(
+          "degraded",
+          `"${KB_FTS_COLUMN}" is generated as ${expr || "<unknown>"} but queries use ` +
+            `websearch_to_tsquery('${KB_FTS_CONFIG}', …). Mismatched text-search configs match far ` +
+            `fewer rows (and no Hindi/Hinglish at all).`
+        );
+        this.logger.error({
+          event: "kb_fts_config_mismatch",
+          message: this.detail,
+          expectedConfig: KB_FTS_CONFIG,
+          generationExpr: expr,
+        });
+        return this.getHealth();
+      }
+
+      if (!row.indexPresent) {
+        this.set(
+          "degraded",
+          `GIN index ${KB_FTS_INDEX} is missing — lexical search still returns correct rows but ` +
+            `sequentially scans every chunk.`
+        );
+        this.logger.warn({ event: "kb_fts_index_missing", message: this.detail, index: KB_FTS_INDEX });
+        return this.getHealth();
+      }
+
+      this.set("ok", `${KB_FTS_COLUMN} generated on '${KB_FTS_CONFIG}', ${KB_FTS_INDEX} present`);
+      this.logger.log({
+        event: "kb_fts_health_ok",
+        message: `Lexical retrieval arm ready: ${this.detail}`,
+      });
+      return this.getHealth();
+    } catch (error: any) {
+      // Could not reach the DB — say so, but do not claim FTS is broken.
+      this.status = "unknown";
+      this.detail = `probe failed: ${error?.message ?? error}`;
+      this.checkedAt = new Date().toISOString();
+      this.lastError = String(error?.message ?? error);
+      this.logger.warn({
+        event: "kb_fts_probe_failed",
+        message: `Could not verify the lexical retrieval arm: ${this.detail}`,
+      });
+      return this.getHealth();
+    }
+  }
+
+  /**
+   * A lexical query failed because the schema does not match it. This is the
+   * condition that hid for three months — it is logged at error level with a
+   * dedicated event and surfaced on the health endpoint, not swallowed.
+   */
+  recordSchemaFailure(error: unknown): void {
+    this.schemaFailureCount += 1;
+    this.lastError = this.describe(error);
+    this.set(
+      "unavailable",
+      `lexical query rejected by Postgres: ${this.lastError}. ` +
+        `Run migration 20260908000000_restore_kb_chunk_fts.`
+    );
+
+    const now = Date.now();
+    if (this.schemaFailureCount === 1 || now - this.lastSchemaLogAt > LOG_THROTTLE_MS) {
+      this.lastSchemaLogAt = now;
+      this.logUnavailable();
+    }
+  }
+
+  /** A lexical query failed for a transient reason. Warn, count, keep serving. */
+  recordQueryFailure(error: unknown): void {
+    this.queryFailureCount += 1;
+    this.lastError = this.describe(error);
+
+    const now = Date.now();
+    if (this.queryFailureCount === 1 || now - this.lastQueryLogAt > LOG_THROTTLE_MS) {
+      this.lastQueryLogAt = now;
+      this.logger.warn({
+        event: "kb_fts_query_failed",
+        message: `Lexical retrieval query failed (transient): ${this.lastError}`,
+        queryFailureCount: this.queryFailureCount,
+      });
+    }
+  }
+
+  /** A lexical query completed. Clears a stale `unavailable` verdict. */
+  recordQuerySuccess(): void {
+    if (this.status === "unavailable" || this.status === "unknown") {
+      this.set("ok", "lexical query executed successfully");
+      this.logger.log({
+        event: "kb_fts_recovered",
+        message: "Lexical retrieval arm is answering again",
+      });
+    }
+  }
+
+  getHealth(): KbFtsHealth {
+    return {
+      status: this.status,
+      detail: this.detail,
+      checkedAt: this.checkedAt,
+      schemaFailureCount: this.schemaFailureCount,
+      queryFailureCount: this.queryFailureCount,
+      lastError: this.lastError,
+    };
+  }
+
+  /** True when the lexical arm is known to be contributing nothing. */
+  isUnavailable(): boolean {
+    return this.status === "unavailable";
+  }
+
+  private set(status: KbFtsStatus, detail: string): void {
+    this.status = status;
+    this.detail = detail;
+    this.checkedAt = new Date().toISOString();
+  }
+
+  private logUnavailable(): void {
+    this.logger.error({
+      event: "kb_fts_unavailable",
+      message:
+        `LEXICAL RETRIEVAL IS DEAD — hybrid search is running vector-only, which silently ` +
+        `discards 45% of the scoring weight on long queries and 20% on short ones. ${this.detail}`,
+      table: KB_FTS_TABLE,
+      column: KB_FTS_COLUMN,
+      index: KB_FTS_INDEX,
+      expectedConfig: KB_FTS_CONFIG,
+      schemaFailureCount: this.schemaFailureCount,
+      remediation: KB_FTS_OWNERSHIP_NOTE,
+    });
+  }
+
+  private describe(error: unknown): string {
+    if (error && typeof error === "object") {
+      const err = error as { message?: unknown; code?: unknown; meta?: { code?: unknown } };
+      const code = (typeof err.code === "string" && err.code) || (typeof err.meta?.code === "string" && err.meta.code) || null;
+      const message = typeof err.message === "string" ? err.message.split("\n")[0] : String(error);
+      return code ? `[${code}] ${message}` : message;
+    }
+    return String(error);
+  }
+}

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -99,12 +99,16 @@ function baselineDdlFromSchema(): string {
 
 async function buildDatabase(
   proc: PgliteProcess,
-  options: { simulateFreshDbPush?: boolean } = {}
+  options: { simulateFreshDbPush?: boolean; leaveUnrepaired?: boolean } = {}
 ): Promise<PgliteDatabase> {
   const db = await proc.createDatabase();
   await db.exec(baselineDdlFromSchema());
 
-  if (options.simulateFreshDbPush) {
+  if (options.leaveUnrepaired) {
+    // A `db push` database with the restore migration NOT yet applied: Prisma's
+    // plain `content_tsv tsvector` placeholder, always NULL, never generated.
+    // The lexical query runs clean against it and returns nothing.
+  } else if (options.simulateFreshDbPush) {
     // A `db push`/`migrate diff` database is baselined at the datamodel, so it keeps
     // Prisma's plain `content_tsv tsvector` placeholder and only *new* migrations run.
     const restore = ftsMigrationsInOrder().find((m) => m.name === RESTORE_MIGRATION);
@@ -339,6 +343,92 @@ describe("KB full-text search (issue #92)", () => {
 
       const events = errorSpy.mock.calls.map((call) => call[0]?.event);
       expect(events).toContain("kb_fts_unavailable");
+    });
+  });
+
+  describe("when content_tsv is present but not generated (always NULL)", () => {
+    // The masking case: the column exists, so the query executes and throws
+    // nothing — it just returns zero rows forever. Query success must never be
+    // read as proof that the schema is healthy.
+    let unrepaired: PgliteDatabase;
+
+    beforeAll(async () => {
+      unrepaired = await buildDatabase(proc, { leaveUnrepaired: true });
+    });
+
+    afterAll(async () => {
+      await unrepaired?.close();
+    });
+
+    it("executes the shipped query without error and returns nothing", async () => {
+      const probe = (await unrepaired.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
+      expect(probe.columnPresent).toBe(true);
+      expect(probe.columnGenerated).toBe(false);
+
+      const rows = await unrepaired.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
+      expect(rows).toHaveLength(0);
+    });
+
+    it("probes as 'unavailable' even though the column exists", async () => {
+      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+      try {
+        const health = new KbFtsHealthService(unrepaired.asPrisma());
+        const result = await health.probe();
+
+        expect(result.status).toBe("unavailable");
+        expect(health.isUnavailable()).toBe(true);
+      } finally {
+        jest.restoreAllMocks();
+      }
+    });
+
+    it("does NOT clear the unavailable verdict when a query merely succeeds", async () => {
+      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+      try {
+        const health = new KbFtsHealthService(unrepaired.asPrisma());
+        await health.probe();
+        expect(health.isUnavailable()).toBe(true);
+
+        // A real retrieval call through RagService: the query succeeds, so the
+        // service records a success. Before the re-probe fix this flipped the
+        // sub-status straight to "ok" and reported a dead arm as healthy.
+        const rag = ragServiceOn(unrepaired, health);
+        const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+        expect(chunks).toHaveLength(0);
+
+        // Give the throttled, fire-and-forget re-probe time to land.
+        await new Promise((resolve) => setTimeout(resolve, 400));
+
+        expect(health.getHealth().status).toBe("unavailable");
+        expect(health.isUnavailable()).toBe(true);
+      } finally {
+        jest.restoreAllMocks();
+      }
+    });
+
+    it("does clear the verdict once the schema is actually repaired", async () => {
+      // The recovery path must still work — the fix defers to the probe, it
+      // does not pin the verdict permanently.
+      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+      try {
+        const health = new KbFtsHealthService(db.asPrisma());
+        (health as any).set("unavailable", "forced stale verdict for test");
+        expect(health.isUnavailable()).toBe(true);
+
+        const rag = ragServiceOn(db, health);
+        await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+
+        const deadline = Date.now() + 3000;
+        while (health.getHealth().status !== "ok" && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+
+        expect(health.getHealth().status).toBe("ok");
+      } finally {
+        jest.restoreAllMocks();
+      }
     });
   });
 

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -1,0 +1,354 @@
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { Logger } from "@nestjs/common";
+import { RagService } from "./rag.service";
+import { KbFtsHealthService } from "./kb-fts-health.service";
+import { PgliteDatabase, PgliteProcess } from "./__test-utils__/pglite-client";
+import {
+  KB_FTS_COLUMN,
+  KB_FTS_CONFIG,
+  KB_FTS_INDEX,
+  KB_FTS_PROBE_SQL,
+  KB_FTS_SEARCH_SQL,
+  KbFtsProbeRow,
+  isFtsSchemaError,
+} from "./kb-fts.sql";
+
+/**
+ * Regression test for issue #92 — "full-text search is dead in production".
+ *
+ * WHY IT IS SHAPED LIKE THIS
+ * Migration 20260606000000 dropped `KbChunk.content_tsv`; the lexical arm of hybrid
+ * retrieval kept querying it and failed inside a catch that returned []. Nothing
+ * noticed because nothing ever executed the SQL — the schema lived in raw migration
+ * files, the query lived in a template literal, and no test put the two in the same
+ * process. Issue #90 is the cautionary counter-example: green tests over hand-written
+ * input while the shipped feature was dead.
+ *
+ * So this suite runs a REAL Postgres (PGlite — Postgres compiled to WASM; no server,
+ * no network, and never the production database), builds the schema from the REAL
+ * artifacts (`prisma/schema.prisma` via `prisma migrate diff`, then every
+ * migration.sql that touches the FTS objects, replayed oldest-first), and executes the
+ * REAL statement the service ships (`KB_FTS_SEARCH_SQL`) — including once through
+ * `RagService.fullTextSearchWithMetadata` itself.
+ *
+ * On the parent commit of the fix, everything below that touches the database fails:
+ * `column c.content_tsv does not exist`.
+ */
+
+const API_ROOT = path.resolve(__dirname, "../../..");
+const SCHEMA_PATH = path.join(API_ROOT, "prisma", "schema.prisma");
+const MIGRATIONS_DIR = path.join(API_ROOT, "prisma", "migrations");
+const RESTORE_MIGRATION = "20260908000000_restore_kb_chunk_fts";
+
+/** KB-shaped rows. Public screening information only — no patient data. */
+const DOC_ID = "doc-cervical-screening";
+const CHUNKS: Array<{ id: string; content: string }> = [
+  {
+    id: "chunk-hpv",
+    content:
+      "Cervical cancer screening in India uses HPV DNA testing and visual inspection with acetic acid (VIA). " +
+      "Screening is recommended for women aged 30 to 65.",
+  },
+  {
+    id: "chunk-followup",
+    content:
+      "After an abnormal screening result, a colposcopy is arranged at the district hospital for follow-up.",
+  },
+  {
+    id: "chunk-hindi",
+    content: "सर्वाइकल कैंसर की जांच के लिए HPV test किया जाता है। यह जांच 30 saal ke baad karani chahiye.",
+  },
+];
+
+/** Every migration that touches the FTS objects, oldest first, as shipped. */
+function ftsMigrationsInOrder(): Array<{ name: string; sql: string }> {
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((entry) => fs.statSync(path.join(MIGRATIONS_DIR, entry)).isDirectory())
+    .sort()
+    .map((name) => ({ name, sql: fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf8") }))
+    .filter((m) => m.sql.includes(KB_FTS_COLUMN) || m.sql.includes(KB_FTS_INDEX));
+}
+
+/**
+ * Baseline DDL for the current datamodel, generated offline by Prisma itself.
+ * `--from-empty` never opens a connection; DATABASE_URL only has to parse.
+ */
+let cachedBaseline: string | null = null;
+function baselineDdlFromSchema(): string {
+  if (cachedBaseline) return cachedBaseline;
+
+  const ddl = execFileSync(
+    "npx",
+    ["prisma", "migrate", "diff", "--from-empty", "--to-schema-datamodel", SCHEMA_PATH, "--script"],
+    {
+      cwd: API_ROOT,
+      encoding: "utf8",
+      env: { ...process.env, DATABASE_URL: "postgresql://unused:unused@127.0.0.1:5432/unused" },
+      maxBuffer: 32 * 1024 * 1024,
+    }
+  );
+
+  // The only substitution: pgvector is not built into PGlite and is irrelevant here.
+  // Nothing in this suite reads or writes `embedding`.
+  cachedBaseline = ddl.replace(/vector\(768\)/g, "text");
+  return cachedBaseline;
+}
+
+async function buildDatabase(
+  proc: PgliteProcess,
+  options: { simulateFreshDbPush?: boolean } = {}
+): Promise<PgliteDatabase> {
+  const db = await proc.createDatabase();
+  await db.exec(baselineDdlFromSchema());
+
+  if (options.simulateFreshDbPush) {
+    // A `db push`/`migrate diff` database is baselined at the datamodel, so it keeps
+    // Prisma's plain `content_tsv tsvector` placeholder and only *new* migrations run.
+    const restore = ftsMigrationsInOrder().find((m) => m.name === RESTORE_MIGRATION);
+    if (!restore) throw new Error(`${RESTORE_MIGRATION} is missing from prisma/migrations`);
+    await db.exec(restore.sql);
+  } else {
+    // Production's base schema predates FTS — `content_tsv` was created by migration
+    // 20260120163141, not by the datamodel. Drop the datamodel's plain placeholder so
+    // the migration history replays from the same starting point production had.
+    await db.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
+    await db.exec(`ALTER TABLE "KbChunk" DROP COLUMN IF EXISTS ${KB_FTS_COLUMN};`);
+
+    for (const migration of ftsMigrationsInOrder()) {
+      await db.exec(migration.sql);
+    }
+  }
+
+  await db.exec(`
+    INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
+    VALUES ('${DOC_ID}', '02_nci_core', 'NCI', 'Cervical cancer screening', '1', 'https://example.org/screening',
+            'active', true, now(), now());
+  `);
+  for (const [index, chunk] of CHUNKS.entries()) {
+    await db.query(
+      `INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt") VALUES ($1, $2, $3, $4, now())`,
+      [chunk.id, DOC_ID, index, chunk.content]
+    );
+  }
+  // A retired document must never surface — the query filters on d.status = 'active'.
+  await db.exec(`
+    INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
+    VALUES ('doc-retired', '02_nci_core', 'NCI', 'Retired screening guidance', '1', NULL, 'archived', true, now(), now());
+    INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
+    VALUES ('chunk-retired', 'doc-retired', 0, 'Cervical cancer screening HPV testing retired guidance', now());
+  `);
+
+  return db;
+}
+
+function ragServiceOn(db: PgliteDatabase, ftsHealth: KbFtsHealthService): RagService {
+  return new RagService(
+    db.asPrisma(),
+    {} as any, // embeddings — the lexical arm does not embed
+    {} as any, // synonyms
+    {} as any, // queryExpander
+    {} as any, // reranker
+    ftsHealth
+  );
+}
+
+describe("KB full-text search (issue #92)", () => {
+  jest.setTimeout(240_000);
+
+  let proc: PgliteProcess;
+  let db: PgliteDatabase;
+
+  beforeAll(async () => {
+    proc = PgliteProcess.start();
+    db = await buildDatabase(proc);
+  });
+
+  afterAll(async () => {
+    await proc?.stop();
+  });
+
+  it("keeps content_tsv in the migration history (the #92 drop is not re-introduced)", () => {
+    const migrations = ftsMigrationsInOrder();
+    const last = migrations[migrations.length - 1];
+
+    // The FTS lifecycle must end with a restore, not a drop. This is the guard that
+    // would have failed CI on 2026-06-06.
+    expect(migrations.map((m) => m.name)).toContain(RESTORE_MIGRATION);
+    expect(last.sql).toMatch(/ADD COLUMN IF NOT EXISTS content_tsv/);
+    expect(last.sql).toContain(`to_tsvector('${KB_FTS_CONFIG}', content)`);
+  });
+
+  it("leaves content_tsv present, STORED GENERATED and on the 'simple' config after replaying the real migrations", async () => {
+    const rows = await db.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL);
+    expect(rows).toHaveLength(1);
+
+    const probe = rows[0];
+    expect(probe.tablePresent).toBe(true);
+    expect(probe.columnPresent).toBe(true);
+    // Existence alone is not enough: a plain column stays NULL forever and the
+    // lexical arm returns zero rows without ever raising an error.
+    expect(probe.columnGenerated).toBe(true);
+    expect(probe.generationExpr).toContain(`'${KB_FTS_CONFIG}'`);
+    expect(probe.indexPresent).toBe(true);
+  });
+
+  it("returns ranked rows for the shipped lexical query", async () => {
+    const rows = await db.query<{ id: string; docId: string; lexRank: number }>(KB_FTS_SEARCH_SQL, [
+      "HPV testing for cervical cancer screening",
+      12,
+    ]);
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].id).toBe("chunk-hpv");
+    expect(rows[0].lexRank).toBeGreaterThan(0);
+    expect(rows[0].docId).toBe(DOC_ID);
+    // Archived documents stay out of retrieval.
+    expect(rows.map((r) => r.id)).not.toContain("chunk-retired");
+  });
+
+  it("matches Hindi/Hinglish content — the reason the config is 'simple' and not 'english'", async () => {
+    const devanagari = await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["सर्वाइकल कैंसर की जांच", 12]);
+    expect(devanagari.map((r) => r.id)).toContain("chunk-hindi");
+
+    const hinglish = await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV test", 12]);
+    expect(hinglish.map((r) => r.id)).toContain("chunk-hindi");
+  });
+
+  it("RagService.fullTextSearchWithMetadata returns normalized evidence chunks against a real database", async () => {
+    const ftsHealth = new KbFtsHealthService(db.asPrisma());
+    const rag = ragServiceOn(db, ftsHealth);
+
+    const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing cervical cancer screening", 6);
+
+    // The assertion that was false in production for three months.
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0].chunkId).toBe("chunk-hpv");
+    expect(chunks[0].document.title).toBe("Cervical cancer screening");
+    expect(chunks[0].document.isTrustedSource).toBe(true);
+    // similarity is lexRank normalized against the top hit
+    expect(chunks[0].similarity).toBeCloseTo(1, 5);
+    for (const chunk of chunks) {
+      expect(chunk.similarity).toBeGreaterThan(0);
+      expect(chunk.similarity).toBeLessThanOrEqual(1);
+    }
+    expect(ftsHealth.getHealth().schemaFailureCount).toBe(0);
+  });
+
+  it("repairs a schema built from schema.prisma, where Prisma renders content_tsv as a plain column", async () => {
+    // `prisma migrate diff` / `db push` cannot express GENERATED, so a database created
+    // straight from the datamodel gets a `content_tsv tsvector` that is always NULL.
+    // The restore migration must rebuild it, not skip it via IF NOT EXISTS.
+    const fresh = await buildDatabase(proc, { simulateFreshDbPush: true });
+    try {
+      const probe = (await fresh.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
+      expect(probe.columnGenerated).toBe(true);
+      expect(probe.generationExpr).toContain(`'${KB_FTS_CONFIG}'`);
+
+      const rows = await fresh.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
+      expect(rows.map((r) => r.id)).toContain("chunk-hpv");
+    } finally {
+      await fresh.close();
+    }
+  });
+
+  it("reports 'ok' from the boot probe on a correctly migrated database", async () => {
+    jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+    try {
+      const ftsHealth = new KbFtsHealthService(db.asPrisma());
+      const health = await ftsHealth.probe();
+
+      expect(health.status).toBe("ok");
+      expect(ftsHealth.isUnavailable()).toBe(false);
+      expect(health.checkedAt).not.toBeNull();
+    } finally {
+      jest.restoreAllMocks();
+    }
+  });
+
+  describe("when content_tsv goes missing again", () => {
+    let broken: PgliteDatabase;
+    let ftsHealth: KbFtsHealthService;
+    let errorSpy: jest.SpyInstance;
+
+    beforeAll(async () => {
+      broken = await buildDatabase(proc);
+      // Reproduce exactly what migration 20260606000000 did to production.
+      await broken.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
+      await broken.exec(`ALTER TABLE "KbChunk" DROP COLUMN ${KB_FTS_COLUMN};`);
+      ftsHealth = new KbFtsHealthService(broken.asPrisma());
+    });
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    afterAll(async () => {
+      await broken?.close();
+    });
+
+    it("classifies the real Postgres error as a schema failure, not an unlucky query", async () => {
+      // Healthy database: the same statement does not raise at all.
+      await expect(db.query(KB_FTS_SEARCH_SQL, ["HPV testing", 12])).resolves.toBeDefined();
+
+      const schemaError = await broken
+        .query(KB_FTS_SEARCH_SQL, ["HPV testing", 12])
+        .then(() => null)
+        .catch((e) => e);
+
+      expect(schemaError).not.toBeNull();
+      expect((schemaError as any).code).toBe("42703"); // undefined_column, straight from Postgres
+      expect(isFtsSchemaError(schemaError)).toBe(true);
+      // A transient failure must NOT be mistaken for a dead schema.
+      expect(isFtsSchemaError(new Error("Timed out fetching a new connection from the pool"))).toBe(false);
+    });
+
+    it("reports 'unavailable' from the probe and logs it at error level", async () => {
+      const health = await ftsHealth.probe();
+
+      expect(health.status).toBe("unavailable");
+      expect(health.detail).toContain(KB_FTS_COLUMN);
+      expect(ftsHealth.isUnavailable()).toBe(true);
+
+      const events = errorSpy.mock.calls.map((call) => call[0]?.event);
+      expect(events).toContain("kb_fts_unavailable");
+    });
+
+    it("escalates a failing lexical query instead of swallowing it, while chat keeps serving", async () => {
+      const health = new KbFtsHealthService(broken.asPrisma());
+      const rag = ragServiceOn(broken, health);
+
+      // Per-query resilience is preserved: the caller still gets an array, so the
+      // vector arm can answer the turn.
+      const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+      expect(chunks).toEqual([]);
+
+      // But the condition is counted and escalated, instead of one indistinguishable
+      // log line per turn.
+      expect(health.getHealth().schemaFailureCount).toBeGreaterThan(0);
+      expect(health.getHealth().status).toBe("unavailable");
+      expect(health.getHealth().lastError).toContain(KB_FTS_COLUMN);
+
+      const events = errorSpy.mock.calls.map((call) => call[0]?.event);
+      expect(events).toContain("kb_fts_unavailable");
+    });
+  });
+
+  it("declares content_tsv in schema.prisma so a schema diff cannot drop it again", () => {
+    const schema = fs.readFileSync(SCHEMA_PATH, "utf8");
+    const fromModel = schema.slice(schema.indexOf("model KbChunk {"));
+    const modelBody = fromModel.slice(0, fromModel.indexOf("\n}"));
+
+    expect(modelBody).toMatch(/content_tsv\s+Unsupported\("tsvector"\)\?/);
+    expect(modelBody).toContain(`map: "${KB_FTS_INDEX}"`);
+    expect(modelBody).toContain("DO NOT REMOVE");
+  });
+});

--- a/apps/api/src/modules/rag/kb-fts.sql.ts
+++ b/apps/api/src/modules/rag/kb-fts.sql.ts
@@ -1,0 +1,141 @@
+/**
+ * Lexical (full-text-search) arm of hybrid retrieval — single source of truth.
+ *
+ * WHY THIS FILE EXISTS (issue #92): the FTS SQL used to be an inline tagged
+ * template inside `RagService.fullTextSearchWithMetadata`. It referenced
+ * `KbChunk.content_tsv`, a generated column that lives only in raw migration
+ * SQL. When migration 20260606000000 dropped that column, nothing in the
+ * TypeScript build, the Prisma schema or the test suite could notice, and the
+ * query failed silently for three months.
+ *
+ * Keeping the SQL and the schema identifiers here means:
+ *   - the boot-time probe (`KbFtsHealthService`) checks the very objects the
+ *     query needs, not a hand-copied guess at them, and
+ *   - `kb-fts.spec.ts` executes this exact statement against a real Postgres.
+ *
+ * If you change the text-search config here you MUST ship a migration that
+ * rebuilds `content_tsv` with the same config — `to_tsvector` and
+ * `websearch_to_tsquery` must agree or `@@` silently matches nothing.
+ */
+
+/** Table carrying the FTS column. */
+export const KB_FTS_TABLE = "KbChunk";
+
+/** Generated tsvector column. Defined in raw migration SQL only — see KB_FTS_OWNERSHIP_NOTE. */
+export const KB_FTS_COLUMN = "content_tsv";
+
+/** GIN index over the tsvector column. */
+export const KB_FTS_INDEX = "kb_chunk_content_tsv_idx";
+
+/**
+ * Postgres text-search configuration. 'simple' (not 'english') is deliberate:
+ * it tokenises without language-specific stemming, so Hindi/Hinglish KB content
+ * is searchable too (migration 20260218000000_fts_simple_config).
+ */
+export const KB_FTS_CONFIG = "simple";
+
+export const KB_FTS_OWNERSHIP_NOTE =
+  `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" is a STORED GENERATED column created by raw ` +
+  `migration SQL (20260908000000_restore_kb_chunk_fts). Prisma cannot express generated ` +
+  `columns, so schema.prisma declares it as Unsupported("tsvector") purely to stop a ` +
+  `schema diff from dropping it again. Never "clean it up" out of either place.`;
+
+/**
+ * The lexical retrieval query.
+ *
+ * $1 = user query text (fed to websearch_to_tsquery, so phrases and AND/OR work)
+ * $2 = row limit
+ *
+ * Kept structurally identical to the pre-#92 inline statement so the fix is a
+ * restoration, not a retrieval-behaviour change.
+ */
+export const KB_FTS_SEARCH_SQL = `
+  SELECT
+    c.id,
+    c."docId",
+    c.content,
+    ts_rank_cd(c.${KB_FTS_COLUMN}, query) AS "lexRank",
+    d.title,
+    d.url,
+    d."sourceType",
+    d.source,
+    d.citation,
+    d."lastReviewed",
+    d."isTrustedSource"
+  FROM "${KB_FTS_TABLE}" c
+  INNER JOIN "KbDocument" d ON c."docId" = d.id,
+  websearch_to_tsquery('${KB_FTS_CONFIG}', $1) query
+  WHERE d.status = 'active'
+    AND c.${KB_FTS_COLUMN} @@ query
+  ORDER BY ts_rank_cd(c.${KB_FTS_COLUMN}, query) DESC
+  LIMIT $2::int
+`;
+
+/**
+ * Schema probe: reports whether the objects `KB_FTS_SEARCH_SQL` depends on exist
+ * AND are shaped correctly. Existence alone is not enough — `prisma migrate diff`
+ * emits `content_tsv tsvector` *without* the GENERATED clause, which would leave a
+ * column that is always NULL and an FTS arm that returns zero rows forever without
+ * ever raising an error. Hence the `attgenerated` / generation-expression checks.
+ */
+export const KB_FTS_PROBE_SQL = `
+  SELECT
+    to_regclass('"${KB_FTS_TABLE}"') IS NOT NULL AS "tablePresent",
+    (a.attname IS NOT NULL) AS "columnPresent",
+    COALESCE(a.attgenerated = 's', false) AS "columnGenerated",
+    pg_get_expr(d.adbin, d.adrelid) AS "generationExpr",
+    EXISTS (
+      SELECT 1 FROM pg_indexes WHERE indexname = '${KB_FTS_INDEX}'
+    ) AS "indexPresent"
+  FROM (SELECT 1) probe
+  LEFT JOIN pg_attribute a
+    ON a.attrelid = to_regclass('"${KB_FTS_TABLE}"')
+   AND a.attname = '${KB_FTS_COLUMN}'
+   AND NOT a.attisdropped
+  LEFT JOIN pg_attrdef d
+    ON d.adrelid = a.attrelid
+   AND d.adnum = a.attnum
+`;
+
+export interface KbFtsProbeRow {
+  tablePresent: boolean;
+  columnPresent: boolean;
+  columnGenerated: boolean;
+  generationExpr: string | null;
+  indexPresent: boolean;
+}
+
+/**
+ * Postgres error classes that mean "the schema does not match the query" rather
+ * than "this particular query had a bad day":
+ *   42P01 undefined_table, 42703 undefined_column, 42883 undefined_function,
+ *   42P17 invalid_object_definition, 3F000 invalid_schema_name,
+ *   42704 undefined_object (e.g. a text-search config that does not exist).
+ * These are permanent until someone runs a migration, so they must escalate.
+ */
+export const PG_SCHEMA_ERROR_CODES = ["42P01", "42703", "42883", "42P17", "42704", "3F000"] as const;
+
+/**
+ * True when the error means the FTS objects are missing/misshapen.
+ *
+ * Prisma surfaces raw-query failures as PrismaClientKnownRequestError P2010 with
+ * `meta.code` holding the Postgres SQLSTATE; other drivers (and PGlite, used by
+ * the regression test) put it on `error.code`. Both are checked, plus a message
+ * fallback so a driver that only gives us prose still escalates.
+ */
+export function isFtsSchemaError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const err = error as { code?: unknown; meta?: { code?: unknown }; message?: unknown };
+  const codes = [err.code, err.meta?.code].filter((c): c is string => typeof c === "string");
+  if (codes.some((c) => (PG_SCHEMA_ERROR_CODES as readonly string[]).includes(c))) {
+    return true;
+  }
+
+  const message = typeof err.message === "string" ? err.message : "";
+  return (
+    new RegExp(`column\\s+.?(c\\.)?${KB_FTS_COLUMN}.?\\s+does not exist`, "i").test(message) ||
+    /relation\s+.?KbChunk.?\s+does not exist/i.test(message) ||
+    /function\s+websearch_to_tsquery.*does not exist/i.test(message)
+  );
+}

--- a/apps/api/src/modules/rag/rag.module.ts
+++ b/apps/api/src/modules/rag/rag.module.ts
@@ -7,11 +7,13 @@ import { RerankerService } from "./reranker.service";
 import { RetrievalToolService } from "./retrieval-tool.service";
 import { QueryDecomposerService } from "./query-decomposer.service";
 import { CrossLingualService } from "./cross-lingual.service";
+import { KbFtsHealthService } from "./kb-fts-health.service";
 
 @Module({
   imports: [EmbeddingsModule],
   providers: [
     RagService,
+    KbFtsHealthService,
     SynonymService,
     QueryExpanderService,
     RerankerService,
@@ -21,6 +23,7 @@ import { CrossLingualService } from "./cross-lingual.service";
   ],
   exports: [
     RagService,
+    KbFtsHealthService,
     QueryExpanderService,
     RerankerService,
     RetrievalToolService,

--- a/apps/api/src/modules/rag/rag.service.ts
+++ b/apps/api/src/modules/rag/rag.service.ts
@@ -9,6 +9,8 @@ import { isTrustedSource, getSourceConfig, TRUSTED_SOURCES } from "../../config/
 import { QueryTypeClassifier } from "./query-type.classifier";
 import { detectCrossCancerTopic, DetectedCrossCancerTopic } from "./cross-cancer-topics";
 import { PatientState } from "../chat/patient-state.service";
+import { KB_FTS_SEARCH_SQL, isFtsSchemaError } from "./kb-fts.sql";
+import { KbFtsHealthService } from "./kb-fts-health.service";
 
 @Injectable()
 export class RagService {
@@ -19,7 +21,8 @@ export class RagService {
     private readonly embeddings: EmbeddingsService,
     private readonly synonyms: SynonymService,
     private readonly queryExpander: QueryExpanderService,
-    private readonly reranker: RerankerService
+    private readonly reranker: RerankerService,
+    private readonly ftsHealth: KbFtsHealthService
   ) {}
 
   /**
@@ -662,14 +665,19 @@ export class RagService {
   /**
    * Full-text search using Postgres tsvector
    * Returns chunks with lexical ranking scores normalized 0-1
+   *
+   * The SQL lives in `kb-fts.sql.ts` so that the boot probe and the regression
+   * test exercise the same statement (issue #92 — this query referenced a
+   * generated column that a migration had dropped, and the failure was
+   * indistinguishable from "no lexical matches" for three months).
    */
   private async fullTextSearchWithMetadata(
-    query: string, 
+    query: string,
     topK: number
   ): Promise<EvidenceChunk[]> {
     try {
       // Use websearch_to_tsquery for better query parsing (handles phrases, AND/OR, etc.)
-      const results = await this.prisma.$queryRaw<Array<{
+      const results = await this.prisma.$queryRawUnsafe<Array<{
         id: string;
         docId: string;
         content: string;
@@ -681,27 +689,9 @@ export class RagService {
         citation: string | null;
         lastReviewed: Date | null;
         isTrustedSource: boolean;
-      }>>`
-        SELECT 
-          c.id,
-          c."docId",
-          c.content,
-          ts_rank_cd(c.content_tsv, query) AS "lexRank",
-          d.title,
-          d.url,
-          d."sourceType",
-          d.source,
-          d.citation,
-          d."lastReviewed",
-          d."isTrustedSource"
-        FROM "KbChunk" c
-        INNER JOIN "KbDocument" d ON c."docId" = d.id,
-        websearch_to_tsquery('simple', ${query}) query
-        WHERE d.status = 'active'
-          AND c.content_tsv @@ query
-        ORDER BY ts_rank_cd(c.content_tsv, query) DESC
-        LIMIT ${topK * 2}
-      `;
+      }>>(KB_FTS_SEARCH_SQL, query, topK * 2);
+
+      this.ftsHealth.recordQuerySuccess();
 
       if (results.length === 0) {
         return [];
@@ -726,7 +716,16 @@ export class RagService {
         }
       }));
     } catch (error) {
-      this.logger.error(`Full-text search error: ${error.message}`, error.stack);
+      // Per-query resilience is kept — one bad lexical query must not take down
+      // chat — but the two failure modes are no longer indistinguishable.
+      if (isFtsSchemaError(error)) {
+        // Permanent until a migration runs: escalated (error level, dedicated
+        // event) and reported on /v1/health + /v1/health/retrieval.
+        this.ftsHealth.recordSchemaFailure(error);
+      } else {
+        this.ftsHealth.recordQueryFailure(error);
+        this.logger.error(`Full-text search error: ${error.message}`, error.stack);
+      }
       return [];
     }
   }
@@ -859,6 +858,9 @@ export class RagService {
       ftsCount: ftsChunks.length,
       mergedCount: chunkMap.size,
       hybridWeights: { wVec, wLex, queryTokens: queryTokens.length },
+      // Issue #92: `ftsCount: 0` used to be ambiguous — no lexical matches, or no
+      // lexical arm at all? This makes every retrieval log line say which.
+      lexicalArm: this.ftsHealth.getHealth().status,
       crossEncoderEnabled: this.reranker.isEnabled(),
       top3TrustedCount: top3Trusted,
       topScore: reranked[0]?.similarity || 0,

--- a/cloudbuild.gated.yaml
+++ b/cloudbuild.gated.yaml
@@ -41,7 +41,7 @@ steps:
       - '--image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REGISTRY}/suchi-api:$BUILD_ID'
       - '--set-cloudsql-instances=${_CLOUDSQL_CONNECTION_NAME}'
       - '--set-secrets=DATABASE_URL=database-url:latest'
-      - '--set-env-vars=NODE_ENV=production,MIG=20260606000000_phase2_user_role_review_kb_metadata'
+      - '--set-env-vars=NODE_ENV=production,MIG=20260908000000_restore_kb_chunk_fts'
       - '--command=/app/scripts/migrate-with-repair.sh'
       - '--max-retries=1'
       - '--parallelism=1'

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,8 @@ HTTP-facing modules (controller path shown is under the global `/v1` prefix):
 | `feedback` | `POST /v1/feedback` | Thumbs up/down + comment on messages. |
 | `voice` | `POST /v1/voice/respond`, `POST /v1/voice/tts` | STT upload → chat → TTS; audio limits enforced. |
 | `voice-ws` | WS `/v1/voice/stream` | Streaming voice via Socket.io gateway (`voice-ws.gateway.ts`), optional. |
-| `health` | `GET /v1/health` | Deep health check: runs `SELECT 1` against Postgres and reports `database: connected|disconnected` (`src/modules/health/health.service.ts`). Used by deploy health gates. |
+| `health` | `GET /v1/health` | Deep health check: runs `SELECT 1` against Postgres and reports `database: connected|disconnected`, plus a `retrieval.fullTextSearch` sub-status (`src/modules/health/health.service.ts`). Used by deploy health gates, so the top-level `status` stays `ok` on a survivable retrieval degradation. |
+| `health` | `GET /v1/health/retrieval` | Retrieval readiness: re-probes `KbChunk.content_tsv` and returns **503** while the lexical arm of hybrid search is unavailable (issue #92). Not used by the deploy gate. |
 | `admin` | `/v1/admin/*` | Conversations, metrics, KB stats, daily report, hospital + article research triggers, navigator review portal, content/social approve-reject links, housekeeping (retention, draft expiry), review queue, analytics. Mixed auth (see §6). |
 | `youtube` | `/v1/admin/youtube/*` | YouTube transcript ingestion into the KB (BasicAuth). |
 | `distribution` | `GET /v1/distribution/approve/:slug`, `/reject/:slug` | One-click HMAC-tokenized approval links for social content packs (added in PR #43, prefix fixed in PR #44). |
@@ -138,7 +139,7 @@ entirely.
 | `Feedback` | Reactions and comments. |
 | `SafetyEvent` | Safety gate triggers per session/message. |
 | `AnalyticsEvent` | Generic event stream. |
-| `KbDocument` / `KbChunk` | KB docs and chunks; `KbChunk.embedding` is `vector(768)` (pgvector) plus FTS column (migration `20260120163141_add_fts_to_kbchunk`). |
+| `KbDocument` / `KbChunk` | KB docs and chunks; `KbChunk.embedding` is `vector(768)` (pgvector) plus the FTS column `content_tsv`, a STORED generated `to_tsvector('simple', content)` (migrations `20260120163141_add_fts_to_kbchunk` → `20260218000000_fts_simple_config`, dropped in error by `20260606000000_phase2_...`, restored by `20260908000000_restore_kb_chunk_fts` — issue #92). Readiness: `GET /v1/health/retrieval`. |
 | `MessageCitation` | Extracted citation markers per assistant message. |
 | `VoiceInteraction` | STT confidence, transcript, durations, TTS URL (migration `20260217000000_add_voice_interaction`). |
 | `WhatsAppContact` | Persistent phone→session mapping (migration `20260622000000_add_whatsapp_contact`). |

--- a/docs/RELIABILITY_BACKLOG.md
+++ b/docs/RELIABILITY_BACKLOG.md
@@ -331,6 +331,32 @@ rotate or remove the code path.
 post the placeholder until the real card is uploaded and the env updated in
 **both** cloudbuild files (and `deploy-api.yml` per P0-1).
 
+### P2-8. Hybrid weights are not renormalized when one retrieval arm returns nothing (new; surfaced fixing issue #92)
+
+`hybridSearchWithMetadata()` in `apps/api/src/modules/rag/rag.service.ts`
+scores `wVec * vecSim + wLex * lexSim` with fixed weights (0.80/0.20 for
+queries ≤6 tokens, 0.55/0.45 above). When the lexical arm contributes nothing
+— whether because FTS is broken (that was #92) or simply because no chunk
+matches the tsquery — every candidate's score is scaled down by `wLex`, which
+pushes borderline evidence under the `EvidenceGateService` thresholds and can
+turn a good answer into an abstention. Renormalizing (`wVec / (wVec + wLex)`
+when one arm is empty) would remove that coupling.
+
+Deliberately **not** changed while fixing #92: it moves evidence-gate outcomes,
+which is safety-adjacent (AGENTS.md §1.3) and needs its own before/after Tier1
+eval rather than riding along on a schema restore.
+
+### P2-9. Other silent `catch → return []` paths in retrieval (new; the #92 failure shape)
+
+#92 hid for three months because a raw query against a dropped column failed
+inside `catch { logger.error(...); return []; }`, which is indistinguishable
+from "no matches". `KbFtsHealthService` now separates the two for the FTS arm,
+but the same shape still exists elsewhere in
+`apps/api/src/modules/rag/rag.service.ts` (`vectorSearchWithMetadata`,
+`keywordSearchWithMetadata`, and the `.catch(() => [])` wrappers in
+`hybridSearchWithMetadata`) and in other modules. Worth a sweep: any retrieval
+arm whose empty result can mean "broken" should say which.
+
 ---
 
 ## Live-QA findings — production run 2026-09-04/05


### PR DESCRIPTION
Fixes #92.

## Confirmed: full-text search has been dead in production since 2026-06-06

Migration `20260606000000_phase2_user_role_review_kb_metadata` dropped both `content_tsv` and `kb_chunk_content_tsv_idx`. No later migration recreates them (the only one since is `20260622000000_add_whatsapp_contact`). But `rag.service.ts` still queried `c.content_tsv`, inside a `catch` that logged and `return []` — so it failed **silently on every call** for three months.

Cost: `hybridSearchWithMetadata` scores `wVec * vecSim + wLex * lexSim` with `wLex = 0.45` for queries over 6 tokens and `0.20` at or under. So long queries — the detailed patient and caregiver ones, and the Hinglish red-flag ones — lost **45% of their scoring weight** to an arm that always returned nothing.

## The drop was not deliberate

The migration comment says "FTS index — replaced by vector search", which reads as a decision. The evidence against is stronger:

1. **That same migration hand-preserved `kbchunk_embedding_hnsw_idx`** with "intentionally NOT dropped — managed outside Prisma". The author was patching around Prisma-diff-generated DROPs for objects Prisma cannot see; `content_tsv` is the same class of object and got a rationalizing comment instead of a preservation guard.
2. **No code change accompanied it** — the lexical query, the dynamic weights and the FTS fallbacks were all left in place. A real vector-only decision deletes the dead arm.
3. **Docs written a month later still specify hybrid** — `docs/ARCHITECTURE.md` (touched 2026-07-07) describes `rag` as "pgvector similarity + Postgres FTS" and lists the FTS column as live.
4. `rag.service.ts` has had **zero commits since 2026-06-01**.
5. Nothing re-baselined the Tier-1 retrieval canary for a vector-only retriever.

So this restores the arm rather than deleting it. Caveat: pre-March history is squashed into `6d37c4d`, so the dynamic-weight tuning could not be dated relative to the drop.

## Changes

**Migration** `20260908000000_restore_kb_chunk_fts` — generated `tsvector` column on `'simple'` config plus the GIN index, under the original names. `'simple'` is deliberate: `20260218000000_fts_simple_config` exists solely to move the column off `'english'`, because Hindi/Hinglish have no stemmer — and it is what the shipped `websearch_to_tsquery('simple', …)` expects. A `DO $$` guard rebuilds the column if it exists in any other shape, covering three real states verified against a real Postgres: absent (prod today), the pre-2026-02-18 `'english'` column, and a plain **non-generated** `content_tsv` — which is what `prisma migrate diff` emits from the new schema declaration and which `IF NOT EXISTS` would skip, leaving it NULL forever. Re-running is a no-op.

**Made loud** (this hid for three months because it was silent):
- `kb-fts.sql.ts` — single source of truth for the SQL, identifiers and config, plus `isFtsSchemaError()` (SQLSTATE `42703/42P01/42883/42P17/42704/3F000`, read from `error.code`, Prisma's `meta.code`, and a message fallback).
- `kb-fts-health.service.ts` — `OnModuleInit` probe that checks `attgenerated = 's'` and the generation expression, not just existence: a plain column returns zero rows *without erroring*, so existence alone proves nothing. Statuses `ok | degraded | unavailable | unknown`, logged at error level with remediation text via the repo's `event:` convention.
- Per-query: schema-class failures are error-level and counted (throttled to 1/min after the first); transient ones warn. The catch still returns `[]`, so one bad query cannot take down chat.
- Every `hybrid_retrieval` log line now carries `lexicalArm: <status>`, so `ftsCount: 0` is no longer ambiguous.
- `GET /v1/health` gains `retrieval.fullTextSearch`; new `GET /v1/health/retrieval` re-probes and returns **503** while the arm is dead.

**Two deliberate noes, commented at the code site.** No fail-fast at boot: vector-only still answers safely, and refusing to start would turn a ranking regression into a chat outage for patients. And `/v1/health`'s top-level `status` stays `"ok"`, because `cloudbuild.gated.yaml:133` gates deploys on that curl — a degraded lexical arm must not block the deploy that fixes it.

**`schema.prisma`** — `content_tsv Unsupported("tsvector")?` plus `@@index(..., type: Gin)` and a `DO NOT REMOVE` comment. Invisibility to Prisma is exactly what let a diff drop it. Prisma cannot express `GENERATED`, which is why the migration repairs that shape and the probe checks `attgenerated`.

## Test — real Postgres, real migrations, the shipped query

`kb-fts.spec.ts` (11 cases) is built specifically to avoid the #90 shape (tests that pass on synthetic input while the feature is dead). It boots **real Postgres** (PGlite/WASM — no server, no network, never prod), builds the schema from the **real `schema.prisma`**, replays **every real FTS `migration.sql` oldest-first**, then executes the **shipped** `KB_FTS_SEARCH_SQL` — including once through `RagService.fullTextSearchWithMetadata` itself. Asserts ranked rows, `d.status='active'` filtering, Devanagari/Hinglish matching, and — with the column dropped again — that a real `42703` is classified as a schema failure, reported `unavailable`, and logged as `kb_fts_unavailable`.

Proof it fails before the fix (restore migration moved aside, schema reverted): **11 failed, 11 total**, `column c.content_tsv does not exist`. Restored: **46 suites / 903 tests pass**, `npm run build` and `prisma validate` clean.

## Deploy notes

`MIG=` in `cloudbuild.gated.yaml` updated per the rule documented in that file and `docs/OPERATIONS_RUNBOOK.md`; `check_deploy_config_parity.py` still passes.

⚠️ **Hazard:** `migrate-with-repair.sh`'s fallback path marks `$MIG` as applied *without running its SQL*. If that path fires, FTS would read as "applied" but be absent — the new boot probe is what catches that.

Applying still needs the manual `migrate diff` + `psql` + `migrate resolve` pattern; `/v1/health/retrieval` is the post-apply check. The production schema was **not** queried, so the live state is inferred from migration history — the guard makes the migration correct either way.

## Filed, not fixed (`docs/RELIABILITY_BACKLOG.md`)

- **P2-8** — hybrid weights are never renormalized when one arm returns nothing, so a dead lexical arm scales *every* score down by `wLex` and pushes borderline evidence **under the evidence-gate thresholds**. That is a candidate mechanism for #81's over-abstention (a Hindi Pap-smear question refused *despite 5 citations retrieved*). Fixing it moves gate outcomes, which is safety-adjacent and needs its own before/after Tier-1 run (AGENTS.md §1.3).
- **P2-9** — the same `catch → return []` shape still exists in `vectorSearchWithMetadata`, `keywordSearchWithMetadata`, and the `.catch(() => [])` wrappers.

`docs/ARCHITECTURE.md` updated so the canonical doc stops describing a column that did not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)