### PR TITLE
fix(eval): make the case manifest count what runs, not what parses (#89)

### DIFF
--- a/.github/workflows/eval-tier1.yml
+++ b/.github/workflows/eval-tier1.yml
@@ -101,10 +101,22 @@ jobs:
         working-directory: eval
         run: npm run test:ci
 
-      - name: Verify case manifest (disappearance guard)
+      - name: Eval framework unit tests
+        working-directory: eval
+        # `test:ci` above is `node --test ci/` — it runs the CI status helper
+        # only, so the jest suite under scripts/, runner/ and cases/ never ran
+        # anywhere (issue #89). That includes the lane guard PR #88 added and
+        # the journey-pattern pins from #70: guards nothing executes are not
+        # guards. No live API or judge credentials are needed — jest.config.js
+        # is unit-tests-only.
+        run: npm test
+
+      - name: Verify case manifest (disappearance + executability guard)
         working-directory: eval
         # Hard-fails if any eval case was removed without an explicit tombstone
-        # entry in cases/case-manifest.json (issue #48).
+        # entry in cases/case-manifest.json (issue #48), or if the number of
+        # cases a runner can actually EXECUTE drifts from what the manifest
+        # records (issue #89).
         run: npx ts-node scripts/case-manifest.ts check
 
       - name: Create reports directory

--- a/docs/RELIABILITY_BACKLOG.md
+++ b/docs/RELIABILITY_BACKLOG.md
@@ -516,4 +516,22 @@ more, and should be decided together with QA0904-1.
    schema (which requires deciding the pass criteria for symptom-worry and
    emergency journeys — SCCF medical review per AGENTS.md §1.3) or retire the
    file with a manifest tombstone. Until then, quote executable coverage as
-   592, not 601.
+   572, not 601 — see item 12; the case manifest now reports the figure
+   directly (`npm --prefix eval run cases:check`, issue #89).
+12. P1-11 (found 2026-09-09 while fixing #89): **20 gold-lane eval cases name
+   an intent `rubrics/rubrics.v1.json` does not define**, so
+   `Evaluator.getRubric` returns null and the run throws before scoring —
+   the same blocker as the journeys, in files that otherwise look runnable.
+   Verified against the shipped rubric pack: `RED_FLAGS_URGENT` → null,
+   `RED_FLAG_URGENT` → found. The unmapped intents are `RED_FLAGS_URGENT`
+   (10 cases, `generalinfo/general_info_100.yaml`), `NAVIGATION` (3),
+   `EMOTIONAL_SUPPORT` (3), `SIDE_EFFECTS_GENERAL` (2), `OUT_OF_SCOPE` (2),
+   across `gold/language_voice.yaml`, `gold/retrieval_grounding.yaml` and
+   `gold/ux_completeness.yaml`. Note the rubric lookup is **not**
+   canonicalised, although the `--intent` filter is
+   (`eval/utils/canonicalize.ts`), so a plural is a different intent.
+   Decision needed: add the missing rubrics, canonicalise the lookup, or
+   re-point the cases at existing intents. All three change what those cases
+   assert — including red-flag ones — so this is an eval-owner + SCCF call,
+   not an agent fix. Pinned by `eval/scripts/case-schema.test.ts` so the list
+   cannot grow silently.

--- a/eval/cases/case-manifest.json
+++ b/eval/cases/case-manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "generatedAt": "2026-07-05T08:16:59.853Z",
+  "version": 2,
+  "generatedAt": "2026-09-09T17:00:50.463Z",
   "totalCases": 601,
   "files": {
     "generalinfo/general_info_100.yaml": {
@@ -106,7 +106,15 @@
         "GI-PANCREAS-08",
         "GI-PANCREAS-09",
         "GI-PANCREAS-10"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 90,
+      "blockers": {
+        "missing-rubric": 10
+      },
+      "executable": false
     },
     "gold/core_safety.yaml": {
       "count": 15,
@@ -126,7 +134,12 @@
         "GOLD-SAFETY-13",
         "GOLD-SAFETY-14",
         "GOLD-SAFETY-15"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 15,
+      "executable": true
     },
     "gold/hospital_navigation.yaml": {
       "count": 5,
@@ -136,7 +149,12 @@
         "GOLD-HN-03",
         "GOLD-HN-04",
         "GOLD-HN-05"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 5,
+      "executable": true
     },
     "gold/language_voice.yaml": {
       "count": 15,
@@ -156,7 +174,15 @@
         "GOLD-LANG-13",
         "GOLD-LANG-14",
         "GOLD-LANG-15"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 13,
+      "blockers": {
+        "missing-rubric": 2
+      },
+      "executable": false
     },
     "gold/retrieval_grounding.yaml": {
       "count": 20,
@@ -181,7 +207,15 @@
         "GOLD-RAG-18",
         "GOLD-RAG-19",
         "GOLD-RAG-20"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 17,
+      "blockers": {
+        "missing-rubric": 3
+      },
+      "executable": false
     },
     "gold/ux_completeness.yaml": {
       "count": 20,
@@ -206,19 +240,37 @@
         "GOLD-UX-18",
         "GOLD-UX-19",
         "GOLD-UX-20"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 15,
+      "blockers": {
+        "missing-rubric": 5
+      },
+      "executable": false
     },
     "regression/p0_2026_03_26_zero_citation_stomach.yaml": {
       "count": 1,
       "caseIds": [
         "REG-P0-20260326-STOMACH-ZERO-CITATION-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 1,
+      "executable": true
     },
     "regression/p0_2026_07_05_lung_retrieval_miss.yaml": {
       "count": 1,
       "caseIds": [
         "REG-P0-20260705-LUNG-RETRIEVAL-MISS-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 1,
+      "executable": true
     },
     "tier1.5/sub_intent_precision.yaml": {
       "count": 21,
@@ -244,7 +296,12 @@
         "SIP-NEGATIVE-02",
         "SIP-VOICE-MESSY-01",
         "SIP-VOICE-MESSY-02"
-      ]
+      ],
+      "lanes": [
+        "voice"
+      ],
+      "executableCases": 21,
+      "executable": true
     },
     "tier1/common_cancers_20_mode_matrix.yaml": {
       "count": 100,
@@ -349,7 +406,12 @@
         "SUCHI-T1-LARYNX-CAREGIVER-01",
         "SUCHI-T1-LARYNX-POST-01",
         "SUCHI-T1-LARYNX-URGENT-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 100,
+      "executable": true
     },
     "tier1/hospital_navigation.yaml": {
       "count": 5,
@@ -359,7 +421,12 @@
         "HN-COMPARE-01",
         "HN-MUZAFFARPUR-01",
         "HN-KOLKATA-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 5,
+      "executable": true
     },
     "tier1/phase2_journeys.yaml": {
       "count": 9,
@@ -373,7 +440,16 @@
         "journey_caregiver_stress_crisis_001",
         "journey_emergency_001",
         "journey_emergency_002"
-      ]
+      ],
+      "lanes": [
+        "orphan"
+      ],
+      "executableCases": 0,
+      "blockers": {
+        "orphan-schema": 9
+      },
+      "executable": false,
+      "unexecutableReason": "issues #71, #89 — bespoke userText/expectedBehavior schema; also uses PERSONAL_SYMPTOMS/EMERGENCY intents that rubrics.v1.json does not define. Porting requires SCCF review of the intent mapping and pass criteria (AGENTS.md §1.3)."
     },
     "tier1/retrieval_quality.yaml": {
       "count": 21,
@@ -399,7 +475,12 @@
         "RQ-THYROID-01",
         "RQ-KIDNEY-01",
         "RQ-BLADDER-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 21,
+      "executable": true
     },
     "tier1/retrieval_quality_batch2.yaml": {
       "count": 3,
@@ -407,7 +488,12 @@
         "RQ-COLORECTAL-01",
         "RQ-PROSTATE-01",
         "RQ-CERVICAL-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 3,
+      "executable": true
     },
     "tier1/retrieval_quality_batch_a.yaml": {
       "count": 7,
@@ -419,7 +505,12 @@
         "RQ-CERVICAL-01",
         "RQ-OVARIAN-01",
         "RQ-ORAL-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 7,
+      "executable": true
     },
     "tier1/retrieval_quality_batch_b.yaml": {
       "count": 7,
@@ -431,7 +522,12 @@
         "RQ-LUNG-02",
         "RQ-COLORECTAL-02",
         "RQ-PROSTATE-02"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 7,
+      "executable": true
     },
     "tier1/retrieval_quality_batch_c.yaml": {
       "count": 7,
@@ -443,7 +539,12 @@
         "RQ-THYROID-01",
         "RQ-KIDNEY-01",
         "RQ-BLADDER-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 7,
+      "executable": true
     },
     "tier1/retrieval_quality_sample.yaml": {
       "count": 3,
@@ -451,7 +552,12 @@
         "RQ-BREAST-01",
         "RQ-LUNG-01",
         "RQ-ORAL-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 3,
+      "executable": true
     },
     "tier1/smoke_test_3_cases.yaml": {
       "count": 3,
@@ -459,7 +565,12 @@
         "SMOKE-LUNG-GEN-01",
         "SMOKE-BREAST-PATIENT-01",
         "SMOKE-URGENT-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 3,
+      "executable": true
     },
     "tier1/zero_citation_regression.yaml": {
       "count": 4,
@@ -468,7 +579,12 @@
         "SUCHI-T1-CERVICAL-CAREGIVER-01",
         "SUCHI-T1-CERVICAL-POST-01",
         "SUCHI-T1-CERVICAL-URGENT-01"
-      ]
+      ],
+      "lanes": [
+        "gold"
+      ],
+      "executableCases": 4,
+      "executable": true
     },
     "tier2/authentic_indian_queries.yaml": {
       "count": 40,
@@ -513,7 +629,12 @@
         "AUTH-GREET-02",
         "AUTH-GREET-03",
         "AUTH-GREET-04"
-      ]
+      ],
+      "lanes": [
+        "voice"
+      ],
+      "executableCases": 40,
+      "executable": true
     },
     "tier2/generated.yaml": {
       "count": 150,
@@ -668,7 +789,12 @@
         "DYN-BREAS-ENGLISH-POSTDI-148",
         "DYN-LUNG-EMOTIONAL-POSTDI-149",
         "DYN-OVARI-CASUAL-SYMPTO-150"
-      ]
+      ],
+      "lanes": [
+        "voice"
+      ],
+      "executableCases": 150,
+      "executable": true
     },
     "tier2/multi_turn_journeys.yaml": {
       "count": 28,
@@ -701,7 +827,12 @@
         "JOURNEY-EMOTIONAL-TREATMENT-03",
         "JOURNEY-EMOTIONAL-TREATMENT-04",
         "JOURNEY-EMOTIONAL-TREATMENT-05"
-      ]
+      ],
+      "lanes": [
+        "voice"
+      ],
+      "executableCases": 28,
+      "executable": true
     },
     "voice/voice_e2e_cases.yaml": {
       "count": 6,
@@ -712,7 +843,12 @@
         "VOICE-HINGLISH-01",
         "VOICE-SHORT-01",
         "VOICE-MISPRONOUNCED-01"
-      ]
+      ],
+      "lanes": [
+        "voice-e2e"
+      ],
+      "executableCases": 6,
+      "executable": true
     },
     "voice/voice_transcript_cancer_queries.yaml": {
       "count": 10,
@@ -727,8 +863,19 @@
         "VT-PROSTATE-POSTDX-01",
         "VT-CHEMO-SIDE-01",
         "VT-HINDI-ORAL-01"
-      ]
+      ],
+      "lanes": [
+        "voice"
+      ],
+      "executableCases": 10,
+      "executable": true
     }
   },
-  "tombstones": []
+  "tombstones": [],
+  "executableCases": 572,
+  "unexecutableCases": 29,
+  "blockers": {
+    "missing-rubric": 20,
+    "orphan-schema": 9
+  }
 }

--- a/eval/cases/tier1/phase2_journeys.yaml
+++ b/eval/cases/tier1/phase2_journeys.yaml
@@ -17,10 +17,17 @@
 #      `apps/api/src/modules/chat/intent-classifier.ts`; the API's red-flag path
 #      is the safety module, not an intent.)
 #
-# Its 9 case IDs are nonetheless counted by the case-manifest guard, so the
-# headline "601 cases" overstates executable coverage by 9. The lane
-# classification is pinned by `eval/scripts/case-schema.test.ts`, which fails if
-# any NEW case file arrives with a schema no runner reads.
+# Its 9 case IDs are nonetheless PRESENT in the suite, so a headline of "601
+# cases" overstates executable coverage. Since issue #89 the case manifest
+# reports both numbers — 601 present, 572 executable — and marks this file
+# `"executable": false` with the reason, so the 9 can no longer read as
+# coverage. (The other 20 blocked cases are a separate defect: gold-lane cases
+# naming an intent `rubrics.v1.json` does not define. See
+# docs/RELIABILITY_BACKLOG.md item 12.) The lane classification lives in
+# `eval/scripts/case-lanes.ts` and is pinned by
+# `eval/scripts/case-schema.test.ts`, which fails if any NEW case file arrives
+# with a schema no runner reads, and if this file is ported without the
+# quarantine entry being cleared.
 #
 # The `mode:` key below (navigate/explain) is descriptive only — it is NOT a
 # request field. `runner/api-client.ts` posts `{sessionId, channel, userText}`,

--- a/eval/scripts/case-lanes.ts
+++ b/eval/scripts/case-lanes.ts
@@ -1,0 +1,223 @@
+/**
+ * Runner-lane classification for eval case files (issues #71, #89).
+ *
+ * A case file is only coverage if some runner can execute it. Until now that
+ * was decided in two places — `scripts/case-schema.test.ts` had its own copy of
+ * the lane rules, and `scripts/case-manifest.ts` had none at all and counted
+ * every case it could parse. That is how `cases/tier1/phase2_journeys.yaml`
+ * (9 cases, in a bespoke schema no runner reads) came to be counted inside a
+ * headline of 601 when only 592 can run.
+ *
+ * The lane rules live here, once, so the manifest and the lane guard cannot
+ * disagree about what "executable" means.
+ *
+ * Lanes
+ * -----
+ *  - "gold"     : `user_messages: string[]` — read by `runner/evaluator.ts`
+ *                 (`executeConversation(sessionId, testCase.user_messages, …)`).
+ *  - "voice"    : `voice_input: string` — read by `runner/voice-transcript-eval.ts`.
+ *  - "voice-e2e": `expectedTranscript: string` — synthetic voice cases.
+ *  - "orphan"   : none of the above. No runner reads it; it is NOT coverage.
+ *
+ * A lane is a statement about the *schema*, not about whether a case would
+ * pass. Nothing here reads, weighs or rewrites an expectation.
+ *
+ * Second blocker: the rubric
+ * --------------------------
+ * A readable schema is necessary but not sufficient. `runner/evaluator.ts` does
+ *
+ *     const rubric = this.getRubric(testCase.intent);
+ *     if (!rubric) throw new Error(`No rubric found for intent: ...`);
+ *
+ * and `getRubric` is a plain lookup in `rubrics.v1.json` — the intent filter is
+ * canonicalised (`utils/canonicalize.ts`) but the rubric lookup is NOT. So a
+ * gold-lane case naming an intent the pack does not define aborts before any
+ * scoring. That is the same defect as the journeys' missing PERSONAL_SYMPTOMS /
+ * EMERGENCY rubrics, just in files that otherwise look runnable, so both
+ * blockers are counted here rather than only the one issue #89 opened on.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+
+export type Lane = "gold" | "voice" | "voice-e2e" | "orphan";
+
+/** A lane whose runner exists. Everything else is not executable. */
+export const EXECUTABLE_LANES: ReadonlySet<Lane> = new Set<Lane>([
+  "gold",
+  "voice",
+  "voice-e2e",
+]);
+
+/**
+ * Case files known to be unrunnable, with the issue tracking the port.
+ *
+ * Adding an entry is a deliberate, reviewable act: it does not make the file
+ * run, it records that we know it does not. `case-schema.test.ts` fails if an
+ * entry goes stale (the file was ported) or if a new orphan appears without one.
+ */
+export const KNOWN_UNRUNNABLE: Record<string, string> = {
+  "tier1/phase2_journeys.yaml":
+    "issues #71, #89 — bespoke userText/expectedBehavior schema; also uses PERSONAL_SYMPTOMS/EMERGENCY intents that rubrics.v1.json does not define. Porting requires SCCF review of the intent mapping and pass criteria (AGENTS.md §1.3).",
+};
+
+/** Classify one case object by the runner that would consume it. */
+export function laneOf(testCase: Record<string, unknown>): Lane {
+  if (Array.isArray(testCase.user_messages)) return "gold";
+  if (typeof testCase.voice_input === "string") return "voice";
+  if (typeof testCase.expectedTranscript === "string") return "voice-e2e";
+  return "orphan";
+}
+
+export function isExecutableLane(lane: Lane): boolean {
+  return EXECUTABLE_LANES.has(lane);
+}
+
+/** Why a case cannot be executed. */
+export type Blocker = "orphan-schema" | "missing-rubric";
+
+export interface FileLanes {
+  /** Number of cases in the file. */
+  count: number;
+  /** Every distinct lane present in the file, sorted for stable output. */
+  lanes: Lane[];
+  /** Cases in this file a runner can actually execute. */
+  executableCases: number;
+  /** Case counts per blocker, present only when non-zero. */
+  blockers?: Partial<Record<Blocker, number>>;
+  /** True when every case in the file is executable. */
+  executable: boolean;
+}
+
+/**
+ * Intents defined by the rubric pack. Read once and passed in, so this module
+ * stays a pure classifier with no opinion about where rubrics live.
+ */
+export function loadRubricIntents(rubricsPath: string): Set<string> {
+  const pack = JSON.parse(fs.readFileSync(rubricsPath, "utf-8"));
+  return new Set(Object.keys(pack?.rubrics ?? {}));
+}
+
+export const DEFAULT_RUBRICS_PATH = path.join(
+  __dirname,
+  "..",
+  "rubrics",
+  "rubrics.v1.json",
+);
+
+/**
+ * The blocker stopping a case from executing, or null if nothing does.
+ *
+ * `rubricIntents` is optional: when it is not supplied only the schema gate is
+ * applied, which is what a caller inspecting an arbitrary fixture directory
+ * wants.
+ */
+export function blockerFor(
+  testCase: Record<string, unknown>,
+  rubricIntents?: ReadonlySet<string>,
+): Blocker | null {
+  const lane = laneOf(testCase);
+  if (!isExecutableLane(lane)) return "orphan-schema";
+  // Only the gold lane goes through `Evaluator.getRubric`; the voice lanes use
+  // their own rubric pack and checks.
+  if (lane === "gold" && rubricIntents && !rubricIntents.has(String(testCase.intent))) {
+    return "missing-rubric";
+  }
+  return null;
+}
+
+function listYamlFiles(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (d: string) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (/\.ya?ml$/i.test(entry.name)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out.sort();
+}
+
+/**
+ * Scan a cases directory and classify each suite file by lane.
+ *
+ * Files without a `cases:` array are skipped — templates and scratch YAML, the
+ * same files the manifest scanner skips.
+ */
+export function scanLanes(
+  casesDir: string,
+  rubricIntents?: ReadonlySet<string>,
+): Record<string, FileLanes> {
+  const result: Record<string, FileLanes> = {};
+  for (const file of listYamlFiles(casesDir)) {
+    let parsed: any;
+    try {
+      parsed = yaml.load(fs.readFileSync(file, "utf-8"));
+    } catch (err: any) {
+      throw new Error(`Failed to parse ${file}: ${err.message}`);
+    }
+    if (!parsed || !Array.isArray(parsed.cases)) continue;
+
+    const cases: Record<string, unknown>[] = (parsed.cases as unknown[]).filter(
+      (c): c is Record<string, unknown> => !!c && typeof c === "object",
+    );
+    const lanes: Lane[] = [...new Set(cases.map(laneOf))].sort();
+
+    const blockers: Partial<Record<Blocker, number>> = {};
+    let executableCases = 0;
+    for (const c of cases) {
+      const blocker = blockerFor(c, rubricIntents);
+      if (blocker) blockers[blocker] = (blockers[blocker] ?? 0) + 1;
+      else executableCases++;
+    }
+
+    const rel = path.relative(casesDir, file).split(path.sep).join("/");
+    result[rel] = {
+      count: cases.length,
+      lanes,
+      executableCases,
+      ...(Object.keys(blockers).length > 0 && { blockers }),
+      executable: cases.length > 0 && executableCases === cases.length,
+    };
+  }
+  return result;
+}
+
+export interface ExecutabilitySummary {
+  /** Cases present in the suite — what the old headline counted. */
+  total: number;
+  /** Cases a runner can actually execute. */
+  executable: number;
+  /** Cases present but executed by nothing. */
+  unexecutable: number;
+  /** `unexecutable` broken down by cause. */
+  blockers: Partial<Record<Blocker, number>>;
+  /** Files containing at least one unexecutable case, sorted. */
+  unexecutableFiles: string[];
+}
+
+export function summariseExecutability(
+  lanes: Record<string, FileLanes>,
+): ExecutabilitySummary {
+  let total = 0;
+  let executable = 0;
+  const blockers: Partial<Record<Blocker, number>> = {};
+  const unexecutableFiles: string[] = [];
+  for (const [file, entry] of Object.entries(lanes)) {
+    total += entry.count;
+    executable += entry.executableCases;
+    for (const [blocker, n] of Object.entries(entry.blockers ?? {})) {
+      blockers[blocker as Blocker] = (blockers[blocker as Blocker] ?? 0) + n;
+    }
+    if (entry.executableCases < entry.count) unexecutableFiles.push(file);
+  }
+  return {
+    total,
+    executable,
+    unexecutable: total - executable,
+    blockers,
+    unexecutableFiles: unexecutableFiles.sort(),
+  };
+}

--- a/eval/scripts/case-manifest.test.ts
+++ b/eval/scripts/case-manifest.test.ts
@@ -12,6 +12,7 @@ import {
   updateManifest,
   runCli,
 } from "./case-manifest";
+import { scanLanes, summariseExecutability } from "./case-lanes";
 
 let tmpDir: string;
 
@@ -180,5 +181,186 @@ describe("runCli", () => {
       ])
     ).toBe(0);
     expect(runCli(["check", "--cases-dir", tmpDir])).toBe(0);
+  });
+});
+
+/**
+ * Issue #89 — the manifest counted every case it could PARSE, which is not the
+ * same as every case a runner can EXECUTE. `tier1/phase2_journeys.yaml` is 9
+ * cases in a schema no runner reads, and the headline said 601.
+ *
+ * A file is "orphan" when it has none of `user_messages` / `voice_input` /
+ * `expectedTranscript` — the three shapes the runners consume.
+ */
+describe("executability tracking (#89)", () => {
+  /** Same shape as phase2_journeys.yaml: no field any runner reads. */
+  const ORPHAN_SUITE = `cases:
+  - id: CASE-ORPHAN-01
+    userText: "a question"
+    expectedBehavior:
+      mustContain: ["doctor"]
+  - id: CASE-ORPHAN-02
+    userText: "another question"
+    expectedBehavior:
+      mustContain: ["doctor"]
+`;
+
+  function writeOrphanSuite() {
+    fs.writeFileSync(path.join(tmpDir, "tier1", "orphan_suite.yaml"), ORPHAN_SUITE);
+  }
+
+  it("classifies runnable and orphan suites, and counts them apart", () => {
+    writeOrphanSuite();
+    const lanes = scanLanes(tmpDir);
+
+    expect(lanes["tier1/suite_a.yaml"]).toEqual({
+      count: 2,
+      lanes: ["gold"],
+      executableCases: 2,
+      executable: true,
+    });
+    expect(lanes["tier1/orphan_suite.yaml"]).toEqual({
+      count: 2,
+      lanes: ["orphan"],
+      executableCases: 0,
+      blockers: { "orphan-schema": 2 },
+      executable: false,
+    });
+
+    expect(summariseExecutability(lanes)).toEqual({
+      total: 5,
+      executable: 3,
+      unexecutable: 2,
+      blockers: { "orphan-schema": 2 },
+      unexecutableFiles: ["tier1/orphan_suite.yaml"],
+    });
+  });
+
+  it("counts a gold case whose intent has no rubric as NOT executable", () => {
+    // `Evaluator.getRubric` is a plain lookup and throws when the intent is
+    // absent, so a readable schema alone is not enough to make a case run.
+    // The rubric lookup is not canonicalised, so RED_FLAGS_URGENT (plural) is
+    // a different, undefined intent from RED_FLAG_URGENT.
+    const rubricIntents = new Set(["INFORMATIONAL_GENERAL"]);
+    const lanes = scanLanes(tmpDir, rubricIntents);
+
+    expect(lanes["tier1/suite_a.yaml"].executableCases).toBe(2); // both INFORMATIONAL_GENERAL
+    expect(lanes["suite_b.yaml"]).toMatchObject({
+      count: 1,
+      lanes: ["gold"], // schema is fine …
+      executableCases: 0, // … but RED_FLAG_URGENT has no rubric here
+      blockers: { "missing-rubric": 1 },
+      executable: false,
+    });
+
+    const summary = summariseExecutability(lanes);
+    expect(summary.executable).toBe(2);
+    expect(summary.blockers).toEqual({ "missing-rubric": 1 });
+  });
+
+  it("counts a file with a mix of blocked and runnable cases per case, not per file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "tier1", "suite_a.yaml"),
+      SUITE_A + `  - id: CASE-A-03
+    tier: 1
+    cancer: oral
+    intent: NO_SUCH_INTENT
+    user_messages: ["q4"]
+    expectations: {}
+`,
+    );
+    const lanes = scanLanes(tmpDir, new Set(["INFORMATIONAL_GENERAL", "RED_FLAG_URGENT"]));
+
+    // The file is not executable as a whole, but 2 of its 3 cases still are —
+    // marking all 3 unexecutable would understate coverage as badly as the old
+    // count overstated it.
+    expect(lanes["tier1/suite_a.yaml"]).toMatchObject({
+      count: 3,
+      executableCases: 2,
+      executable: false,
+      blockers: { "missing-rubric": 1 },
+    });
+    expect(summariseExecutability(lanes).executable).toBe(3);
+  });
+
+  it("records both counts in the manifest, not just the present count", () => {
+    writeOrphanSuite();
+    const manifest = buildManifest(scanCases(tmpDir), [], scanLanes(tmpDir));
+
+    expect(manifest.version).toBe(2);
+    expect(manifest.totalCases).toBe(5);
+    expect(manifest.executableCases).toBe(3);
+    expect(manifest.unexecutableCases).toBe(2);
+    expect(manifest.files["tier1/orphan_suite.yaml"].executable).toBe(false);
+    expect(manifest.files["tier1/suite_a.yaml"].executable).toBe(true);
+  });
+
+  it("fails the check when a suite silently stops being executable", () => {
+    // The regression this guard exists for: a suite is edited into a schema no
+    // runner reads. Case IDs all still present, so every pre-#89 check passes
+    // and the headline count does not move — while real coverage drops.
+    const scanned = scanCases(tmpDir);
+    const manifest = buildManifest(scanned, [], scanLanes(tmpDir));
+    expect(manifest.executableCases).toBe(3);
+
+    fs.writeFileSync(
+      path.join(tmpDir, "tier1", "suite_a.yaml"),
+      SUITE_A.replace(/user_messages: \["q\d"\]/g, 'userText: "q"'),
+    );
+
+    const after = checkManifest(manifest, scanCases(tmpDir), scanLanes(tmpDir));
+
+    expect(after.ok).toBe(false);
+    expect(after.errors.join("\n")).toMatch(/changed executability/);
+    expect(after.errors.join("\n")).toMatch(/Executable case count changed/);
+  });
+
+  it("fails the check when an orphan suite is ported, so the gain is recorded", () => {
+    writeOrphanSuite();
+    const manifest = buildManifest(scanCases(tmpDir), [], scanLanes(tmpDir));
+
+    // The port that issue #89 asks for, once SCCF has approved the criteria.
+    fs.writeFileSync(
+      path.join(tmpDir, "tier1", "orphan_suite.yaml"),
+      ORPHAN_SUITE.replace(/userText: "([^"]+)"/g, 'user_messages: ["$1"]'),
+    );
+
+    const after = checkManifest(manifest, scanCases(tmpDir), scanLanes(tmpDir));
+
+    expect(after.ok).toBe(false);
+    expect(after.executableCases).toBe(5);
+  });
+
+  it("warns, without failing, that a known-orphan file is not coverage", () => {
+    writeOrphanSuite();
+    const lanes = scanLanes(tmpDir);
+    const manifest = buildManifest(scanCases(tmpDir), [], lanes);
+
+    const result = checkManifest(manifest, scanCases(tmpDir), lanes);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(
+      /"tier1\/orphan_suite\.yaml": 2 of 2 cases are counted but cannot be executed \(2 orphan-schema\)/,
+    );
+  });
+
+  it("warns when a pre-#89 manifest cannot say how many cases run", () => {
+    const scanned = scanCases(tmpDir);
+    const v1 = buildManifest(scanned); // no lanes — the old shape
+    expect(v1.version).toBe(1);
+    expect(v1.executableCases).toBeUndefined();
+
+    const result = checkManifest(v1, scanned, scanLanes(tmpDir));
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(/predates executability tracking/);
+  });
+
+  it("keeps working for callers that pass no lanes at all", () => {
+    const scanned = scanCases(tmpDir);
+    const result = checkManifest(buildManifest(scanned), scanned);
+
+    expect(result.ok).toBe(true);
+    expect(result.executableCases).toBeUndefined();
   });
 });

--- a/eval/scripts/case-manifest.ts
+++ b/eval/scripts/case-manifest.ts
@@ -10,6 +10,14 @@
  *   - new cases/files exist that the manifest does not know about
  *     (forces a deliberate `--update` so the inventory stays current).
  *
+ * Issue #89: the manifest also records which cases are EXECUTABLE. Counting a
+ * file no runner reads is how `cases/tier1/phase2_journeys.yaml` (9 cases,
+ * including caregiver-crisis and emergency journeys) sat inside a headline of
+ * 601 while only 592 could run. The manifest now carries both numbers, and the
+ * check fails if a file's executability changes without the inventory being
+ * updated — so a port, or a regression into an unreadable schema, is a
+ * deliberate act rather than a silent shift in the coverage headline.
+ *
  * Removing a case requires an explicit tombstone:
  *
  *   npx ts-node scripts/case-manifest.ts update \
@@ -23,6 +31,16 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
+import {
+  Blocker,
+  DEFAULT_RUBRICS_PATH,
+  FileLanes,
+  KNOWN_UNRUNNABLE,
+  Lane,
+  loadRubricIntents,
+  scanLanes,
+  summariseExecutability,
+} from "./case-lanes";
 
 export interface Tombstone {
   caseId: string;
@@ -31,11 +49,33 @@ export interface Tombstone {
   reason: string;
 }
 
+export interface ManifestFileEntry {
+  count: number;
+  caseIds: string[];
+  /** Runner lanes present in the file (issue #89). Absent in v1 manifests. */
+  lanes?: Lane[];
+  /** Cases in this file a runner can execute. Absent in v1 manifests. */
+  executableCases?: number;
+  /** Unexecutable case counts by cause. Absent when there are none. */
+  blockers?: Partial<Record<Blocker, number>>;
+  /** Whether EVERY case in this file is executable. Absent in v1 manifests. */
+  executable?: boolean;
+  /** Why it cannot be executed, when that is recorded in `KNOWN_UNRUNNABLE`. */
+  unexecutableReason?: string;
+}
+
 export interface CaseManifest {
   version: number;
   generatedAt: string;
+  /** Cases PRESENT in the suite. Not the same thing as coverage. */
   totalCases: number;
-  files: Record<string, { count: number; caseIds: string[] }>;
+  /** Cases a runner can execute (issue #89). Absent in v1 manifests. */
+  executableCases?: number;
+  /** Cases present but executed by nothing (issue #89). */
+  unexecutableCases?: number;
+  /** `unexecutableCases` broken down by cause. */
+  blockers?: Partial<Record<Blocker, number>>;
+  files: Record<string, ManifestFileEntry>;
   tombstones: Tombstone[];
 }
 
@@ -45,6 +85,8 @@ export interface ManifestCheckResult {
   warnings: string[];
   scannedFiles: number;
   scannedCases: number;
+  /** Cases a runner can execute in the current scan, when lanes were supplied. */
+  executableCases?: number;
 }
 
 const MANIFEST_FILENAME = "case-manifest.json";
@@ -89,28 +131,59 @@ export function scanCases(casesDir: string): Record<string, string[]> {
 
 // ── Manifest build / check ───────────────────────────────────────────────────
 
+/**
+ * Build a manifest from a scan.
+ *
+ * `lanes` is optional so a caller that only cares about case IDs (the original
+ * v1 behaviour) still works. When it is supplied the manifest records
+ * executability per file and in the totals — that is the honest headline
+ * issue #89 asks for.
+ */
 export function buildManifest(
   scanned: Record<string, string[]>,
-  tombstones: Tombstone[] = []
+  tombstones: Tombstone[] = [],
+  lanes?: Record<string, FileLanes>
 ): CaseManifest {
   const files: CaseManifest["files"] = {};
   let total = 0;
   for (const [file, caseIds] of Object.entries(scanned).sort()) {
-    files[file] = { count: caseIds.length, caseIds };
+    const entry: ManifestFileEntry = { count: caseIds.length, caseIds };
+    const laneInfo = lanes?.[file];
+    if (laneInfo) {
+      entry.lanes = laneInfo.lanes;
+      entry.executableCases = laneInfo.executableCases;
+      if (laneInfo.blockers) entry.blockers = laneInfo.blockers;
+      entry.executable = laneInfo.executable;
+      if (!laneInfo.executable && KNOWN_UNRUNNABLE[file]) {
+        entry.unexecutableReason = KNOWN_UNRUNNABLE[file];
+      }
+    }
+    files[file] = entry;
     total += caseIds.length;
   }
-  return {
-    version: 1,
+
+  const manifest: CaseManifest = {
+    version: lanes ? 2 : 1,
     generatedAt: new Date().toISOString(),
     totalCases: total,
     files,
     tombstones,
   };
+
+  if (lanes) {
+    const summary = summariseExecutability(lanes);
+    manifest.executableCases = summary.executable;
+    manifest.unexecutableCases = summary.unexecutable;
+    if (Object.keys(summary.blockers).length > 0) manifest.blockers = summary.blockers;
+  }
+
+  return manifest;
 }
 
 export function checkManifest(
   manifest: CaseManifest,
-  scanned: Record<string, string[]>
+  scanned: Record<string, string[]>,
+  lanes?: Record<string, FileLanes>
 ): ManifestCheckResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -169,6 +242,60 @@ export function checkManifest(
     }
   }
 
+  // 4. Executability must not drift (issue #89).
+  //
+  // A file that stops being executable silently shrinks real coverage while the
+  // headline stays put; a file that BECOMES executable (a port landed) must
+  // update the inventory so the number goes up on purpose. Either way the
+  // change has to be acknowledged, which is the whole point of the guard.
+  let executableCases: number | undefined;
+  if (lanes) {
+    const summary = summariseExecutability(lanes);
+    executableCases = summary.executable;
+
+    for (const [file, laneInfo] of Object.entries(lanes)) {
+      const entry = manifest.files[file];
+      // A file missing from the manifest is already reported by check 2.
+      if (!entry || entry.executableCases === undefined) continue;
+      if (entry.executableCases !== laneInfo.executableCases) {
+        errors.push(
+          `Case file "${file}" changed executability: manifest records ${entry.executableCases} of ${entry.count} executable, ` +
+            `the scan finds ${laneInfo.executableCases} of ${laneInfo.count} (lanes: ${laneInfo.lanes.join(", ")}). ` +
+            `Run: ts-node scripts/case-manifest.ts update`
+        );
+      }
+    }
+
+    if (
+      manifest.executableCases !== undefined &&
+      manifest.executableCases !== summary.executable
+    ) {
+      errors.push(
+        `Executable case count changed: manifest records ${manifest.executableCases}, scan finds ${summary.executable} ` +
+          `(of ${summary.total} present). Run: ts-node scripts/case-manifest.ts update`
+      );
+    }
+
+    if (manifest.executableCases === undefined) {
+      warnings.push(
+        `Manifest predates executability tracking (issue #89) — it counts ${manifest.totalCases} cases but does not say how many run. ` +
+          `Run: ts-node scripts/case-manifest.ts update`
+      );
+    }
+
+    for (const file of summary.unexecutableFiles) {
+      const info = lanes[file];
+      const blocked = info.count - info.executableCases;
+      const why = Object.entries(info.blockers ?? {})
+        .map(([b, n]) => `${n} ${b}`)
+        .join(", ");
+      warnings.push(
+        `Case file "${file}": ${blocked} of ${info.count} cases are counted but cannot be executed (${why})` +
+          (KNOWN_UNRUNNABLE[file] ? ` — ${KNOWN_UNRUNNABLE[file]}` : "")
+      );
+    }
+  }
+
   const scannedCases = Object.values(scanned).reduce((s, ids) => s + ids.length, 0);
   return {
     ok: errors.length === 0,
@@ -176,6 +303,7 @@ export function checkManifest(
     warnings,
     scannedFiles: Object.keys(scanned).length,
     scannedCases,
+    ...(executableCases !== undefined && { executableCases }),
   };
 }
 
@@ -187,7 +315,8 @@ export function checkManifest(
 export function updateManifest(
   previous: CaseManifest | null,
   scanned: Record<string, string[]>,
-  newTombstones: Array<{ caseId: string; reason: string }> = []
+  newTombstones: Array<{ caseId: string; reason: string }> = [],
+  lanes?: Record<string, FileLanes>
 ): CaseManifest {
   const now = new Date().toISOString();
   const scannedIds = new Set(Object.values(scanned).flat());
@@ -234,7 +363,7 @@ export function updateManifest(
     );
   }
 
-  return buildManifest(scanned, [...keptTombstones, ...addedTombstones]);
+  return buildManifest(scanned, [...keptTombstones, ...addedTombstones], lanes);
 }
 
 // ── File IO helpers ──────────────────────────────────────────────────────────
@@ -285,14 +414,25 @@ function parseArgs(argv: string[]): {
 export function runCli(argv: string[]): number {
   const { command, casesDir, tombstones } = parseArgs(argv);
   const scanned = scanCases(casesDir);
+  // The rubric pack is the same one `cli.ts` defaults to; a case naming an
+  // intent it does not define cannot be executed (issue #89).
+  const rubricIntents = fs.existsSync(DEFAULT_RUBRICS_PATH)
+    ? loadRubricIntents(DEFAULT_RUBRICS_PATH)
+    : undefined;
+  const lanes = scanLanes(casesDir, rubricIntents);
 
   if (command === "update") {
     const previous = loadManifest(casesDir);
-    const manifest = updateManifest(previous, scanned, tombstones);
+    const manifest = updateManifest(previous, scanned, tombstones, lanes);
     saveManifest(casesDir, manifest);
+    const blockers = Object.entries(manifest.blockers ?? {})
+      .map(([b, n]) => `${n} ${b}`)
+      .join(", ");
     console.log(
-      `✅ Manifest updated: ${manifest.totalCases} cases in ${Object.keys(manifest.files).length} files, ` +
-        `${manifest.tombstones.length} tombstone(s).`
+      `✅ Manifest updated: ${manifest.executableCases} executable of ${manifest.totalCases} cases present ` +
+        `in ${Object.keys(manifest.files).length} files` +
+        (blockers ? ` — ${manifest.unexecutableCases} blocked (${blockers})` : "") +
+        `, ${manifest.tombstones.length} tombstone(s).`
     );
     return 0;
   }
@@ -305,16 +445,19 @@ export function runCli(argv: string[]): number {
       );
       return 1;
     }
-    const result = checkManifest(manifest, scanned);
+    const result = checkManifest(manifest, scanned, lanes);
     for (const w of result.warnings) console.warn(`⚠️  ${w}`);
     if (!result.ok) {
       console.error(`❌ Case manifest check FAILED (${result.errors.length} error(s)):`);
       for (const e of result.errors) console.error(`   - ${e}`);
       return 1;
     }
+    // The executable count leads. "601 cases" was the number that misled;
+    // "592 executable of 601 present" is the one that cannot (issue #89).
+    const summary = summariseExecutability(lanes);
     console.log(
-      `✅ Case manifest OK: ${result.scannedCases} cases across ${result.scannedFiles} files match the manifest ` +
-        `(${manifest.tombstones.length} tombstone(s)).`
+      `✅ Case manifest OK: ${summary.executable} executable of ${result.scannedCases} cases present ` +
+        `across ${result.scannedFiles} files (${manifest.tombstones.length} tombstone(s)).`
     );
     return 0;
   }

--- a/eval/scripts/case-schema.test.ts
+++ b/eval/scripts/case-schema.test.ts
@@ -13,92 +13,38 @@
  * the orphan is listed by name, with its issue, so it stays visible until it is
  * either ported to a runnable schema or removed with a tombstone.
  *
- * Lanes
- * -----
- *  - "gold"  : `user_messages: string[]` — read by `runner/evaluator.ts`
- *              (`executeConversation(sessionId, testCase.user_messages, ...)`).
- *  - "voice" : `voice_input: string` — read by `runner/voice-transcript-eval.ts`.
- *  - "voice-e2e": `expectedTranscript` — synthetic voice cases.
- *  - "orphan": none of the above; no runner reads it.
+ * The lane rules themselves live in `scripts/case-lanes.ts` (issue #89) so that
+ * this guard and the case manifest cannot disagree about what "executable"
+ * means. This file asserts the repository's current state against them.
  */
 
 import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
+import {
+  DEFAULT_RUBRICS_PATH,
+  KNOWN_UNRUNNABLE,
+  loadRubricIntents,
+  scanLanes,
+  summariseExecutability,
+} from "./case-lanes";
+import { CaseManifest, manifestPathFor } from "./case-manifest";
 
 const CASES_DIR = path.join(__dirname, "..", "cases");
-
-/**
- * Case files that are known to be unrunnable, with the issue tracking the port.
- * Adding an entry here is a deliberate, reviewable act — it does not make the
- * file run, it only records that we know it does not.
- */
-const KNOWN_UNRUNNABLE: Record<string, string> = {
-  "tier1/phase2_journeys.yaml":
-    "issue #71 — bespoke userText/expectedBehavior schema; also uses PERSONAL_SYMPTOMS/EMERGENCY intents that rubrics.v1.json does not define",
-};
-
-type Lane = "gold" | "voice" | "voice-e2e" | "orphan";
-
-function listYamlFiles(dir: string): string[] {
-  const out: string[] = [];
-  const walk = (d: string) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const p = path.join(d, entry.name);
-      if (entry.isDirectory()) walk(p);
-      else if (/\.ya?ml$/i.test(entry.name)) out.push(p);
-    }
-  };
-  walk(dir);
-  return out.sort();
-}
-
-function laneOf(testCase: Record<string, unknown>): Lane {
-  if (Array.isArray(testCase.user_messages)) return "gold";
-  if (typeof testCase.voice_input === "string") return "voice";
-  if (typeof testCase.expectedTranscript === "string") return "voice-e2e";
-  return "orphan";
-}
-
-interface FileClassification {
-  relPath: string;
-  count: number;
-  lanes: Set<Lane>;
-}
-
-function classifyCaseFiles(): FileClassification[] {
-  const out: FileClassification[] = [];
-  for (const file of listYamlFiles(CASES_DIR)) {
-    const parsed = yaml.load(fs.readFileSync(file, "utf-8")) as {
-      cases?: unknown;
-    };
-    // Files without a `cases:` array are templates/scratch — the manifest
-    // guard skips them too.
-    if (!parsed || !Array.isArray(parsed.cases)) continue;
-
-    const cases = parsed.cases.filter(
-      (c): c is Record<string, unknown> => !!c && typeof c === "object",
-    );
-    out.push({
-      relPath: path.relative(CASES_DIR, file).split(path.sep).join("/"),
-      count: cases.length,
-      lanes: new Set(cases.map(laneOf)),
-    });
-  }
-  return out;
-}
+const RUBRIC_INTENTS = loadRubricIntents(DEFAULT_RUBRICS_PATH);
 
 describe("eval case files are claimed by a runner lane", () => {
-  const classified = classifyCaseFiles();
+  const lanes = scanLanes(CASES_DIR, RUBRIC_INTENTS);
+  const entries = Object.entries(lanes);
 
   it("finds case files to classify", () => {
-    expect(classified.length).toBeGreaterThan(0);
+    expect(entries.length).toBeGreaterThan(0);
   });
 
   it("has no case file in an unreadable schema except the recorded ones", () => {
-    const orphans = classified
-      .filter((f) => f.lanes.has("orphan"))
-      .map((f) => f.relPath);
+    const orphans = entries
+      .filter(([, f]) => f.lanes.includes("orphan"))
+      .map(([relPath]) => relPath);
 
     const unexpected = orphans.filter((p) => !(p in KNOWN_UNRUNNABLE));
 
@@ -109,7 +55,9 @@ describe("eval case files are claimed by a runner lane", () => {
     // If a quarantined file is ported to a runnable schema, this fails so the
     // entry gets removed rather than lingering as a permanent excuse.
     const orphans = new Set(
-      classified.filter((f) => f.lanes.has("orphan")).map((f) => f.relPath),
+      entries
+        .filter(([, f]) => f.lanes.includes("orphan"))
+        .map(([relPath]) => relPath),
     );
 
     const stale = Object.keys(KNOWN_UNRUNNABLE).filter((p) => !orphans.has(p));
@@ -117,19 +65,102 @@ describe("eval case files are claimed by a runner lane", () => {
     expect(stale).toEqual([]);
   });
 
-  it("reports how many manifest cases are actually executable", () => {
-    const total = classified.reduce((n, f) => n + f.count, 0);
-    const unrunnable = classified
-      .filter((f) => f.relPath in KNOWN_UNRUNNABLE)
-      .reduce((n, f) => n + f.count, 0);
+  it("reports how many suite cases are actually executable", () => {
+    const summary = summariseExecutability(lanes);
 
-    // Pins the gap between "cases in the manifest" and "cases a runner can
-    // execute". If either number moves, this test forces the change to be
+    // Pins the gap between "cases in the suite" and "cases a runner can
+    // execute". If any number moves, this test forces the change to be
     // acknowledged instead of quietly re-inflating the coverage headline.
-    expect({ total, unrunnable, runnable: total - unrunnable }).toEqual({
+    //
+    // 601 present / 572 executable / 29 blocked, in two kinds:
+    //   - 9  orphan-schema   — tier1/phase2_journeys.yaml (issue #89)
+    //   - 20 missing-rubric  — gold-lane cases naming an intent
+    //                          rubrics.v1.json does not define, so
+    //                          `Evaluator.getRubric` throws before scoring.
+    //     Found while fixing #89; NOT fixed here, because both candidate fixes
+    //     (adding rubrics, or re-pointing a case at a different intent) change
+    //     what those cases assert — SCCF review, per AGENTS.md §1.3.
+    expect({
+      total: summary.total,
+      runnable: summary.executable,
+      unrunnable: summary.unexecutable,
+      blockers: summary.blockers,
+    }).toEqual({
       total: 601,
-      unrunnable: 9,
-      runnable: 592,
+      runnable: 572,
+      unrunnable: 29,
+      blockers: { "orphan-schema": 9, "missing-rubric": 20 },
     });
+  });
+
+  it("names the intents that have no rubric, so the list cannot grow silently", () => {
+    // Every distinct intent used by a gold-lane case must resolve, or be listed
+    // here. A new unmapped intent fails this test rather than surfacing as a
+    // mid-run crash.
+    const unmapped = new Set<string>();
+    for (const file of Object.keys(lanes)) {
+      const parsed: any = yaml.load(
+        fs.readFileSync(path.join(CASES_DIR, file), "utf-8"),
+      );
+      for (const c of parsed.cases ?? []) {
+        if (!Array.isArray(c?.user_messages)) continue;
+        if (!RUBRIC_INTENTS.has(String(c.intent))) unmapped.add(String(c.intent));
+      }
+    }
+
+    expect([...unmapped].sort()).toEqual([
+      "EMOTIONAL_SUPPORT",
+      "NAVIGATION",
+      "OUT_OF_SCOPE",
+      "RED_FLAGS_URGENT",
+      "SIDE_EFFECTS_GENERAL",
+    ]);
+  });
+});
+
+/**
+ * Issue #89: the manifest is the artefact people quote. Before this change it
+ * carried one number — 601 — and no way to tell that 29 of those cases run
+ * nowhere. These tests hold the manifest ON DISK to the same truth as the scan,
+ * so the committed inventory cannot drift from what the runners can do.
+ */
+describe("the committed manifest tells the truth about executability", () => {
+  const manifest: CaseManifest = JSON.parse(
+    fs.readFileSync(manifestPathFor(CASES_DIR), "utf-8"),
+  );
+  const lanes = scanLanes(CASES_DIR, RUBRIC_INTENTS);
+  const summary = summariseExecutability(lanes);
+
+  it("records the executable count, not just the present count", () => {
+    expect(manifest.totalCases).toBe(summary.total);
+    expect(manifest.executableCases).toBe(summary.executable);
+    expect(manifest.unexecutableCases).toBe(summary.unexecutable);
+    expect(manifest.blockers).toEqual(summary.blockers);
+  });
+
+  it("marks every file with its lanes and executable case count", () => {
+    for (const [file, entry] of Object.entries(manifest.files)) {
+      expect(lanes[file]).toBeDefined();
+      expect(entry.lanes).toEqual(lanes[file].lanes);
+      expect(entry.executableCases).toBe(lanes[file].executableCases);
+      expect(entry.executable).toBe(lanes[file].executable);
+    }
+  });
+
+  it("records WHY the known-unrunnable file is not executable", () => {
+    for (const file of Object.keys(KNOWN_UNRUNNABLE)) {
+      const entry = manifest.files[file];
+      expect(entry).toBeDefined();
+      expect(entry.executable).toBe(false);
+      expect(entry.unexecutableReason).toBe(KNOWN_UNRUNNABLE[file]);
+    }
+  });
+
+  it("still counts the quarantined journey cases as present, not deleted", () => {
+    // The 9 journeys are not coverage, but they are also not gone: their
+    // clinical expectations are preserved verbatim for whoever ports them.
+    const entry = manifest.files["tier1/phase2_journeys.yaml"];
+    expect(entry.count).toBe(9);
+    expect(entry.caseIds).toHaveLength(9);
   });
 });


### PR DESCRIPTION
Refs #89.

The manifest reported **601 cases**. It counted every case it could *parse*, which is not the same as every case a runner can *execute*. Nine journeys — including caregiver crisis escalation and emergency red flags — read as coverage while running nowhere.

## What this PR does NOT do, deliberately

**It does not port the 9 journeys.** Porting requires choosing an intent mapping (`PERSONAL_SYMPTOMS` / `EMERGENCY` → which existing rubric?) and pass criteria for symptom-worry and emergency journeys. That is clinical policy requiring SCCF review — AGENTS.md §1.3, and issue #89's own "Decisions needed" 1 and 2. Inventing it would swap a visible gap for an invisible wrong answer on the most safety-critical surface in the product.

A half-port would be worse than none: adding `user_messages` alone flips the file into the "gold" lane, and the run then dies at `No rubric found for intent: PERSONAL_SYMPTOMS` — an honest quarantine turned into a runtime crash.

**No expectation in `phase2_journeys.yaml` was weakened, reworded, or removed.** The only edit to that file is its header comment, updating the case-count arithmetic. The 9 cases and their assertions are byte-identical.

So this implements issue #89's **decision 3**: make the count only claim what is executable.

## What it does

**`eval/scripts/case-lanes.ts` (new)** — one home for the lane rules. They previously existed in two states: `case-schema.test.ts` had its own copy, and `case-manifest.ts` had none and counted everything. That divergence is how the 9 got inside the 601.

**Executability is per case, not per file.** A file with one unrunnable case would otherwise mark all its cases as non-coverage — understating the suite as badly as the old count overstated it.

**`cases:check` enforces it.** The check now fails when the executable count drifts — in either direction, so a port that lands raises the number *on purpose* — and prints:

```
✅ Case manifest OK: 572 executable of 601 cases present across 25 files
⚠️  Case file "tier1/phase2_journeys.yaml": 9 of 9 cases are counted but cannot be executed (9 orphan-schema) — issues #71, #89 — …
```

**CI actually runs the guards now.** The eval jest suite ran *nowhere*: `test:ci` is `node --test ci/`, which only covers the CI status helper. PR #88's lane guard and #70's journey-pattern pins have never executed in CI. Added `npm test` to `eval-tier1.yml`, beside the existing manifest step. It needs no API or judge credentials (`jest.config.js` is unit-tests-only). **Reviewer's call** — if you would rather the nightly eval not gate on unit tests, drop that one step; nothing else in the PR depends on it.

## Second blocker found — reported, not fixed

While verifying "592 executable" I found that number is itself wrong. **20 gold-lane cases name an intent `rubrics/rubrics.v1.json` does not define**, so `Evaluator.getRubric` returns null and the case throws before any scoring — the same blocker as the journeys, hiding in files that look runnable.

Verified against the shipped rubric pack:

```
getRubric("RED_FLAGS_URGENT")  -> NULL -> evaluator throws
getRubric("RED_FLAG_URGENT")   -> found
getRubric("PERSONAL_SYMPTOMS") -> NULL -> evaluator throws
getRubric("EMERGENCY")         -> NULL -> evaluator throws
```

| Intent | Cases | Files |
|---|---|---|
| `RED_FLAGS_URGENT` (plural) | 10 | `generalinfo/general_info_100.yaml` |
| `NAVIGATION` | 3 | `gold/language_voice.yaml`, `gold/ux_completeness.yaml` |
| `EMOTIONAL_SUPPORT` | 3 | same |
| `SIDE_EFFECTS_GENERAL` | 2 | `gold/retrieval_grounding.yaml`, `gold/ux_completeness.yaml` |
| `OUT_OF_SCOPE` | 2 | `gold/retrieval_grounding.yaml` |

Note the rubric lookup is **not** canonicalised although the `--intent` filter is (`eval/utils/canonicalize.ts`), so `RED_FLAGS_URGENT` is a genuinely different, undefined intent.

Not fixed here: all three candidate fixes — add the rubrics, canonicalise the lookup, or re-point the cases — change what those cases assert, and 10 of them are red-flag cases. Eval-owner + SCCF call. Recorded as **`docs/RELIABILITY_BACKLOG.md` item 12** and pinned by a test that lists the unmapped intents by name, so the list cannot grow silently.

## Honest headline

| | before | after |
|---|---|---|
| present | 601 | 601 |
| **executable** | *not tracked* | **572** |
| blocked | *not tracked* | 29 — 9 orphan-schema, 20 missing-rubric |

## Changed files

| File | Change |
|---|---|
| `eval/scripts/case-lanes.ts` | **new** — lane + blocker classification, single source of truth |
| `eval/scripts/case-manifest.ts` | manifest v2: `executableCases`, `unexecutableCases`, `blockers`, per-file lanes; drift is an error |
| `eval/scripts/case-manifest.test.ts` | **+7 tests** |
| `eval/scripts/case-schema.test.ts` | lane logic imported instead of duplicated; pins moved to 601/572/29; **+4 tests** |
| `eval/cases/case-manifest.json` | regenerated (`npm run cases:update`) |
| `eval/cases/tier1/phase2_journeys.yaml` | header comment only — **no case, expectation or assertion touched** |
| `.github/workflows/eval-tier1.yml` | run the eval jest suite; manifest step renamed |
| `docs/RELIABILITY_BACKLOG.md` | item 11 corrected 592→572; item 12 added for the 20 |

## Commands and results

```
cd eval && npm test
Test Suites: 7 passed, 7 total
Tests:       92 passed, 92 total          # was 78, none of which ran in CI

cd eval && npm run typecheck              # tsc --noEmit, clean

cd eval && npx ts-node scripts/case-manifest.ts check
✅ Case manifest OK: 572 executable of 601 cases present across 25 files (0 tombstone(s))
```

The drift guard was confirmed by watching it fire: after the rubric blocker was added to the classifier, `check` failed with
`Executable case count changed: manifest records 592, scan finds 572 (of 601 present)` until the manifest was updated. That is the intended behaviour, observed rather than assumed.

`apps/api` is untouched by this branch.

## Verified vs assumed

**Verified — no judge needed**

- **All 601 cases load.** `Evaluator.loadTestCases` parses every one of the 25 files, 0 failures. This is not a YAML problem.
- **0 of the 9 journeys have `user_messages`**, the field `evaluator.ts` passes to `executeConversation` — confirmed by loading the file through the real loader.
- **The rubric lookups return null** for `PERSONAL_SYMPTOMS`, `EMERGENCY` and `RED_FLAGS_URGENT`, against the real `rubrics.v1.json` (output above).
- **Manifest counts round-trip**: `cases:update` then `cases:check` is clean, and the committed manifest is asserted against a fresh scan by test.
- **The guard catches both directions** — a suite silently losing `user_messages`, and an orphan suite being ported — each with its own test.
- **`case-schema.test.ts` behaviour is preserved**: its original four assertions still exist, now reading lane rules from the shared module.

**Assumed / not verified**

- **No Tier1 eval run was attempted.** The judge provider is down (**issue #74**), so pass/fail rates could not be measured. **Tier1 must be re-run after #74 is resolved** to confirm the 572 executable cases in fact execute end-to-end. Everything here is static analysis of loading and lookup, which is exactly the layer the defect lives in — but it is not the same as a green run.
- The claim that a missing rubric aborts the case comes from reading `evaluator.ts` (`getRubric` → `if (!rubric) throw`) plus verifying the lookup returns null. No case was driven through the evaluator to observe the throw, because that needs a live API.
- Voice-lane cases are treated as executable on schema alone; their rubric pack (`voice-rubrics.v1.json`) was not cross-checked the way the gold lane was. If the same defect exists there, this count is still optimistic.

## Human decisions required

1. **The 9 journeys: port or retire?** Needs the intent mapping and pass criteria (issue #89, decisions 1–2). SCCF medical review. Until then the manifest says 572, and `KNOWN_UNRUNNABLE` keeps the file visible with its reason.
2. **The 20 missing-rubric cases** (backlog item 12) — add rubrics, canonicalise the lookup, or re-point the cases. 10 are red-flag cases, so this is not a typo fix.
3. **Should the nightly eval gate on eval unit tests?** Included here; drop that one step if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
