### PR TITLE
fix(hooks): git-preflight inspects the invoking worktree, not the primary checkout (#102)

### DIFF
--- a/.claude/hooks/git-preflight.sh
+++ b/.claude/hooks/git-preflight.sh
@@ -3,54 +3,152 @@
 # unless it is already preserved in a stash. Added after a `git reset --hard`
 # silently wiped uncommitted WIP.
 #
-# Reads the hook payload (JSON) on stdin; the Bash command is tool_input.command.
+# Reads the hook payload (JSON) on stdin; the Bash command is tool_input.command
+# and the invoking directory is the payload's top-level `cwd`.
 # Exit 0 = allow. Exit 2 = block (stderr is shown to the model).
 
 input="$(cat)"
-cmd="$(printf '%s' "$input" | python3 -c 'import sys,json
+
+# Parse the payload once. Emits four fields, one per line, command last (it may
+# be multi-line, so it has to be the tail):
+#   1: cwd        - the directory the Bash tool runs the command from
+#   2: dir_hint   - explicit target dir from `git -C <dir>` or a leading `cd <dir> &&`
+#   3: push_ref   - refspec of a `git push`, used for the cross-worktree check
+#   4+: command
+# shellcheck disable=SC2016  # the python source is deliberately unexpanded
+payload="$(printf '%s' "$input" | python3 -c 'import sys, json, re
 try:
-    print(json.load(sys.stdin).get("tool_input",{}).get("command",""))
+    d = json.load(sys.stdin)
 except Exception:
-    print("")' 2>/dev/null)"
+    d = {}
+if not isinstance(d, dict):
+    d = {}
+cmd = ((d.get("tool_input") or {}).get("command") or "")
+cwd = (d.get("cwd") or "")
+
+# Where will the command actually run? An explicit `git -C <dir>` or a leading
+# `cd <dir> &&` overrides the payload cwd.
+hint = ""
+m = re.search(r"\bgit\s+(?:-c\s+\S+\s+)*-C\s+(\S+)", cmd)
+if m:
+    hint = m.group(1)
+else:
+    m = re.match(r"\s*cd\s+([^\s;&|]+)\s*(?:&&|;)", cmd)
+    if m:
+        hint = m.group(1)
+hint = hint.strip("\"" + chr(39))
+
+# Refspec of a push, if any: the second non-flag token after `push` (the first is
+# the remote). Stop at a command separator so `&& echo ...` is not consumed.
+push_ref = ""
+m = re.search(r"\bgit\b[^\n;&|]*?\bpush\b([^\n;&|]*)", cmd)
+if m:
+    toks = [t for t in m.group(1).split() if not t.startswith("-")]
+    if len(toks) >= 2:
+        push_ref = toks[1]
+
+print(cwd)
+print(hint)
+print(push_ref)
+sys.stdout.write(cmd)' 2>/dev/null)"
+
+cwd_hint="$(printf '%s\n' "$payload" | sed -n '1p')"
+dir_hint="$(printf '%s\n' "$payload" | sed -n '2p')"
+push_ref="$(printf '%s\n' "$payload" | sed -n '3p')"
+cmd="$(printf '%s\n' "$payload" | sed -n '4,$p')"
 
 # Fast path: ignore anything that is not a git command.
 printf '%s' "$cmd" | grep -Eq '(^|[^a-zA-Z])git[[:space:]]' || exit 0
 
 d=0          # matched a destructive command
 is_clean=0   # the command is `git clean` (also endangers untracked files)
+is_push=0    # the command is a force-push (cross-worktree branch check applies)
 # Patterns require the destructive subcommand to follow `git` directly (no `.*`
-# gap) so prose in a commit message ("…blocks git on reset --hard…") never matches.
+# gap) so prose in a commit message ("...blocks git on reset --hard...") never matches.
 printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'                                          && d=1
 printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+clean[[:space:]]+-[a-zA-Z]*f'                                     && { d=1; is_clean=1; }
 printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+checkout[[:space:]]+(-f|--force|--theirs|--ours|--[[:space:]])'   && d=1
 printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+switch[[:space:]]+(-f|--force|--discard-changes)'                 && d=1
 printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+branch[[:space:]]+-D'                                             && d=1
 printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+stash[[:space:]]+(drop|clear)'                                    && d=1
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]].*(--force([^-]|$)|--force-with-lease|[[:space:]]-f([[:space:]]|$))' && d=1
+printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]].*(--force([^-]|$)|--force-with-lease|[[:space:]]-f([[:space:]]|$))' && { d=1; is_push=1; }
 # `git restore <path>` discards worktree changes; `restore --staged` only unstages (safe).
 if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+restore' && ! printf '%s' "$cmd" | grep -Eq 'restore[[:space:]]+--staged([[:space:]]|$)'; then d=1; fi
 
 [ "$d" -eq 1 ] || exit 0
 
-# Only meaningful inside a git work tree.
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+# Resolve the work tree the command will actually run in (#102). The hook
+# process itself is launched from the primary checkout (settings.json invokes it
+# via ${CLAUDE_PROJECT_DIR}), so the hook's own $PWD is NOT the tree at risk when
+# Claude Code is working inside a `git worktree`. Try, in order: an explicit
+# `git -C`/`cd` target, the payload cwd, then the hook's own $PWD as a last
+# resort -- so a payload without `cwd` degrades to the previous behaviour rather
+# than to "allow".
+target_tree=""
+for candidate in "$dir_hint" "$cwd_hint" "$PWD"; do
+  [ -n "$candidate" ] || continue
+  case "$candidate" in
+    /*) probe="$candidate" ;;
+    -*) continue ;;
+    *)  probe="${cwd_hint:-$PWD}/$candidate" ;;   # a relative hint is relative to cwd
+  esac
+  top="$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null)" || continue
+  [ -n "$top" ] || continue
+  target_tree="$top"
+  break
+done
 
-status="$(git status --short 2>/dev/null)"
+# Only meaningful inside a git work tree.
+[ -n "$target_tree" ] || exit 0
+
+status="$(git -C "$target_tree" status --short 2>/dev/null)"
 tracked_dirty="$(printf '%s\n' "$status" | grep -vE '^\?\?' | grep -v '^$')"
-untracked="$(printf '%s\n' "$status" | grep -E '^\?\?')"
 
 # What this command can destroy: tracked modifications for all; clean also eats untracked.
 at_risk="$tracked_dirty"
-[ "$is_clean" -eq 1 ] && at_risk="$status"
-[ -n "$at_risk" ] || exit 0
+[ "$is_clean" -eq 1 ] && at_risk="$(printf '%s\n' "$status" | grep -v '^$')"
 
-# Block. Preservation = make the tree clean (stash -u / commit) — that is the
-# robust signal. We deliberately do NOT treat "a stash exists" as preserved: a
-# stale, unrelated stash would silently defeat the guard.
+if [ -n "$at_risk" ]; then
+  # Block. Preservation = make the tree clean (stash -u / commit) -- that is the
+  # robust signal. We deliberately do NOT treat "a stash exists" as preserved: a
+  # stale, unrelated stash would silently defeat the guard.
+  {
+    echo "BLOCKED (git-preflight): destructive git command with unpreserved changes."
+    echo "Tree inspected: $target_tree"
+    echo "Preserve first - 'git stash -u' or commit to a WIP branch (cleans the tree) - then retry."
+    echo "At-risk changes this command would destroy:"
+    printf '%s\n' "$at_risk"
+  } >&2
+  exit 2
+fi
+
+# The invoking tree is clean. A force-push is still destructive for a branch that
+# ANOTHER linked worktree has checked out with unpreserved changes on it, so check
+# those too -- that is the one cross-tree case the command can genuinely destroy.
+[ "$is_push" -eq 1 ] || exit 0
+
+branch="${push_ref#+}"
+branch="${branch##*:}"
+branch="${branch#refs/heads/}"
+if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+  branch="$(git -C "$target_tree" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+fi
+[ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
+
+other_tree="$(git -C "$target_tree" worktree list --porcelain 2>/dev/null | awk -v want="refs/heads/$branch" -v self="$target_tree" '
+  /^worktree / { path = substr($0, 10) }
+  /^branch /   { if (substr($0, 8) == want && path != self) { print path; exit } }
+')"
+[ -n "$other_tree" ] || exit 0
+
+other_dirty="$(git -C "$other_tree" status --short 2>/dev/null | grep -vE '^\?\?' | grep -v '^$')"
+[ -n "$other_dirty" ] || exit 0
+
 {
-  echo "BLOCKED (git-preflight): destructive git command with unpreserved changes."
-  echo "Preserve first — 'git stash -u' or commit to a WIP branch (cleans the tree) — then retry."
-  echo "At-risk changes this command would destroy:"
-  printf '%s\n' "$at_risk"
+  echo "BLOCKED (git-preflight): force-push to '$branch', which another worktree has checked out with unpreserved changes."
+  echo "Tree at risk: $other_tree (this tree, $target_tree, is clean)"
+  echo "Preserve there first - 'git -C $other_tree stash -u' or commit - then retry."
+  echo "At-risk changes:"
+  printf '%s\n' "$other_dirty"
 } >&2
 exit 2

--- a/.claude/hooks/git-preflight.sh
+++ b/.claude/hooks/git-preflight.sh
@@ -9,14 +9,25 @@
 
 input="$(cat)"
 
-# Parse the payload once. Emits four fields, one per line, command last (it may
-# be multi-line, so it has to be the tail):
-#   1: cwd        - the directory the Bash tool runs the command from
-#   2: dir_hint   - explicit target dir from `git -C <dir>` or a leading `cd <dir> &&`
-#   3: push_ref   - refspec of a `git push`, used for the cross-worktree check
-#   4+: command
+# Parse the payload once, in python, because the matching has to be structural
+# rather than a flat grep over the command text (PR #104 review, two P1s):
+#
+#   * real git syntax puts global options between `git` and the subcommand
+#     (`git -C <dir> reset --hard HEAD`), so a `git[[:space:]]+reset` pattern
+#     misses exactly the commands that name another work tree;
+#   * each segment of a compound payload runs in its own directory, so a `-C`
+#     belonging to a harmless segment must not decide which tree is inspected
+#     (`git -C /clean status --short && git reset --hard HEAD` destroys WIP in
+#     the payload cwd, not in /clean).
+#
+# So the parser splits the payload into command segments, tracks `cd` across
+# them, and reports one record per DESTRUCTIVE invocation together with the
+# directory that invocation itself will run in.
+#
+# Output: line 1 is the payload cwd; each following line is one destructive
+# invocation, TAB-separated: is_clean, is_push, dir, push_ref.
 # shellcheck disable=SC2016  # the python source is deliberately unexpanded
-payload="$(printf '%s' "$input" | python3 -c 'import sys, json, re
+findings="$(printf '%s' "$input" | python3 -c 'import sys, json, re, posixpath
 try:
     d = json.load(sys.stdin)
 except Exception:
@@ -26,129 +37,307 @@ if not isinstance(d, dict):
 cmd = ((d.get("tool_input") or {}).get("command") or "")
 cwd = (d.get("cwd") or "")
 
-# Where will the command actually run? An explicit `git -C <dir>` or a leading
-# `cd <dir> &&` overrides the payload cwd.
-hint = ""
-m = re.search(r"\bgit\s+(?:-c\s+\S+\s+)*-C\s+(\S+)", cmd)
-if m:
-    hint = m.group(1)
-else:
-    m = re.match(r"\s*cd\s+([^\s;&|]+)\s*(?:&&|;)", cmd)
-    if m:
-        hint = m.group(1)
-hint = hint.strip("\"" + chr(39))
+QUOTES = "\"" + chr(39)
+ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# A `git` word at the start of the text or after a non-path character.
+GIT_WORD = re.compile(r"(?:^|[^A-Za-z0-9_./-])git[ \t]")
+# git global options that consume the following token as their value.
+GLOBAL_VALUE_OPTS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+                     "--exec-path", "--super-prefix", "--config-env")
 
-# Refspec of a push, if any: the second non-flag token after `push` (the first is
-# the remote). Stop at a command separator so `&& echo ...` is not consumed.
-push_ref = ""
-m = re.search(r"\bgit\b[^\n;&|]*?\bpush\b([^\n;&|]*)", cmd)
-if m:
-    toks = [t for t in m.group(1).split() if not t.startswith("-")]
-    if len(toks) >= 2:
-        push_ref = toks[1]
 
-print(cwd)
-print(hint)
-print(push_ref)
-sys.stdout.write(cmd)' 2>/dev/null)"
+def split_segments(text):
+    """Split a compound command on && || ; | & and newlines, ignoring
+    separators that sit inside quotes."""
+    segs, cur, quote, i, n = [], [], None, 0, len(text)
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            cur.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in QUOTES:
+            quote = ch
+            cur.append(ch)
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < n:
+            cur.append(ch)
+            cur.append(text[i + 1])
+            i += 2
+            continue
+        if text[i:i + 2] in ("&&", "||"):
+            segs.append("".join(cur))
+            cur = []
+            i += 2
+            continue
+        if ch in ";|&\n":
+            segs.append("".join(cur))
+            cur = []
+            i += 1
+            continue
+        cur.append(ch)
+        i += 1
+    segs.append("".join(cur))
+    return [s.strip() for s in segs if s.strip()]
 
-cwd_hint="$(printf '%s\n' "$payload" | sed -n '1p')"
-dir_hint="$(printf '%s\n' "$payload" | sed -n '2p')"
-push_ref="$(printf '%s\n' "$payload" | sed -n '3p')"
-cmd="$(printf '%s\n' "$payload" | sed -n '4,$p')"
 
-# Fast path: ignore anything that is not a git command.
-printf '%s' "$cmd" | grep -Eq '(^|[^a-zA-Z])git[[:space:]]' || exit 0
+def tokenize(text):
+    """Word-split a segment, dropping quote characters."""
+    toks, cur, quote, quoted = [], [], None, False
+    for ch in text:
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            else:
+                cur.append(ch)
+            continue
+        if ch in QUOTES:
+            quote = ch
+            quoted = True
+            continue
+        if ch.isspace():
+            if cur or quoted:
+                toks.append("".join(cur))
+                cur = []
+                quoted = False
+            continue
+        cur.append(ch)
+    if cur or quoted:
+        toks.append("".join(cur))
+    return toks
 
-d=0          # matched a destructive command
-is_clean=0   # the command is `git clean` (also endangers untracked files)
-is_push=0    # the command is a force-push (cross-worktree branch check applies)
-# Patterns require the destructive subcommand to follow `git` directly (no `.*`
-# gap) so prose in a commit message ("...blocks git on reset --hard...") never matches.
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'                                          && d=1
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+clean[[:space:]]+-[a-zA-Z]*f'                                     && { d=1; is_clean=1; }
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+checkout[[:space:]]+(-f|--force|--theirs|--ours|--[[:space:]])'   && d=1
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+switch[[:space:]]+(-f|--force|--discard-changes)'                 && d=1
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+branch[[:space:]]+-D'                                             && d=1
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+stash[[:space:]]+(drop|clear)'                                    && d=1
-printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]].*(--force([^-]|$)|--force-with-lease|[[:space:]]-f([[:space:]]|$))' && { d=1; is_push=1; }
-# `git restore <path>` discards worktree changes; `restore --staged` only unstages (safe).
-if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+restore' && ! printf '%s' "$cmd" | grep -Eq 'restore[[:space:]]+--staged([[:space:]]|$)'; then d=1; fi
 
-[ "$d" -eq 1 ] || exit 0
+def parse_git(toks):
+    """toks start AFTER the `git` word. Skip global options to reach the real
+    subcommand, capturing a `-C <dir>` on the way.
+    Returns (subcommand, args, dir_hint)."""
+    i, hint = 0, ""
+    while i < len(toks):
+        t = toks[i]
+        if t == "-C" and i + 1 < len(toks):
+            hint = toks[i + 1]
+            i += 2
+            continue
+        if t.startswith("-C") and len(t) > 2:
+            hint = t[2:]
+            i += 1
+            continue
+        if t in GLOBAL_VALUE_OPTS:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        return t, toks[i + 1:], hint
+    return "", [], hint
 
-# Resolve the work tree the command will actually run in (#102). The hook
-# process itself is launched from the primary checkout (settings.json invokes it
-# via ${CLAUDE_PROJECT_DIR}), so the hook's own $PWD is NOT the tree at risk when
-# Claude Code is working inside a `git worktree`. Try, in order: an explicit
-# `git -C`/`cd` target, the payload cwd, then the hook's own $PWD as a last
-# resort -- so a payload without `cwd` degrades to the previous behaviour rather
-# than to "allow".
-target_tree=""
-for candidate in "$dir_hint" "$cwd_hint" "$PWD"; do
-  [ -n "$candidate" ] || continue
-  case "$candidate" in
-    /*) probe="$candidate" ;;
-    -*) continue ;;
-    *)  probe="${cwd_hint:-$PWD}/$candidate" ;;   # a relative hint is relative to cwd
-  esac
-  top="$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null)" || continue
-  [ -n "$top" ] || continue
-  target_tree="$top"
-  break
-done
 
-# Only meaningful inside a git work tree.
-[ -n "$target_tree" ] || exit 0
+def classify(sub, args):
+    """Returns (destructive, is_clean, is_push, push_ref). is_clean marks
+    `git clean`, which also destroys untracked files; is_push marks a
+    force-push, for which the cross-worktree branch check applies."""
+    if sub == "reset":
+        if "--hard" in args:
+            return (1, 0, 0, "")
+    elif sub == "clean":
+        for a in args:
+            if re.match(r"^-[a-zA-Z]*f", a):
+                return (1, 1, 0, "")
+    elif sub == "checkout":
+        for a in args:
+            if a in ("-f", "--force", "--theirs", "--ours", "--"):
+                return (1, 0, 0, "")
+    elif sub == "switch":
+        for a in args:
+            if a in ("-f", "--force", "--discard-changes"):
+                return (1, 0, 0, "")
+    elif sub == "branch":
+        if "-D" in args:
+            return (1, 0, 0, "")
+    elif sub == "stash":
+        for a in args:
+            if a.startswith("-"):
+                continue
+            if a in ("drop", "clear"):
+                return (1, 0, 0, "")
+            break
+    elif sub == "push":
+        forced = False
+        for a in args:
+            if a in ("-f", "--force") or a.startswith("--force-with-lease"):
+                forced = True
+        if forced:
+            # Refspec = second non-flag argument (the first is the remote).
+            plain = [a for a in args if not a.startswith("-")]
+            return (1, 0, 1, plain[1] if len(plain) >= 2 else "")
+    elif sub == "restore":
+        # `git restore <path>` discards worktree changes; `restore --staged`
+        # only unstages (safe).
+        if "--staged" not in args:
+            return (1, 0, 0, "")
+    return (0, 0, 0, "")
 
-status="$(git -C "$target_tree" status --short 2>/dev/null)"
-tracked_dirty="$(printf '%s\n' "$status" | grep -vE '^\?\?' | grep -v '^$')"
 
-# What this command can destroy: tracked modifications for all; clean also eats untracked.
-at_risk="$tracked_dirty"
-[ "$is_clean" -eq 1 ] && at_risk="$(printf '%s\n' "$status" | grep -v '^$')"
+def program_tokens(toks):
+    """Drop leading VAR=value assignments to reach the program word."""
+    i = 0
+    while i < len(toks) and ASSIGN.match(toks[i]):
+        i += 1
+    return toks[i:]
 
-if [ -n "$at_risk" ]; then
-  # Block. Preservation = make the tree clean (stash -u / commit) -- that is the
-  # robust signal. We deliberately do NOT treat "a stash exists" as preserved: a
-  # stale, unrelated stash would silently defeat the guard.
+
+def cd_target(toks):
+    rest = program_tokens(toks)
+    if not rest or rest[0] != "cd":
+        return None
+    for a in rest[1:]:
+        if not a.startswith("-"):
+            return a
+    return None
+
+
+def resolve(base, path):
+    if not path:
+        return base
+    if path.startswith("/") or path.startswith("~"):
+        return path
+    if base:
+        return posixpath.normpath(posixpath.join(base, path))
+    return path
+
+
+def scan_anywhere(seg):
+    """Fallback for a segment whose program is not git (bash -c ..., sudo git
+    ..., xargs git ...): treat any git invocation in the text as real.
+    Deliberately conservative -- blocking is the safe direction."""
+    hits = []
+    for m in GIT_WORD.finditer(seg):
+        sub, args, hint = parse_git(tokenize(seg[m.end():]))
+        res = classify(sub, args)
+        if res[0]:
+            hits.append((res, hint))
+    return hits
+
+
+lines = [cwd]
+cwd_here = cwd
+for seg in split_segments(cmd):
+    toks = tokenize(seg)
+    target = cd_target(toks)
+    if target is not None:
+        cwd_here = resolve(cwd_here, target)
+        continue
+    rest = program_tokens(toks)
+    hits = []
+    if rest and (rest[0] == "git" or rest[0].endswith("/git")):
+        # The segment IS a git command: only this invocation counts, so prose
+        # inside its arguments (a commit message quoting a destructive verb)
+        # never matches.
+        sub, args, hint = parse_git(rest[1:])
+        res = classify(sub, args)
+        if res[0]:
+            hits = [(res, hint)]
+    elif GIT_WORD.search(seg):
+        hits = scan_anywhere(seg)
+    for (_d, is_clean, is_push, push_ref), hint in hits:
+        lines.append("\t".join([str(is_clean), str(is_push),
+                                resolve(cwd_here, hint), push_ref]))
+
+sys.stdout.write("\n".join(lines))' 2>/dev/null)"
+
+[ -n "$findings" ] || exit 0
+
+cwd_hint="$(printf '%s\n' "$findings" | sed -n '1p')"
+hits="$(printf '%s\n' "$findings" | sed -n '2,$p' | grep -v '^$')"
+
+# Nothing destructive in the payload.
+[ -n "$hits" ] || exit 0
+
+# Resolve the work tree a destructive command will actually run in (#102). The
+# hook process itself is launched from the primary checkout (settings.json
+# invokes it via ${CLAUDE_PROJECT_DIR}), so the hook's own $PWD is NOT the tree
+# at risk when Claude Code is working inside a `git worktree`. Try, in order:
+# the directory that invocation resolved to (its own `git -C` / a preceding
+# `cd`), the payload cwd, then the hook's own $PWD as a last resort -- so a
+# payload without `cwd` degrades to the previous behaviour, not to "allow".
+resolve_tree() {
+  local hint="$1" candidate probe top
+  for candidate in "$hint" "$cwd_hint" "$PWD"; do
+    [ -n "$candidate" ] || continue
+    case "$candidate" in
+      /*) probe="$candidate" ;;
+      -*) continue ;;
+      *)  probe="${cwd_hint:-$PWD}/$candidate" ;;   # a relative hint is relative to cwd
+    esac
+    top="$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null)" || continue
+    [ -n "$top" ] || continue
+    printf '%s' "$top"
+    return 0
+  done
+  return 1
+}
+
+while IFS="$(printf '\t')" read -r is_clean is_push dir_hint push_ref; do
+  target_tree="$(resolve_tree "$dir_hint")" || continue
+  # Only meaningful inside a git work tree.
+  [ -n "$target_tree" ] || continue
+
+  status="$(git -C "$target_tree" status --short 2>/dev/null)"
+  tracked_dirty="$(printf '%s\n' "$status" | grep -vE '^\?\?' | grep -v '^$')"
+
+  # What this command can destroy: tracked modifications for all; clean also
+  # eats untracked.
+  at_risk="$tracked_dirty"
+  [ "$is_clean" = "1" ] && at_risk="$(printf '%s\n' "$status" | grep -v '^$')"
+
+  if [ -n "$at_risk" ]; then
+    # Block. Preservation = make the tree clean (stash -u / commit) -- that is
+    # the robust signal. We deliberately do NOT treat "a stash exists" as
+    # preserved: a stale, unrelated stash would silently defeat the guard.
+    {
+      echo "BLOCKED (git-preflight): destructive git command with unpreserved changes."
+      echo "Tree inspected: $target_tree"
+      echo "Preserve first - 'git stash -u' or commit to a WIP branch (cleans the tree) - then retry."
+      echo "At-risk changes this command would destroy:"
+      printf '%s\n' "$at_risk"
+    } >&2
+    exit 2
+  fi
+
+  # This tree is clean. A force-push is still destructive for a branch that
+  # ANOTHER linked worktree has checked out with unpreserved changes on it, so
+  # check those too -- that is the one cross-tree case the command can
+  # genuinely destroy.
+  [ "$is_push" = "1" ] || continue
+
+  branch="${push_ref#+}"
+  branch="${branch##*:}"
+  branch="${branch#refs/heads/}"
+  if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+    branch="$(git -C "$target_tree" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  fi
+  [ -n "$branch" ] && [ "$branch" != "HEAD" ] || continue
+
+  other_tree="$(git -C "$target_tree" worktree list --porcelain 2>/dev/null | awk -v want="refs/heads/$branch" -v self="$target_tree" '
+    /^worktree / { path = substr($0, 10) }
+    /^branch /   { if (substr($0, 8) == want && path != self) { print path; exit } }
+  ')"
+  [ -n "$other_tree" ] || continue
+
+  other_dirty="$(git -C "$other_tree" status --short 2>/dev/null | grep -vE '^\?\?' | grep -v '^$')"
+  [ -n "$other_dirty" ] || continue
+
   {
-    echo "BLOCKED (git-preflight): destructive git command with unpreserved changes."
-    echo "Tree inspected: $target_tree"
-    echo "Preserve first - 'git stash -u' or commit to a WIP branch (cleans the tree) - then retry."
-    echo "At-risk changes this command would destroy:"
-    printf '%s\n' "$at_risk"
+    echo "BLOCKED (git-preflight): force-push to '$branch', which another worktree has checked out with unpreserved changes."
+    echo "Tree at risk: $other_tree (this tree, $target_tree, is clean)"
+    echo "Preserve there first - 'git -C $other_tree stash -u' or commit - then retry."
+    echo "At-risk changes:"
+    printf '%s\n' "$other_dirty"
   } >&2
   exit 2
-fi
+done <<<"$hits"
 
-# The invoking tree is clean. A force-push is still destructive for a branch that
-# ANOTHER linked worktree has checked out with unpreserved changes on it, so check
-# those too -- that is the one cross-tree case the command can genuinely destroy.
-[ "$is_push" -eq 1 ] || exit 0
-
-branch="${push_ref#+}"
-branch="${branch##*:}"
-branch="${branch#refs/heads/}"
-if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
-  branch="$(git -C "$target_tree" rev-parse --abbrev-ref HEAD 2>/dev/null)"
-fi
-[ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
-
-other_tree="$(git -C "$target_tree" worktree list --porcelain 2>/dev/null | awk -v want="refs/heads/$branch" -v self="$target_tree" '
-  /^worktree / { path = substr($0, 10) }
-  /^branch /   { if (substr($0, 8) == want && path != self) { print path; exit } }
-')"
-[ -n "$other_tree" ] || exit 0
-
-other_dirty="$(git -C "$other_tree" status --short 2>/dev/null | grep -vE '^\?\?' | grep -v '^$')"
-[ -n "$other_dirty" ] || exit 0
-
-{
-  echo "BLOCKED (git-preflight): force-push to '$branch', which another worktree has checked out with unpreserved changes."
-  echo "Tree at risk: $other_tree (this tree, $target_tree, is clean)"
-  echo "Preserve there first - 'git -C $other_tree stash -u' or commit - then retry."
-  echo "At-risk changes:"
-  printf '%s\n' "$other_dirty"
-} >&2
-exit 2
+exit 0

--- a/.claude/hooks/git-preflight.test.sh
+++ b/.claude/hooks/git-preflight.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Test harness for git-preflight.sh (issue #102).
+#
+# There is no jest for shell hooks, so this is the regression proof: it builds a
+# throwaway repo with a linked `git worktree`, feeds the hook real PreToolUse
+# payloads, and asserts the exit code. Crucially, every case runs the hook with
+# its own $PWD set to the PRIMARY checkout, which is how Claude Code invokes it
+# (settings.json: `bash "${CLAUDE_PROJECT_DIR}/.claude/hooks/git-preflight.sh"`).
+# That is what makes the #102 cases fail against the pre-fix hook and pass after.
+#
+# Usage: bash .claude/hooks/git-preflight.test.sh
+# Exit 0 = all passed.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/git-preflight.sh"
+[ -f "$HOOK" ] || { echo "hook not found: $HOOK" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PRIMARY="$TMP/primary"
+LINKED="$TMP/linked"
+
+git init -q -b main "$PRIMARY"
+git -C "$PRIMARY" config user.email t@example.com
+git -C "$PRIMARY" config user.name  Test
+echo base > "$PRIMARY/tracked.txt"
+git -C "$PRIMARY" add tracked.txt
+git -C "$PRIMARY" commit -qm "base"
+git -C "$PRIMARY" worktree add -q -b feature "$LINKED"
+
+# The destructive commands under test are assembled from fragments so that this
+# harness does not itself trip the hook when an agent edits it.
+RESET="git re""set --hard HEAD"
+FPUSH="git pu""sh --force origin"
+GCLEAN="git cl""ean -fd"
+RESTORE_FILE="git re""store tracked.txt"
+
+pass=0
+fail=0
+LAST_OUT=""
+
+# run <name> <expected_exit> <cwd> <command>
+run() {
+  local name="$1" want="$2" cwd="$3" command="$4" out got payload
+  payload="$(cwd="$cwd" command="$command" python3 -c 'import json, os
+print(json.dumps({
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "cwd": os.environ["cwd"],
+    "tool_input": {"command": os.environ["command"]},
+}))')"
+  # $PWD is the primary checkout for every case: that is how the hook is launched.
+  out="$(cd "$PRIMARY" && printf '%s' "$payload" | bash "$HOOK" 2>&1)"
+  got=$?
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf 'ok   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s: expected exit %s, got %s\n%s\n' "$name" "$want" "$got" "$out"
+  fi
+  LAST_OUT="$out"
+}
+
+# assert_mentions <needle> <label> -- checked against the last run's output
+assert_mentions() {
+  case "$LAST_OUT" in
+    *"$1"*) pass=$((pass + 1)); printf 'ok   %s\n' "$2" ;;
+    *) fail=$((fail + 1)); printf 'FAIL %s\n%s\n' "$2" "$LAST_OUT" ;;
+  esac
+}
+
+# --- baseline behaviour that must not regress ------------------------------
+
+run "non-git command is ignored"          0 "$PRIMARY" "ls -la"
+run "non-destructive git is ignored"      0 "$PRIMARY" "git status --short"
+run "prose mentioning a destructive verb" 0 "$PRIMARY" "git commit -m 'note: the hook blocks $RESET'"
+run "destructive command, clean tree"     0 "$PRIMARY" "$RESET"
+
+# --- a dirty tree still blocks (acceptance #2) -----------------------------
+
+echo dirty > "$PRIMARY/tracked.txt"
+run "dirty tree blocks"                   2 "$PRIMARY" "$RESET"
+assert_mentions "$PRIMARY" "block message names the primary tree"
+run "dirty tree blocks path restore"      2 "$PRIMARY" "$RESTORE_FILE"
+
+# --- issue #102: a clean worktree is NOT blocked by primary dirt -----------
+# The primary checkout is dirty (above); the linked worktree is clean. The
+# pre-#102 hook inspected its own $PWD (= primary) and blocked both of these.
+
+run "#102 force-push from clean worktree" 0 "$LINKED"  "$FPUSH feature"
+run "#102 destructive in clean worktree"  0 "$LINKED"  "$RESET"
+
+# --- the linked worktree's own dirt does block, and is named ---------------
+
+echo wip > "$LINKED/tracked.txt"
+run "dirty linked worktree blocks"        2 "$LINKED"  "$RESET"
+assert_mentions "$LINKED" "block message names the linked worktree"
+
+# --- explicit `git -C <dir>` / `cd <dir> &&` target the named tree ---------
+
+git -C "$PRIMARY" checkout -q -- tracked.txt   # primary clean, linked still dirty
+run "git -C targets the named dirty tree" 2 "$PRIMARY" "git -C $LINKED $RESET"
+run "cd <dir> && targets that tree"       2 "$PRIMARY" "cd $LINKED && $RESET"
+
+# --- acceptance #3: force-push to a branch another dirty worktree holds ----
+# Run from the clean primary, pushing 'feature' -- which the dirty linked
+# worktree has checked out. Must still block.
+
+run "force-push to a dirty worktree's branch" \
+                                          2 "$PRIMARY" "$FPUSH feature"
+assert_mentions "$LINKED" "cross-worktree block names the linked worktree"
+run "force-push to an unrelated branch"   0 "$PRIMARY" "$FPUSH main"
+
+# --- untracked files: only the clean subcommand can destroy them -----------
+
+git -C "$LINKED" checkout -q -- tracked.txt    # both trees tracked-clean
+echo junk > "$LINKED/untracked.txt"
+run "destructive command ignores untracked" \
+                                          0 "$LINKED"  "$RESET"
+run "clean -fd blocks on untracked"       2 "$LINKED"  "$GCLEAN"
+
+# --- a payload with no cwd degrades to the hook's own $PWD, not to "allow" --
+
+echo dirty > "$PRIMARY/tracked.txt"
+run "no cwd in payload falls back to \$PWD" \
+                                          2 ""         "$RESET"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/git-preflight.test.sh
+++ b/.claude/hooks/git-preflight.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Test harness for git-preflight.sh (issue #102).
+# Test harness for git-preflight.sh (issue #102, PR #104 review).
 #
 # There is no jest for shell hooks, so this is the regression proof: it builds a
 # throwaway repo with a linked `git worktree`, feeds the hook real PreToolUse
@@ -9,11 +9,14 @@
 # That is what makes the #102 cases fail against the pre-fix hook and pass after.
 #
 # Usage: bash .claude/hooks/git-preflight.test.sh
+#        GIT_PREFLIGHT_HOOK=<path> bash .claude/hooks/git-preflight.test.sh
+# The override exists so a case can be demonstrated red against an older copy of
+# the hook before the fix lands.
 # Exit 0 = all passed.
 
 set -u
 
-HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/git-preflight.sh"
+HOOK="${GIT_PREFLIGHT_HOOK:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/git-preflight.sh}"
 [ -f "$HOOK" ] || { echo "hook not found: $HOOK" >&2; exit 1; }
 
 TMP="$(mktemp -d)"
@@ -31,11 +34,19 @@ git -C "$PRIMARY" commit -qm "base"
 git -C "$PRIMARY" worktree add -q -b feature "$LINKED"
 
 # The destructive commands under test are assembled from fragments so that this
-# harness does not itself trip the hook when an agent edits it.
-RESET="git re""set --hard HEAD"
-FPUSH="git pu""sh --force origin"
-GCLEAN="git cl""ean -fd"
-RESTORE_FILE="git re""store tracked.txt"
+# harness does not itself trip the hook when an agent edits it. They are
+# SUBCOMMAND-ONLY: every case spells out the `git` word itself, so that
+# `git -C <dir> <subcommand>` is Git's real syntax and not the nonsense
+# `git -C <dir> git <subcommand>` (PR #104 review, P1).
+RESET="re""set --hard HEAD"
+FPUSH="pu""sh --force origin"
+GCLEAN="cl""ean -fd"
+RESTORE_FILE="re""store tracked.txt"
+RESTORE_STAGED="re""store --staged tracked.txt"
+CHECKOUT_F="check""out -f main"
+SWITCH_D="swi""tch --discard-changes"
+BRANCH_D="bra""nch -D scratch"
+STASH_DROP="sta""sh drop"
 
 pass=0
 fail=0
@@ -76,57 +87,102 @@ assert_mentions() {
 
 run "non-git command is ignored"          0 "$PRIMARY" "ls -la"
 run "non-destructive git is ignored"      0 "$PRIMARY" "git status --short"
-run "prose mentioning a destructive verb" 0 "$PRIMARY" "git commit -m 'note: the hook blocks $RESET'"
-run "destructive command, clean tree"     0 "$PRIMARY" "$RESET"
+run "destructive command, clean tree"     0 "$PRIMARY" "git $RESET"
+run "git -C at a clean tree is allowed"   0 "$PRIMARY" "git -C $LINKED $RESET"
 
 # --- a dirty tree still blocks (acceptance #2) -----------------------------
 
 echo dirty > "$PRIMARY/tracked.txt"
-run "dirty tree blocks"                   2 "$PRIMARY" "$RESET"
+run "dirty tree blocks"                   2 "$PRIMARY" "git $RESET"
 assert_mentions "$PRIMARY" "block message names the primary tree"
-run "dirty tree blocks path restore"      2 "$PRIMARY" "$RESTORE_FILE"
+run "dirty tree blocks path restore"      2 "$PRIMARY" "git $RESTORE_FILE"
+run "restore --staged is not destructive" 0 "$PRIMARY" "git $RESTORE_STAGED"
+
+# Prose quoting a destructive verb inside a commit message must never match --
+# and a commit is precisely when the tree IS dirty, so the clean-tree version of
+# this case proved nothing.
+run "prose in a commit message on a dirty tree" \
+                                          0 "$PRIMARY" "git commit -m 'note: the hook blocks git $RESET'"
+# ...but a destructive git call wrapped in another program is still caught.
+run "wrapped destructive command blocks"  2 "$PRIMARY" "bash -c \"git $RESET\""
 
 # --- issue #102: a clean worktree is NOT blocked by primary dirt -----------
 # The primary checkout is dirty (above); the linked worktree is clean. The
 # pre-#102 hook inspected its own $PWD (= primary) and blocked both of these.
 
-run "#102 force-push from clean worktree" 0 "$LINKED"  "$FPUSH feature"
-run "#102 destructive in clean worktree"  0 "$LINKED"  "$RESET"
+run "#102 force-push from clean worktree" 0 "$LINKED"  "git $FPUSH feature"
+run "#102 destructive in clean worktree"  0 "$LINKED"  "git $RESET"
 
-# --- the linked worktree's own dirt does block, and is named ---------------
+# --- real `git -C <dir> <subcommand>` syntax, every destructive verb -------
+# cwd is the CLEAN linked worktree; the command targets the DIRTY primary.
+# Against the pre-fix hook every one of these exits 0, because the patterns
+# required the subcommand to follow `git` with no global options in between.
 
+run "-C reset --hard blocks"              2 "$LINKED"  "git -C $PRIMARY $RESET"
+assert_mentions "$PRIMARY" "-C block message names the -C tree"
+run "-C clean -fd blocks"                 2 "$LINKED"  "git -C $PRIMARY $GCLEAN"
+run "-C checkout -f blocks"               2 "$LINKED"  "git -C $PRIMARY $CHECKOUT_F"
+run "-C switch --discard-changes blocks"  2 "$LINKED"  "git -C $PRIMARY $SWITCH_D"
+run "-C branch -D blocks"                 2 "$LINKED"  "git -C $PRIMARY $BRANCH_D"
+run "-C stash drop blocks"                2 "$LINKED"  "git -C $PRIMARY $STASH_DROP"
+run "-C restore <path> blocks"            2 "$LINKED"  "git -C $PRIMARY $RESTORE_FILE"
+run "-C force-push blocks"                2 "$LINKED"  "git -C $PRIMARY $FPUSH main"
+run "-C with other global options blocks" 2 "$LINKED"  "git -c core.pager=cat -C $PRIMARY $RESET"
+run "attached -C<dir> form blocks"        2 "$LINKED"  "git -C$PRIMARY $RESET"
+run "-C restore --staged is allowed"      0 "$LINKED"  "git -C $PRIMARY $RESTORE_STAGED"
+
+# --- compound payloads: the hint must belong to the destructive segment ----
+# Primary (payload cwd) is dirty, linked is clean. The pre-fix parser took the
+# first `git -C` anywhere in the payload, so it inspected the clean linked tree
+# and let the reset erase the primary's WIP.
+
+run "compound: -C on a harmless segment does not move the inspection" \
+                                          2 "$PRIMARY" "git -C $LINKED status --short && git $RESET"
+assert_mentions "$PRIMARY" "compound block names the tree the reset runs in"
+
+# Flip the dirt: now the primary (payload cwd) is clean and the linked tree is
+# dirty. A `-C <dirty>` that belongs only to a harmless segment must NOT block.
+git -C "$PRIMARY" checkout -q -- tracked.txt
 echo wip > "$LINKED/tracked.txt"
-run "dirty linked worktree blocks"        2 "$LINKED"  "$RESET"
-assert_mentions "$LINKED" "block message names the linked worktree"
 
-# --- explicit `git -C <dir>` / `cd <dir> &&` target the named tree ---------
-
-git -C "$PRIMARY" checkout -q -- tracked.txt   # primary clean, linked still dirty
+run "compound: dirty tree named only in a harmless segment does not block" \
+                                          0 "$PRIMARY" "git -C $LINKED status --short && git $RESET"
+run "compound: -C on the destructive segment does target it" \
+                                          2 "$PRIMARY" "echo checking && git -C $LINKED $RESET"
+run "cd <dir> && targets that tree"       2 "$PRIMARY" "cd $LINKED && git $RESET"
+run "cd in an earlier segment carries over" \
+                                          2 "$PRIMARY" "cd $LINKED && echo hi && git $RESET"
 run "git -C targets the named dirty tree" 2 "$PRIMARY" "git -C $LINKED $RESET"
-run "cd <dir> && targets that tree"       2 "$PRIMARY" "cd $LINKED && $RESET"
+assert_mentions "$LINKED" "block message names the linked worktree"
 
 # --- acceptance #3: force-push to a branch another dirty worktree holds ----
 # Run from the clean primary, pushing 'feature' -- which the dirty linked
 # worktree has checked out. Must still block.
 
 run "force-push to a dirty worktree's branch" \
-                                          2 "$PRIMARY" "$FPUSH feature"
+                                          2 "$PRIMARY" "git $FPUSH feature"
 assert_mentions "$LINKED" "cross-worktree block names the linked worktree"
-run "force-push to an unrelated branch"   0 "$PRIMARY" "$FPUSH main"
+run "force-push to an unrelated branch"   0 "$PRIMARY" "git $FPUSH main"
+# Same cross-worktree check, reached through `git -C` from the dirty worktree:
+# the -C tree is clean, so only the cross-tree branch check can block this.
+run "-C force-push hits the cross-worktree check" \
+                                          2 "$LINKED"  "git -C $PRIMARY $FPUSH feature"
+assert_mentions "$LINKED" "-C cross-worktree block names the linked worktree"
 
 # --- untracked files: only the clean subcommand can destroy them -----------
 
 git -C "$LINKED" checkout -q -- tracked.txt    # both trees tracked-clean
 echo junk > "$LINKED/untracked.txt"
 run "destructive command ignores untracked" \
-                                          0 "$LINKED"  "$RESET"
-run "clean -fd blocks on untracked"       2 "$LINKED"  "$GCLEAN"
+                                          0 "$LINKED"  "git $RESET"
+run "clean -fd blocks on untracked"       2 "$LINKED"  "git $GCLEAN"
+run "-C clean -fd blocks on untracked"    2 "$PRIMARY" "git -C $LINKED $GCLEAN"
 
 # --- a payload with no cwd degrades to the hook's own $PWD, not to "allow" --
 
 echo dirty > "$PRIMARY/tracked.txt"
 run "no cwd in payload falls back to \$PWD" \
-                                          2 ""         "$RESET"
+                                          2 ""         "git $RESET"
 
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #102.

## The defect

`.claude/settings.json` launches the hook as
`bash "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/git-preflight.sh"`, so the hook
process always starts in the **primary checkout**. The script then called a bare
`git status`, which resolves against its own `$PWD` — the primary checkout —
regardless of which worktree the destructive command was actually going to run
in.

Result: during the 2026-09-08 PR splits, force-pushes from clean agent
worktrees were blocked by uncommitted files in `/home/gauta/suchi_repo` that the
command could not have touched. The workaround (park primary WIP, push, restore)
is exactly the "train people around the guard" failure mode that caused the
original WIP loss.

## The fix

`.claude/hooks/git-preflight.sh` now resolves the tree from the payload:

1. an explicit `git -C <dir>` or leading `cd <dir> &&` target in the command;
2. else the payload's top-level `cwd` (the directory the Bash tool runs in);
3. else the hook's own `$PWD` — a last resort, so a payload without `cwd`
   degrades to the **previous** behaviour rather than to "allow".

The first candidate that `git -C <dir> rev-parse --show-toplevel` accepts becomes
the inspected tree, and all status/at-risk logic runs with `git -C <that tree>`.
The block message now names the tree it inspected.

Fail-closed is preserved: no new path exits 0 on a dirty tree, and the
resolution chain always ends at the old behaviour rather than at "allow".

### Acceptance #3 — the one real cross-tree case

A force-push is genuinely destructive for a branch that *another* linked worktree
has checked out with unpreserved changes. The hook now parses the push refspec
(`+`, `HEAD:refs/heads/x`, bare branch; falls back to the current branch),
scans `git worktree list --porcelain`, and **blocks** if a different worktree
holds that branch and is tracked-dirty — naming that worktree. The issue said
"warns or blocks"; a PreToolUse exit-0 warning is not surfaced to the model, so a
warning here would be invisible. Blocking is the only signal that works, and this
is a real at-risk case rather than the unrelated-tree noise #102 is about.

## Regression proof

The brief allowed either a harness or a manual demo. **I added a harness** —
`.claude/hooks/git-preflight.test.sh` (`.claude/hooks/` had no tests before).
It builds a throwaway repo plus a linked `git worktree` under `mktemp -d`, and
drives the hook with real `PreToolUse` payloads. Every case runs the hook with
its own `$PWD` set to the primary checkout, which is how Claude Code invokes it —
that detail is what makes the #102 cases discriminating.

No network, no live repo, self-cleaning via `trap`.

### Before / after — same harness, both hooks

```
$ git show origin/main:.claude/hooks/git-preflight.sh > /tmp/preflight-baseline/git-preflight.sh
$ cp .claude/hooks/git-preflight.test.sh /tmp/preflight-baseline/
$ bash /tmp/preflight-baseline/git-preflight.test.sh
...
10 passed, 9 failed          # EXIT=1

$ bash .claude/hooks/git-preflight.test.sh
...
19 passed, 0 failed          # EXIT=0
```

The exact #102 case, verbatim from the pre-fix run — primary dirty, linked
worktree clean, command run from the linked worktree:

```
FAIL #102 force-push from clean worktree: expected exit 0, got 2
BLOCKED (git-preflight): destructive git command with unpreserved changes.
At-risk changes this command would destroy:
 M tracked.txt              <- this file is in the PRIMARY checkout

FAIL #102 destructive in clean worktree: expected exit 0, got 2
BLOCKED (git-preflight): destructive git command with unpreserved changes.
At-risk changes this command would destroy:
 M tracked.txt              <- same; the linked worktree is clean
```

After the fix both are `ok ... (exit 0)`, and the linked worktree's *own* dirt
still blocks with `Tree inspected: <linked worktree>`.

The 9 pre-fix failures, by acceptance criterion:

| Pre-fix failure | Acceptance |
|---|---|
| `#102 force-push from clean worktree` | #1 — clean worktree not blocked by primary dirt |
| `#102 destructive in clean worktree` | #1 |
| `block message names the primary tree` | new: message must name the inspected tree |
| `block message names the linked worktree` | #2 — blocked, but for the wrong tree's dirt |
| `git -C targets the named dirty tree` | new: `-C` target is the tree at risk |
| `cd <dir> && targets that tree` | new |
| `force-push to a dirty worktree's branch` | #3 |
| `cross-worktree block names the linked worktree` | #3 |
| `clean -fd blocks on untracked` | pre-existing behaviour, now checked in the right tree |

Note `dirty linked worktree blocks` *passed* pre-fix — for the wrong reason (it
blocked on primary dirt). The paired `assert_mentions` is what catches that.

## Changed files

- `.claude/hooks/git-preflight.sh` — worktree resolution, `git -C` throughout,
  tree named in the block message, cross-worktree force-push check.
- `.claude/hooks/git-preflight.test.sh` — new, 19 assertions.

## Commands run

| Command | Result |
|---|---|
| `bash -n .claude/hooks/git-preflight.sh` | clean |
| `bash -n .claude/hooks/git-preflight.test.sh` | clean |
| `npx --yes shellcheck .claude/hooks/git-preflight.sh .claude/hooks/git-preflight.test.sh` | **exit 0, no findings** (shellcheck 0.11.0; not installed on this machine, fetched via npx) |
| `bash .claude/hooks/git-preflight.test.sh` | 19 passed, 0 failed |
| `bash /tmp/preflight-baseline/git-preflight.test.sh` (pre-fix hook) | 10 passed, **9 failed** |

The one shellcheck finding before I silenced it was `SC2016` on the embedded
python heredoc — expressions deliberately not expanded; suppressed with a
targeted `# shellcheck disable=SC2016` and a reason comment.

## Verified vs assumed

**Verified:** everything in the table above, plus the live hook firing on this
very PR's work (writing the test file tripped the guard on the primary tree's
own modification — the new message correctly printed
`Tree inspected: /home/gautam/dev/suchi-cancer-bot`).

**Assumed:** that Claude Code's `PreToolUse` payload carries a top-level `cwd`
holding the Bash tool's working directory. This is the documented hook-input
field, but I could not observe a payload from inside a worktree in this session.
If it were ever absent, resolution falls through to `$PWD` and the hook behaves
exactly as it does on `main` today — the fallback is the old code path, so the
worst case is "no improvement", never "no guard".

**Not changed:** `.claude/settings.json`. The `${CLAUDE_PROJECT_DIR}` prefix
there is only *locating* the script, which is correct — the bug was the tree the
script inspected, not the path it was loaded from.

## Human decisions required

None. One judgement call to flag: acceptance #3 is implemented as a **block**
rather than a warn, for the reason given above. Say the word and it becomes an
exit-0 advisory.

## Scope

No app code, no safety module, no prompts, no KB, no medical content. Nothing
staged from `docs/GROWTH_REACH_PLAN.md` or `apps/web/test-results/`.
