### PR TITLE
fix(web): render only the escalation block in the emergency banner (#111)

### DIFF
--- a/apps/api/src/modules/chat/chat.service.escalation-banner.spec.ts
+++ b/apps/api/src/modules/chat/chat.service.escalation-banner.spec.ts
@@ -1,0 +1,253 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ChatService, ESCALATION_RAG_SEPARATOR } from "./chat.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { AnalyticsService } from "../analytics/analytics.service";
+import { SafetyService } from "../safety/safety.service";
+import { RagService } from "../rag/rag.service";
+import { LlmService } from "../llm/llm.service";
+import { EvidenceGateService } from "../evidence/evidence-gate.service";
+import { CitationService } from "../citations/citation.service";
+import { AbstentionService } from "../abstention/abstention.service";
+import { IntentClassifier } from "./intent-classifier";
+import { TemplateSelector } from "./template-selector";
+import { StructuredExtractorService } from "./structured-extractor.service";
+import { ResponseValidatorService } from "./response-validator.service";
+import { GreetingFlowService } from "./greeting-flow.service";
+import { EmpathyDetector } from "./empathy-detector";
+import { PatientStateService } from "./patient-state.service";
+import { ClinicalKeywordEnforcerService } from "../llm/clinical-keyword-enforcer";
+import { RetrievalToolService } from "../rag/retrieval-tool.service";
+import { QueryDecomposerService } from "../rag/query-decomposer.service";
+import { CrossLingualService } from "../rag/cross-lingual.service";
+import { ExecutionPlannerService } from "./execution-planner.service";
+import { PlanExecutorService } from "./plan-executor.service";
+import { OutputVerifierService } from "./output-verifier.service";
+import { ReviewService } from "../review/review.service";
+import { ObservabilityService } from "../observability/observability.service";
+import { ResponseTemplates } from "./response-templates";
+
+/**
+ * Regression: the chat response must expose the escalation block on its own, so
+ * the web emergency banner can render *only* that block (issue #111).
+ *
+ * Live browser QA on 2026-09-10 (run `2026-09-10T19-02-52`, q05) found the
+ * banner being handed the entire ~3,000-character reply and rendering it as
+ * plain text. DOM proof from the same message:
+ *
+ *   banner : literal_asterisks=true,  <strong>=0, <em>=0
+ *   bubble : literal_asterisks=false, <strong>=8, <em>=1
+ *
+ * The escalation copy is unchanged by this fix — `bannerText` is a byte-exact
+ * prefix of `responseText`.
+ */
+describe("ChatService — escalation banner text (issue #111)", () => {
+  let chatService: ChatService;
+
+  /** The half the LLM contributes on the urgent path. */
+  const RAG_ANSWER =
+    "**Educational answer**:\nA new lump should be *evaluated* by a doctor within a few days.";
+
+  const SESSION = {
+    id: "test-session",
+    createdAt: new Date(),
+    channel: "web",
+    locale: "en",
+    userType: null,
+    status: "active",
+    userContext: "general",
+    cancerType: null,
+    greetingCompleted: true,
+    emotionalState: "neutral",
+  };
+
+  const CHUNK = {
+    id: "chunk-1",
+    docId: "doc-1",
+    chunkId: "chunk-1",
+    text: "A new breast lump should be evaluated by a clinician.",
+    similarity: 0.9,
+    document: { sourceType: "NCI", isTrustedSource: true, title: "Breast changes" },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChatService,
+        {
+          provide: PrismaService,
+          useValue: {
+            $queryRaw: jest.fn().mockResolvedValue([SESSION]),
+            $executeRawUnsafe: jest.fn().mockResolvedValue(1),
+            session: { findUnique: jest.fn().mockResolvedValue(SESSION), update: jest.fn() },
+            message: {
+              create: jest.fn().mockImplementation((args: any) =>
+                Promise.resolve({ id: "msg-1", ...args.data, createdAt: new Date() }),
+              ),
+              findMany: jest.fn().mockResolvedValue([]),
+              count: jest.fn().mockResolvedValue(0),
+            },
+            messageCitation: { create: jest.fn(), createMany: jest.fn() },
+            safetyEvent: { create: jest.fn().mockResolvedValue({}) },
+          },
+        },
+        { provide: AnalyticsService, useValue: { emit: jest.fn().mockResolvedValue(undefined) } },
+        // Real safety + abstention: this test must exercise the production
+        // urgent path, not a stubbed approximation of it.
+        { provide: SafetyService, useValue: new SafetyService() },
+        { provide: AbstentionService, useValue: new AbstentionService() },
+        {
+          provide: RagService,
+          useValue: {
+            retrieveWithMetadata: jest.fn().mockResolvedValue([CHUNK]),
+            retrieveWithExpansion: jest.fn().mockResolvedValue([CHUNK]),
+          },
+        },
+        {
+          provide: LlmService,
+          useValue: {
+            generateWithCitations: jest.fn().mockResolvedValue(RAG_ANSWER),
+            generateRaw: jest.fn().mockResolvedValue(RAG_ANSWER),
+          },
+        },
+        {
+          provide: EvidenceGateService,
+          useValue: {
+            validateEvidence: jest.fn().mockReturnValue({
+              status: "ok",
+              approvedChunks: [CHUNK],
+              reasonCode: null,
+              shouldAbstain: false,
+              confidence: "high",
+              quality: "strong",
+            }),
+            generateClarifyingQuestion: jest.fn(),
+          },
+        },
+        {
+          provide: CitationService,
+          useValue: {
+            extractCitations: jest.fn().mockReturnValue({ citations: [], orphanCount: 0 }),
+            validateCitations: jest
+              .fn()
+              .mockReturnValue({ isValid: true, confidenceLevel: "GREEN", citations: [], citationDensity: 0 }),
+            enrichCitations: jest.fn().mockResolvedValue([]),
+          },
+        },
+        { provide: IntentClassifier, useValue: new IntentClassifier(new AbstentionService()) },
+        {
+          provide: TemplateSelector,
+          useValue: new TemplateSelector(new IntentClassifier(new AbstentionService())),
+        },
+        { provide: StructuredExtractorService, useValue: new StructuredExtractorService() },
+        {
+          provide: ResponseValidatorService,
+          useValue: { validate: jest.fn().mockReturnValue({ shouldAbstain: false, isValid: true, ungroundedEntities: [] }) },
+        },
+        {
+          provide: GreetingFlowService,
+          useValue: {
+            extractContextFromMessage: jest
+              .fn()
+              .mockResolvedValue({ context: undefined, cancerType: undefined, confidence: 0 }),
+            needsGreetingFlow: jest.fn().mockResolvedValue(false),
+            getGreetingStep: jest.fn().mockResolvedValue(0),
+            isGreetingFlowInProgress: jest.fn().mockResolvedValue(false),
+            handleGreetingFlowInterruption: jest.fn().mockResolvedValue(undefined),
+            parseGreetingResponse: jest.fn(),
+            updateSessionContext: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: EmpathyDetector,
+          useValue: {
+            detectEmotionalTone: jest.fn().mockResolvedValue({ tone: "urgent" }),
+            detectMentalHealthNeed: jest
+              .fn()
+              .mockReturnValue({ needsSupport: false, isCrisis: false, category: null, keywords: [] }),
+          },
+        },
+        { provide: PatientStateService, useValue: new PatientStateService() },
+        { provide: CrossLingualService, useValue: new CrossLingualService() },
+        { provide: OutputVerifierService, useValue: new OutputVerifierService() },
+        { provide: ClinicalKeywordEnforcerService, useValue: { enforce: (t: string) => t } },
+        { provide: QueryDecomposerService, useValue: { needsDecomposition: () => false, decompose: jest.fn() } },
+        { provide: RetrievalToolService, useValue: { multiRetrieve: jest.fn() } },
+        { provide: ExecutionPlannerService, useValue: { needsPlanning: () => false, plan: jest.fn() } },
+        { provide: PlanExecutorService, useValue: { execute: jest.fn() } },
+        {
+          provide: ReviewService,
+          useValue: {
+            copilotMode: "off",
+            review: jest.fn().mockResolvedValue({ verdict: "PASS" }),
+            persistRecord: jest.fn().mockResolvedValue(undefined),
+            buildBlockedFallback: jest.fn(),
+          },
+        },
+        {
+          provide: ObservabilityService,
+          useValue: {
+            startTrace: () => ({}),
+            startSpan: () => ({}),
+            endSpan: jest.fn(),
+            finalizeTrace: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    chatService = module.get<ChatService>(ChatService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  const urgentTurn = () =>
+    chatService.handle({
+      sessionId: "test-session",
+      userText: "my father is rapidly worsening since yesterday",
+      channel: "web",
+      locale: "en",
+    } as any);
+
+  it("still escalates and still appends the trusted-sources half", async () => {
+    const result = await urgentTurn();
+
+    expect(result.safety.classification).toBe("red_flag");
+    expect(result.safety.actions).toContain("show_emergency_banner");
+    expect(result.responseText).toContain(ESCALATION_RAG_SEPARATOR.trim());
+    expect(result.responseText).toContain("Educational answer");
+  });
+
+  it("returns bannerText holding the escalation block alone", async () => {
+    const result = await urgentTurn();
+    const bannerText = (result.safety as any).bannerText as string;
+
+    expect(bannerText).toBeTruthy();
+    expect(bannerText).toContain("seek emergency medical care now");
+    expect(bannerText).toContain("112");
+    // The appended answer must not be repeated in the banner.
+    expect(bannerText).not.toContain("Educational answer");
+    expect(bannerText).not.toContain("Information from trusted sources");
+  });
+
+  it("keeps the escalation copy byte-identical to the S2 template", async () => {
+    const result = await urgentTurn();
+    const bannerText = (result.safety as any).bannerText as string;
+
+    // Nothing is reworded: bannerText is exactly the S2 template, and exactly
+    // the prefix of the delivered response.
+    expect(bannerText).toBe(ResponseTemplates.S2({ isFirstMessage: true } as any));
+    expect(result.responseText.startsWith(bannerText)).toBe(true);
+  });
+
+  it("sets bannerText on the emergency fast path too", async () => {
+    const result = await chatService.handle({
+      sessionId: "test-session",
+      userText: "I am coughing up blood right now",
+      channel: "web",
+      locale: "en",
+    } as any);
+
+    expect(result.safety.actions).toContain("show_emergency_banner");
+    expect((result.safety as any).bannerText).toBe(result.responseText);
+  });
+});

--- a/apps/api/src/modules/chat/chat.service.ts
+++ b/apps/api/src/modules/chat/chat.service.ts
@@ -43,6 +43,14 @@ import { stripForVoice } from "./voice-output-stripper";
 import { ObservabilityService } from "../observability/observability.service";
 import { buildSymptomSoftRedirectPrompt } from "./utils/response-language";
 
+/**
+ * Joins the safety escalation block and the appended RAG answer on the urgent
+ * path. Everything before it is the escalation; the web client renders exactly
+ * that in the emergency banner (issue #111). Mirrored byte-for-byte in
+ * apps/web/src/utils/escalationText.ts — change both or neither.
+ */
+export const ESCALATION_RAG_SEPARATOR = "\n\n**Information from trusted sources:**\n\n";
+
 @Injectable()
 export class ChatService {
   private readonly logger = new Logger(ChatService.name);
@@ -289,6 +297,9 @@ export class ChatService {
         safety: {
           classification: "red_flag" as const,
           actions: ["show_emergency_banner", "end_conversation"],
+          // Nothing is appended on the fast path, so the banner block is the
+          // whole reply (issue #111).
+          bannerText: assistant.text,
         },
       };
     }
@@ -322,7 +333,7 @@ export class ChatService {
         this.logger.warn(`Analytics emit failed: ${err.message}`)
       );
 
-      return { sessionId: dto.sessionId, messageId: assistant.id, responseText: assistant.text, safety: { classification: safetyResult.classification, actions: safetyResult.actions } };
+      return { sessionId: dto.sessionId, messageId: assistant.id, responseText: assistant.text, safety: { classification: safetyResult.classification, actions: safetyResult.actions, bannerText: assistant.text } };
     }
 
     // 1.5. Check for urgent red flags (but retrieve RAG first to include citations)
@@ -421,7 +432,7 @@ export class ChatService {
         const citationValidation = this.citationService.validateCitations(
           citations,
           earlyEvidenceChunks,
-          urgentResponse + "\n\n**Information from trusted sources:**\n\n" + ragResponse,
+          urgentResponse + ESCALATION_RAG_SEPARATOR + ragResponse,
           false, // isIdentifyQuestionWithGeneralIntent
           orphanCount,
           dto.userText
@@ -429,7 +440,10 @@ export class ChatService {
         
         // Combine urgent guidance with RAG content (urgent guidance first, then RAG with citations)
         urgentResponse = urgentResponse.split("\n\n**Next steps:**")[0]; // Remove generic next steps
-        urgentResponse += "\n\n**Information from trusted sources:**\n\n" + ragResponse;
+        // Captured before the append so the banner gets the escalation block
+        // alone — same bytes, no slicing on the client (issue #111).
+        const escalationText = urgentResponse;
+        urgentResponse += ESCALATION_RAG_SEPARATOR + ragResponse;
 
         // PHASE 2.5+: Append citation markers to response text for LLM judge compliance
         // The judge looks for [citation:docId:chunkId] markers in the response text
@@ -465,7 +479,7 @@ export class ChatService {
           sessionId: dto.sessionId, 
           messageId: assistant.id, 
           responseText: assistant.text, 
-          safety: { classification: "red_flag" as const, actions: ["show_emergency_banner", "end_conversation"] },
+          safety: { classification: "red_flag" as const, actions: ["show_emergency_banner", "end_conversation"], bannerText: escalationText },
           citations: citations.map(c => ({ docId: c.docId, chunkId: c.chunkId, position: c.position })),
           citationConfidence: citationValidation.confidenceLevel,
           retrievedChunks: earlyEvidenceChunks.slice(0, 6).map(chunk => ({
@@ -511,7 +525,7 @@ export class ChatService {
         sessionId: dto.sessionId, 
         messageId: assistant.id, 
         responseText: assistant.text, 
-        safety: { classification: "red_flag" as const, actions: ["show_emergency_banner", "end_conversation"] } 
+        safety: { classification: "red_flag" as const, actions: ["show_emergency_banner", "end_conversation"], bannerText: assistant.text }
       };
     }
 

--- a/apps/web/src/components/ChatInterface.tsx
+++ b/apps/web/src/components/ChatInterface.tsx
@@ -9,6 +9,7 @@ import { LoadingIndicator } from "./LoadingIndicator";
 import { ErrorDisplay } from "./ErrorDisplay";
 import { WelcomeMessage } from "./WelcomeMessage";
 import { apiService, ChatResponse, UserRole } from "../services/api";
+import { resolveEscalationText } from "../utils/escalationText";
 
 interface ChatInterfaceProps {
   sessionId: string | null;
@@ -160,9 +161,11 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ sessionId, onStart
         }
 
         if (response.safety.actions.includes("show_emergency_banner")) {
+          // Issue #111: the banner carries only the escalation block. Handing it
+          // the whole responseText repeated the entire answer above the bubble.
           setSafetyBanner({
             classification: response.safety.classification as "red_flag" | "self_harm",
-            message: response.responseText
+            message: resolveEscalationText(response.responseText, response.safety.bannerText)
           });
         }
       } else {

--- a/apps/web/src/components/SafetyBanner.tsx
+++ b/apps/web/src/components/SafetyBanner.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import ReactMarkdown from "react-markdown";
+import { removeCitationMarkers } from "../utils/citationParser";
 
 interface SafetyBannerProps {
   classification: "red_flag" | "self_harm";
@@ -21,7 +23,14 @@ export const SafetyBanner: React.FC<SafetyBannerProps> = ({ classification, mess
         <div style={styles.title}>
           {isEmergency ? "Seek Emergency Medical Care" : "Important Notice"}
         </div>
-        <div style={styles.message}>{message}</div>
+        {/*
+          Issue #111: the escalation copy is markdown, so it goes through the
+          same ReactMarkdown pipeline the message bubble uses. Rendering it as
+          plain text showed patients literal `**` on the highest-stakes path.
+        */}
+        <div style={styles.message}>
+          <ReactMarkdown>{removeCitationMarkers(message)}</ReactMarkdown>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/__tests__/ChatInterface.escalation.test.tsx
+++ b/apps/web/src/components/__tests__/ChatInterface.escalation.test.tsx
@@ -1,0 +1,159 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sendMessage = vi.fn();
+const getSession = vi.fn();
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    sendMessage: (...args: unknown[]) => sendMessage(...args),
+    getSession: (...args: unknown[]) => getSession(...args),
+    createSession: vi.fn(),
+    submitFeedback: vi.fn(),
+  },
+}));
+
+import { ChatInterface } from '../ChatInterface';
+
+// Head of the S2 escalation template, verbatim
+// (apps/api/src/modules/chat/response-templates.ts).
+const ESCALATION = `Some of what you described could be urgent. Please seek emergency medical care now.
+
+**Call for help immediately:**
+• **112** (national emergency number) or **108** (ambulance service)`;
+
+// The separator chat.service.ts uses to append the RAG answer on the urgent path.
+const SEPARATOR = '\n\n**Information from trusted sources:**\n\n';
+
+const RAG_HALF = `**Educational answer**:
+A new lump should be *evaluated* by a doctor within a few days.`;
+
+const COMPOSED = ESCALATION + SEPARATOR + RAG_HALF;
+
+const escalatedResponse = (extra: Record<string, unknown> = {}) => ({
+  sessionId: 'session-1',
+  messageId: 'msg-1',
+  responseText: COMPOSED,
+  safety: {
+    classification: 'red_flag',
+    actions: ['show_emergency_banner', 'end_conversation'],
+    ...extra,
+  },
+});
+
+function installLocalStorage(seed: Record<string, string>) {
+  const store = new Map(Object.entries(seed));
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+      clear: () => store.clear(),
+    },
+  });
+}
+
+const bannerContent = () =>
+  screen.getByText('Seek Emergency Medical Care').parentElement as HTMLElement;
+
+const sendQuestion = async () => {
+  const user = userEvent.setup();
+  const input = screen.getByPlaceholderText('Type your message...');
+  await user.type(input, 'I found a hard lump. Is this an emergency?');
+  await user.keyboard('{Enter}');
+  // ChatInterface refreshes greeting state after every reply; settle those
+  // promises here so the assertions below run against a quiet component.
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('ChatInterface — emergency banner (issue #111)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom in this project runs without a Storage implementation, and
+    // ChatInterface reads localStorage on every reply.
+    installLocalStorage({
+      suchi_welcome_seen: 'true',
+      suchi_sources_disclosure_seen: 'true',
+    });
+    // jsdom does not implement scrollIntoView; ChatInterface calls it on every
+    // new message.
+    Element.prototype.scrollIntoView = vi.fn();
+    getSession.mockResolvedValue({
+      sessionId: 'session-1',
+      createdAt: '2026-09-10T00:00:00.000Z',
+      greetingCompleted: true,
+      currentGreetingStep: null,
+      userContext: null,
+      cancerType: null,
+    });
+  });
+
+  it('shows only the escalation block in the banner, never the appended answer', async () => {
+    sendMessage.mockResolvedValue(escalatedResponse({ bannerText: ESCALATION }));
+    render(<ChatInterface sessionId="session-1" onStartOver={vi.fn()} />);
+
+    await sendQuestion();
+    await screen.findByText('Seek Emergency Medical Care');
+
+    const banner = bannerContent();
+    expect(banner.textContent).toContain('seek emergency medical care now');
+    // The ~3,000-char answer must not be repeated inside the emergency card.
+    expect(banner.textContent).not.toContain('Educational answer');
+    expect(banner.textContent).not.toContain('Information from trusted sources');
+  });
+
+  it('renders the banner as markdown — no literal ** or --- reaches the patient', async () => {
+    sendMessage.mockResolvedValue(escalatedResponse({ bannerText: ESCALATION }));
+    render(<ChatInterface sessionId="session-1" onStartOver={vi.fn()} />);
+
+    await sendQuestion();
+    await screen.findByText('Seek Emergency Medical Care');
+
+    const banner = bannerContent();
+    expect(banner.textContent).not.toContain('**');
+    expect(banner.textContent).not.toContain('---');
+    expect(banner.querySelectorAll('strong').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to slicing at the separator when the API sends no bannerText', async () => {
+    // Guards the currently-deployed API build, which has no bannerText field.
+    sendMessage.mockResolvedValue(escalatedResponse());
+    render(<ChatInterface sessionId="session-1" onStartOver={vi.fn()} />);
+
+    await sendQuestion();
+    await screen.findByText('Seek Emergency Medical Care');
+
+    const banner = bannerContent();
+    expect(banner.textContent).not.toContain('**');
+    expect(banner.textContent).not.toContain('Educational answer');
+    expect(banner.textContent).toContain('seek emergency medical care now');
+  });
+
+  it('keeps the full answer once, in the message bubble, rendered as markdown', async () => {
+    sendMessage.mockResolvedValue(escalatedResponse({ bannerText: ESCALATION }));
+    const { container } = render(
+      <ChatInterface sessionId="session-1" onStartOver={vi.fn()} />
+    );
+
+    await sendQuestion();
+    await screen.findByText('Seek Emergency Medical Care');
+
+    const bubble = await waitFor(() => {
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      expect(log.textContent).toContain('Educational answer');
+      return log;
+    });
+
+    expect(bubble.textContent).not.toContain('**');
+    expect(bubble.querySelectorAll('strong').length).toBeGreaterThan(0);
+    expect(bubble.querySelectorAll('em').length).toBeGreaterThan(0);
+
+    // The appended answer appears exactly once in the whole page.
+    const occurrences = (container.textContent ?? '').split('Educational answer').length - 1;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/apps/web/src/components/__tests__/SafetyBanner.test.tsx
+++ b/apps/web/src/components/__tests__/SafetyBanner.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SafetyBanner } from '../SafetyBanner';
+
+// Verbatim head of the S2 escalation template
+// (apps/api/src/modules/chat/response-templates.ts).
+const ESCALATION = `Some of what you described could be urgent. Please seek emergency medical care now.
+
+**Call for help immediately:**
+• **112** (national emergency number) or **108** (ambulance service)
+• **102** (medical emergency helpline, available in many states)
+
+---
+*If this is a medical emergency, call 112 or 108 immediately.*`;
+
+describe('SafetyBanner', () => {
+  describe('markdown rendering (issue #111)', () => {
+    // Live prod DOM proof, run 2026-09-10T19-02-52 (q05):
+    //   banner: literal_asterisks=true,  <strong>=0, <em>=0
+    //   bubble: literal_asterisks=false, <strong>=8, <em>=1
+    // The banner must go through the same markdown pipeline as the bubble.
+    it('renders bold markers as <strong>, not literal asterisks', () => {
+      const { container } = render(
+        <SafetyBanner classification="red_flag" message={ESCALATION} />
+      );
+
+      expect(container.textContent).not.toContain('**');
+      expect(container.querySelectorAll('strong').length).toBeGreaterThan(0);
+      expect(screen.getByText('112')).toBeInTheDocument();
+    });
+
+    it('does not leak a raw horizontal rule', () => {
+      const { container } = render(
+        <SafetyBanner classification="red_flag" message={ESCALATION} />
+      );
+
+      expect(container.textContent).not.toContain('---');
+      expect(container.querySelector('hr')).toBeInTheDocument();
+    });
+
+    it('does not leak citation markers', () => {
+      const { container } = render(
+        <SafetyBanner
+          classification="red_flag"
+          message={'Call **112** now [citation:doc1:chunk1].'}
+        />
+      );
+
+      expect(container.textContent).not.toContain('[citation:');
+    });
+  });
+
+  describe('classification', () => {
+    it('shows the emergency title for red_flag', () => {
+      render(<SafetyBanner classification="red_flag" message="Call 112." />);
+      expect(screen.getByText('Seek Emergency Medical Care')).toBeInTheDocument();
+    });
+
+    it('shows the notice title for self_harm', () => {
+      render(<SafetyBanner classification="self_harm" message="Support is available." />);
+      expect(screen.getByText('Important Notice')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -38,6 +38,12 @@ export interface ChatResponse {
   safety: {
     classification: "normal" | "refusal" | "red_flag" | "self_harm";
     actions: Array<"show_emergency_banner" | "suggest_doctor_visit" | "end_conversation">;
+    /**
+     * Escalation copy for the emergency banner, sent with
+     * `show_emergency_banner`. Optional: older API builds omit it, and the
+     * client then slices `responseText` instead (see resolveEscalationText).
+     */
+    bannerText?: string;
   };
 }
 

--- a/apps/web/src/utils/__tests__/escalationText.test.ts
+++ b/apps/web/src/utils/__tests__/escalationText.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ESCALATION_RAG_SEPARATOR, resolveEscalationText } from '../escalationText';
+
+// Verbatim opening of the S2 escalation template
+// (apps/api/src/modules/chat/response-templates.ts).
+const ESCALATION = `Some of what you described could be urgent. Please seek emergency medical care now.
+
+**Call for help immediately:**
+• **112** (national emergency number) or **108** (ambulance service)`;
+
+const RAG_HALF = `**Educational answer**:
+A new lump should be checked by a doctor.`;
+
+describe('resolveEscalationText', () => {
+  it('prefers the explicit bannerText sent by the API', () => {
+    const composed = ESCALATION + ESCALATION_RAG_SEPARATOR + RAG_HALF;
+    expect(resolveEscalationText(composed, ESCALATION)).toBe(ESCALATION);
+  });
+
+  it('falls back to slicing at the separator when bannerText is absent', () => {
+    const composed = ESCALATION + ESCALATION_RAG_SEPARATOR + RAG_HALF;
+    expect(resolveEscalationText(composed)).toBe(ESCALATION);
+  });
+
+  it('does not alter the escalation copy when slicing', () => {
+    const composed = ESCALATION + ESCALATION_RAG_SEPARATOR + RAG_HALF;
+    // Byte-identical: the fix changes where text is rendered, never what it says.
+    expect(composed.startsWith(resolveEscalationText(composed))).toBe(true);
+  });
+
+  it('drops the appended RAG half so the answer is not duplicated in the banner', () => {
+    const composed = ESCALATION + ESCALATION_RAG_SEPARATOR + RAG_HALF;
+    expect(resolveEscalationText(composed)).not.toContain('Educational answer');
+    expect(resolveEscalationText(composed)).not.toContain('Information from trusted sources');
+  });
+
+  it('returns the whole response when no RAG half was appended', () => {
+    expect(resolveEscalationText(ESCALATION)).toBe(ESCALATION);
+  });
+
+  it('ignores a blank bannerText and falls back to slicing', () => {
+    const composed = ESCALATION + ESCALATION_RAG_SEPARATOR + RAG_HALF;
+    expect(resolveEscalationText(composed, '   ')).toBe(ESCALATION);
+    expect(resolveEscalationText(composed, null)).toBe(ESCALATION);
+  });
+});

--- a/apps/web/src/utils/escalationText.ts
+++ b/apps/web/src/utils/escalationText.ts
@@ -1,0 +1,29 @@
+/**
+ * Separator the API uses to join the safety escalation block and the appended
+ * RAG answer on the urgent path (`ESCALATION_RAG_SEPARATOR` in
+ * apps/api/src/modules/chat/chat.service.ts). Kept byte-identical here.
+ */
+export const ESCALATION_RAG_SEPARATOR = "\n\n**Information from trusted sources:**\n\n";
+
+/**
+ * Picks the text the emergency banner should show (issue #111).
+ *
+ * Prefers `safety.bannerText`, which the API sends alongside
+ * `show_emergency_banner`. Falls back to slicing the composed response at the
+ * separator so the banner is still correct against an API build that predates
+ * that field.
+ *
+ * This only chooses where to cut — the escalation copy itself is never
+ * rewritten, and the full response still renders once in the message bubble.
+ */
+export function resolveEscalationText(
+  responseText: string,
+  bannerText?: string | null
+): string {
+  if (bannerText && bannerText.trim().length > 0) {
+    return bannerText;
+  }
+
+  const separatorIndex = responseText.indexOf(ESCALATION_RAG_SEPARATOR);
+  return separatorIndex === -1 ? responseText : responseText.slice(0, separatorIndex);
+}


### PR DESCRIPTION
Fixes #111.

## What live prod did

Browser QA run `2026-09-10T19-02-52_seed444043013`, question q05 (`messageId f35aa46a`), against `chat.suchitracancercare.org`. One escalated message, two surfaces, DOM read (not a screenshot):

```
banner : literal_asterisks=true,  <strong>=0, <em>=0
bubble : literal_asterisks=false, <strong>=8, <em>=1
```

`ChatInterface.tsx:163-166` set `safetyBanner.message = response.responseText` — the **entire** reply — and `SafetyBanner.tsx:23` rendered `{message}` as plain text. So a patient on the emergency path read `**Call for help immediately:** • **112** (national emergency number) or **108**…` as literal markup collapsed into one dense paragraph, **and** saw the same ~3,000-character answer a second time, correctly formatted, in the bubble below. Highest-stakes path, worst formatting.

## What changed

**API — `apps/api/src/modules/chat/chat.service.ts`**
- Extracted the join string into an exported `ESCALATION_RAG_SEPARATOR` constant (previously an inline literal in two places, lines 424/432).
- On the urgent path, the escalation block is captured into `escalationText` *before* the RAG half is appended, and returned as `safety.bannerText`. It is therefore a byte-exact prefix of `responseText` — no slicing, no re-wording.
- The other two `show_emergency_banner` returns (emergency fast path, safety-classification branch) set `bannerText` to the full reply, which is what the escalation is on those paths.

**Web**
- `SafetyBanner.tsx` renders through `ReactMarkdown` (with `removeCitationMarkers`), the same pipeline `MessageList.tsx:53` uses for the bubble.
- `ChatInterface.tsx` passes `resolveEscalationText(responseText, safety.bannerText)` instead of the whole reply.
- New `apps/web/src/utils/escalationText.ts`: prefers `bannerText`; falls back to slicing at the separator.
- `services/api.ts`: `safety.bannerText?: string`.

### Client-side fallback — the tradeoff

The banner prefers the server field, but keeps a client-side slice at the separator. Without it the fix would do nothing against the currently-deployed API (which has no `bannerText`), since web and API deploy separately. The slice is defensive: no match → returns the response unchanged, so the worst case is today's behaviour, now rendered as markdown. The separator constant is duplicated byte-for-byte on both sides with a comment on each pointing at the other.

### Not changed

Escalation copy is byte-identical (asserted against `ResponseTemplates.S2`), classification and `actions` untouched, safety module not reordered or bypassed. This changes *where* text renders, not what it says.

Residual, deliberate: the escalation block itself still appears in both the banner and the bubble (the bubble is the full transcript record). What is gone is the duplication of the whole ~3,000-char answer. Narrowing that further would mean editing the delivered message text, which is SCCF territory.

## Tests

Regression tests fail on the pre-fix sources — verified by checking the three source files back out to `HEAD~1` and re-running:
- web: **7 failed** (the 2 that passed are the classification-title tests, unrelated to rendering)
- api: the spec fails to compile (`ESCALATION_RAG_SEPARATOR` does not exist)

With the fix:

```
$ cd apps/web && npx vitest run
Test Files  12 passed (12)
     Tests  170 passed (170)          # baseline on origin/main: 155

$ cd apps/web && npx tsc --noEmit     # exit 0

$ cd apps/api && npx jest
Test Suites: 53 passed, 53 total
Tests:       979 passed, 979 total    # baseline on origin/main: 52 suites / 975 tests
```

New coverage:
- `SafetyBanner.test.tsx` — banner text contains no literal `**` and no raw `---`; `<strong>` present; `[citation:` markers do not leak.
- `ChatInterface.escalation.test.tsx` — banner holds only the escalation; the appended answer appears exactly once on the page; markdown renders in both surfaces; the no-`bannerText` fallback path is covered.
- `escalationText.test.ts` — separator slicing, blank/absent `bannerText`, copy left byte-identical.
- `chat.service.escalation-banner.spec.ts` — `bannerText` equals `ResponseTemplates.S2(...)` exactly and is a prefix of `responseText`; the urgent path still escalates and still appends the trusted-sources half; fast path also sets it.

## Unverified assumptions

- Not re-run against live prod — this branch is not deployed. The DOM evidence above is from prod before the fix; the after-state is asserted in jsdom.
- `bannerText` is additive and optional, so an un-upgraded web client is unaffected. Not exercised against a real deployed API pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)