### PR TITLE
docs: correct the autoresearch pause references (#60)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,7 +197,7 @@ operational detail in `docs/OPERATIONS_RUNBOOK.md`; pipeline internals in
 | `suchi-db-migrate` / `suchi-migrate` | Cloud Run Jobs running `prisma migrate deploy` | `cloudbuild.gated.yaml` / `deploy-api.yml` respectively |
 | `suchi-kb-ingest` | Cloud Run Job image (KB ingestion, `Dockerfile.kb-ingest`) | `cloudbuild.kb-ingest.yaml` |
 | `suchi-navigator-research`, `suchi-navigator-sender` | Cloud Run Jobs (hospital research via Claude API; daily sender) | `cloudbuild.navigator-research.yaml` |
-| Autoresearch loop | Cloud Build run producing `autoresearch/*` proposal branches (never auto-merged) | `cloudbuild-autoresearch.yaml` |
+| Autoresearch loop — **PAUSED 2026-07-20** (trigger disabled; see issue #60) | Cloud Build run producing `autoresearch/*` proposal branches (never auto-merged, never a deploy gate) | `cloudbuild-autoresearch.yaml` |
 | Database | Cloud SQL Postgres `suchi-db` with pgvector | connection `gen-lang-client-0202543132:us-central1:suchi-db` |
 
 **Critical property:** every deploy path uses `--set-env-vars` /

--- a/docs/GATED_DEPLOYMENT.md
+++ b/docs/GATED_DEPLOYMENT.md
@@ -9,7 +9,9 @@ This deployment pattern provides "staging safety" without creating a separate en
 3. Only shifting traffic to the candidate if the health check passes
 4. If the health check fails, the build stops and live traffic remains on the previous revision
 
-> **Note (Feb 2026):** The eval:tier1 gate was removed from the gated pipeline due to reliability issues (see `cloudbuild-gated-issues.md`). The gate is now health-check only. Quality gating is handled separately by the autoresearch engine (`eval/autoresearch/`).
+> **Note (Feb 2026, corrected 2026-09-10):** The eval:tier1 gate was removed from the gated pipeline due to reliability issues (see `cloudbuild-gated-issues.md`). **The gate is health-check only: nothing gates answer quality on deploy.**
+>
+> This note previously said "Quality gating is handled separately by the autoresearch engine (`eval/autoresearch/`)". That has been false since 2026-07-20, when the `autoresearch-nightly` Cloud Build trigger was disabled (audit record and re-enable criteria: issue #60). The autoresearch loop was proposal-mode only in any case — it pushed `autoresearch/*` branches for human review and never gated a deploy. Do not read this page as describing a quality safety net on the deploy path; there is none. Retrieval quality is watched *after* the fact by the nightly Tier1 eval (`.github/workflows/eval-tier1.yml`), which is a canary, not a gate.
 
 ## How It Works
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -201,6 +201,10 @@ Caveats:
   (state in `gs://suchi-navigator-state`; secret names
   `ANTHROPIC_API_KEY`, `NAVIGATOR_APPROVAL_SECRET`, `SMTP_PASS`).
 - Autoresearch nightly loop: `cloudbuild-autoresearch.yaml`, proposal-mode
-  only — it pushes `autoresearch/*` branches for human review.
+  only — it pushed `autoresearch/*` branches for human review.
+  **PAUSED since 2026-07-20** — the Cloud Build trigger `autoresearch-nightly`
+  is disabled, last build 2026-07-19. It does not run, and it never gated a
+  deploy. Audit record, preserved-branch manifest and the re-enable criteria
+  are in issue #60; do not re-enable without meeting them.
 - KB ingestion job image: `cloudbuild.kb-ingest.yaml` + `Dockerfile.kb-ingest`
   (runs `src/scripts/ingest-kb.ts --wipeChunks`).


### PR DESCRIPTION
Discharges the one actionable item from **#60**'s 2026-09-06 triage ("KEEP OPEN — stay paused, but one doc correction is overdue").

**Docs only.** No trigger, workflow, schedule, code, KB or prompt touched. **Nothing re-enabled** — #60 stays open as the standing audit record and re-enable checklist, and the pause stays in force.

## The false claim — why this is worth its own PR

`docs/GATED_DEPLOYMENT.md:12` said, verbatim:

> The gate is now health-check only. **Quality gating is handled separately by the autoresearch engine (`eval/autoresearch/`).**

That second sentence has been false since **2026-07-20**, when the `autoresearch-nightly` Cloud Build trigger was disabled. The `eval:tier1` gate had already been removed from the gated pipeline in **Feb 2026**. So **nothing gates answer quality on deploy today** — and anyone reading that page concluded there was a safety net that does not exist. On a medical product that is the kind of doc error worth fixing on its own.

The note now:
- states plainly that the gate is **health-check only, with no quality gate**;
- records what the sentence used to claim, so the correction is auditable rather than silently rewritten;
- points at the nightly Tier1 eval (`.github/workflows/eval-tier1.yml`) as an **after-the-fact canary, not a gate** — so the corrected text does not leave a reader thinking *nothing at all* watches retrieval quality;
- notes autoresearch was proposal-mode only and never gated a deploy in any case.

## The two present-tense references

Both described the loop as running, with no mention of the pause. Now marked **PAUSED (2026-07-20)** with a pointer to #60's re-enable criteria:

| file:line | was |
|---|---|
| `docs/OPERATIONS_RUNBOOK.md:203-204` | "Autoresearch nightly loop: `cloudbuild-autoresearch.yaml`, proposal-mode only — it pushes `autoresearch/*` branches for human review." |
| `docs/ARCHITECTURE.md:200` | "Autoresearch loop \| Cloud Build run producing `autoresearch/*` proposal branches (never auto-merged)" |

## Diff size

```
 docs/ARCHITECTURE.md       | 2 +-
 docs/GATED_DEPLOYMENT.md   | 4 +++-
 docs/OPERATIONS_RUNBOOK.md | 6 +++++-
 3 files changed, 9 insertions(+), 3 deletions(-)
```

## What I verified vs. what I took from the record

- **Verified myself:** all three quoted strings exist verbatim on `main` @ `5a2d4f7`, at the line numbers #60's triage cited.
- **Taken from #60's triage, not re-verified:** the GCP-side pause state (trigger `disabled: true`, last build `2026-07-19T16:30:03Z`, 60 preserved `autoresearch/*` branches). That triage verified it against GCP on 2026-09-06. **I did not re-query GCP** — no cloud state was read or changed in this PR.

## Note on the suggested home

#60's triage suggested PR #79 (the operational-decisions doc) "may be the natural home for it". I put it in its own branch instead: #79 is a pure *append* of a new decisions section and is already rebased and green, whereas this edits three existing canonical docs. Keeping them separate means the safety-relevant correction can merge on its own timeline, and neither PR's conflict surface grows.

Closes nothing. Related: #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)