### PR TITLE
fix(whatsapp): strip citation markers, relative links and --- rules from outbound text (#116)

### DIFF
--- a/apps/api/src/modules/whatsapp/whatsapp-format.spec.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp-format.spec.ts
@@ -82,6 +82,13 @@ describe("toWhatsAppMarkdown — internal markup must not reach the patient (#11
     expect(toWhatsAppMarkdown("Text [source:kb_x]")).toBe("Text");
   });
 
+  it("strips an UNTERMINATED marker left by a cut-off generation (shared text-cleaning behaviour, #68/#87)", () => {
+    expect(toWhatsAppMarkdown("might be effective [citation:kb_en_nci_types_breast_diagnosis_v1:kb_")).toBe(
+      "might be effective",
+    );
+    expect(toWhatsAppMarkdown("Rest helps [1]. Drink water [2].")).toBe("Rest helps. Drink water.");
+  });
+
   it("renders a RELATIVE markdown link as its label only (no dead path delivered)", () => {
     const leaked =
       "Side effects of chemotherapy The most common side effect of chemotherapy is [fatigue](/about-cancer/treatment/side-effects/fatigue), which is feeling exhausted or extremely tired.";

--- a/apps/api/src/modules/whatsapp/whatsapp-format.spec.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp-format.spec.ts
@@ -6,6 +6,9 @@ import {
   WA_MAX_LEN,
   WA_MAX_MESSAGES,
 } from "./whatsapp-format";
+import { appendDisclaimer } from "../safety/disclaimer-engine";
+import { evaluateEmergencyFastPath } from "../safety/emergency-fast-path";
+import { ResponseTemplates } from "../chat/response-templates";
 
 describe("toWhatsAppMarkdown", () => {
   it("converts ** bold ** to WhatsApp *bold*", () => {
@@ -36,6 +39,84 @@ describe("toWhatsAppMarkdown", () => {
 
   it("collapses excessive blank lines", () => {
     expect(toWhatsAppMarkdown("a\n\n\n\nb")).toBe("a\n\nb");
+  });
+});
+
+// Regression tests for #116: internal markup delivered to patients on the live
+// WhatsApp channel (2026-09-10). Strings below are the exact leaked fragments
+// quoted in the issue (no patient data — bot output only).
+describe("toWhatsAppMarkdown — internal markup must not reach the patient (#116)", () => {
+  it("strips [citation:docId:chunkId] markers, including internal KB doc ids", () => {
+    const leaked =
+      "Bleeding and Bruising and Cancer Treatment - Side Effects - NCI [citation:kb_en_nci_about_cancer_treatment_side_effects_bleeding_bruising_v1:kb_en_nci_about_cancer_treatment_side_effects_bleeding_bruising_v1::chunk::0]";
+    const out = toWhatsAppMarkdown(leaked);
+    expect(out).toBe("Bleeding and Bruising and Cancer Treatment - Side Effects - NCI");
+    expect(out).not.toMatch(/\[citation:/);
+    expect(out).not.toContain("kb_en_");
+  });
+
+  it("strips several citation markers on consecutive lines and leaves the sentences intact", () => {
+    const leaked = [
+      "Red flags (seek urgent care now) If you experience any of these symptoms, seek immediate medical attention: - Severe shortness of breath or chest... [citation:kb_en_red_flags_urgent_care_v1:kb_en_red_flags_urgent_care_v1::chunk::0]",
+      "Coping with breast cancer treatment Cancer treatment can cause side effects or changes to your body and how you feel. [citation:kb_en_nci_types_breast_breast_cancer_survivorship_v1:kb_en_nci_types_breast_breast_cancer_survivorship_v1::chunk::1]",
+    ].join("\n");
+    const out = toWhatsAppMarkdown(leaked);
+    expect(out).not.toMatch(/\[citation:/);
+    expect(out).toContain("seek immediate medical attention");
+    expect(out).toContain("changes to your body and how you feel.");
+    expect(out.split("\n")).toHaveLength(2);
+  });
+
+  it("strips a mid-sentence marker without leaving a double space before the period", () => {
+    expect(toWhatsAppMarkdown("Chemo can cause fatigue [citation:doc:chunk]. Rest helps.")).toBe(
+      "Chemo can cause fatigue. Rest helps.",
+    );
+  });
+
+  it("strips the raw '**Sources:**' block appended by citation repair (same as the web controller)", () => {
+    const text = "Answer text.\n\n**Sources:** [citation:kb_a:kb_a::chunk::0] [citation:kb_b:kb_b::chunk::2]";
+    expect(toWhatsAppMarkdown(text)).toBe("Answer text.");
+  });
+
+  it("strips [source:...] markers (voice parity)", () => {
+    expect(toWhatsAppMarkdown("Text [source:kb_x]")).toBe("Text");
+  });
+
+  it("renders a RELATIVE markdown link as its label only (no dead path delivered)", () => {
+    const leaked =
+      "Side effects of chemotherapy The most common side effect of chemotherapy is [fatigue](/about-cancer/treatment/side-effects/fatigue), which is feeling exhausted or extremely tired.";
+    expect(toWhatsAppMarkdown(leaked)).toBe(
+      "Side effects of chemotherapy The most common side effect of chemotherapy is fatigue, which is feeling exhausted or extremely tired.",
+    );
+  });
+
+  it("still rewrites ABSOLUTE links to 'label: url'", () => {
+    expect(toWhatsAppMarkdown("[NCI](https://www.cancer.gov/x) and [anchor](#top) and [rel](./page)")).toBe(
+      "NCI: https://www.cancer.gov/x and anchor and rel",
+    );
+  });
+
+  it("drops the '---' separator line emitted by the disclaimer append, keeping the disclaimer", () => {
+    const leaked =
+      "Would you like me to help you think of some questions to ask your doctor during your visit?\n\n---\n*This information is for general educational purposes only and is not a substitute for professional medical advice, diagnosis, or treatment. Always consult your healthcare provider for personalized guidance.*";
+    const out = toWhatsAppMarkdown(leaked);
+    expect(out).not.toMatch(/^-{3,}$/m);
+    expect(out).toContain("questions to ask your doctor during your visit?");
+    expect(out).toContain("This information is for general educational purposes only");
+    // No stray blank-line run where the rule used to be.
+    expect(out).not.toMatch(/\n{3,}/);
+  });
+
+  it("drops '***' / '___' rules and the template closing-note '---' too", () => {
+    const text = "Track your temperature daily\n\n---\n_Every patient's experience is different._\n***\nend\n___";
+    const out = toWhatsAppMarkdown(text);
+    expect(out).not.toMatch(/^[-*_]{3,}$/m);
+    expect(out).toContain("Every patient's experience is different.");
+    expect(out).toContain("end");
+  });
+
+  it("does not mistake a bullet or a hyphenated word for a horizontal rule", () => {
+    expect(toWhatsAppMarkdown("- one\n-- not a rule --\nwell-known")).toBe("• one\n-- not a rule --\nwell-known");
   });
 });
 
@@ -91,6 +172,41 @@ describe("splitForWhatsApp", () => {
 describe("formatForWhatsApp", () => {
   it("translates then splits", () => {
     expect(formatForWhatsApp("**hi** there")).toEqual(["*hi* there"]);
+  });
+
+  // #116 follow-up check: emergency content must arrive whole. The S2 urgent
+  // template + emergency disclaimer is the exact composition the chat pipeline
+  // sends for a red flag (chat.service urgency branch → appendDisclaimer).
+  it("delivers the S2 emergency template + emergency disclaimer as ONE message with every bullet intact", () => {
+    const composed = appendDisclaimer(ResponseTemplates.S2({ isFirstMessage: true, userText: "x" } as any), "en", true);
+    const msgs = formatForWhatsApp(composed);
+    expect(msgs).toHaveLength(1);
+    const body = msgs[0];
+    expect(body).toContain("• *112* (national emergency number) or *108* (ambulance service)");
+    expect(body).toContain("• If you have severe bleeding, apply gentle pressure if possible (without causing more harm)");
+    expect(body).toContain("If this is a medical emergency, call 112 or 108 immediately.");
+    expect(body).not.toMatch(/^-{3,}$/m);
+    expect(body.length).toBeLessThanOrEqual(WA_MAX_LEN);
+  });
+
+  it("delivers the emergency fast-path response as ONE message", () => {
+    const fp = evaluateEmergencyFastPath("She collapsed during chemo");
+    expect(fp.isEmergency).toBe(true);
+    const msgs = formatForWhatsApp(appendDisclaimer(fp.responseText!, "en", true));
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain("112");
+    expect(msgs[0]).toContain("108");
+  });
+
+  it("keeps every emergency bullet whole even when the template straddles a message boundary", () => {
+    const s2 = toWhatsAppMarkdown(ResponseTemplates.S2({ isFirstMessage: true, userText: "x" } as any));
+    const bullets = s2.split("\n").filter((l) => l.startsWith("• "));
+    expect(bullets.length).toBeGreaterThan(5);
+    // Pad so the S2 block begins near the end of message 1.
+    const padded = "p".repeat(WA_MAX_LEN - 400) + "\n\n" + s2;
+    const msgs = formatForWhatsApp(padded);
+    expect(msgs.length).toBeGreaterThan(1);
+    for (const b of bullets) expect(msgs.some((m) => m.includes(b))).toBe(true);
   });
 });
 

--- a/apps/api/src/modules/whatsapp/whatsapp-format.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp-format.ts
@@ -3,6 +3,8 @@
 // auto-links bare URLs. The chat pipeline emits GitHub-flavoured markdown, so
 // we translate, then split on the 4096-char message-body limit.
 
+import { stripCitationDebris, stripCitationMarkers } from "../../common/text-cleaning";
+
 // FR-9: configurable safe per-message threshold (well under WhatsApp's 4096 hard
 // cap) and a max number of outbound messages for one answer.
 export const WA_MAX_LEN = 3200;
@@ -10,23 +12,18 @@ export const WA_MAX_MESSAGES = 3;
 // Appended to the last message when content is truncated to the message cap.
 const CONTINUATION_NOTE = "(Reply *continue* / *aur* to see the rest.)";
 
-// Internal markup that must never reach a patient (#116, OD-003 "citations are
-// for auditors, not users"). Same patterns the web controller
-// (chat.controller.ts `cleanResponseForDisplay`) and the voice stripper
-// (chat/voice-output-stripper.ts) already apply on their channels.
-const RAW_SOURCES_SECTION_PATTERN = /\n\n\*\*Sources:\*\*\s*(\[citation:[^\]]+\]\s*)+/g;
-const CITATION_MARKER_PATTERN = /\s*\[(?:citation|source):[^\]]*\]/g;
 // A markdown horizontal rule on its own line (`---`, `***`, `___`), e.g. the
 // separator emitted by appendDisclaimer() and renderTemplate()'s closing note.
 const HORIZONTAL_RULE_LINE = /^[ \t]*([-*_])\1{2,}[ \t]*$/gm;
 
 /** Translate markdown emphasis/links/headings/bullets to WhatsApp-friendly text. */
 export function toWhatsAppMarkdown(input: string): string {
-  let t = input;
-
-  // Strip internal citation markup first so nothing below can mangle it.
-  t = t.replace(RAW_SOURCES_SECTION_PATTERN, "");
-  t = t.replace(CITATION_MARKER_PATTERN, "");
+  // Internal citation markup must never reach a patient (#116; OD-003 "citations
+  // are for auditors, not users"). Same shared primitives the web display path
+  // (chat/display-text-cleaner.ts) and the voice/TTS path use, so the three
+  // surfaces cannot drift again (#87). Runs first so nothing below can mangle
+  // a marker, then per-line trailing whitespace the strip may leave behind.
+  let t = stripCitationDebris(stripCitationMarkers(input)).replace(/[ \t]+$/gm, "");
 
   // Markdown links [label](url) -> "label: url" (WhatsApp auto-links the bare URL).
   t = t.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "$1: $2");

--- a/apps/api/src/modules/whatsapp/whatsapp-format.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp-format.ts
@@ -10,12 +10,32 @@ export const WA_MAX_MESSAGES = 3;
 // Appended to the last message when content is truncated to the message cap.
 const CONTINUATION_NOTE = "(Reply *continue* / *aur* to see the rest.)";
 
+// Internal markup that must never reach a patient (#116, OD-003 "citations are
+// for auditors, not users"). Same patterns the web controller
+// (chat.controller.ts `cleanResponseForDisplay`) and the voice stripper
+// (chat/voice-output-stripper.ts) already apply on their channels.
+const RAW_SOURCES_SECTION_PATTERN = /\n\n\*\*Sources:\*\*\s*(\[citation:[^\]]+\]\s*)+/g;
+const CITATION_MARKER_PATTERN = /\s*\[(?:citation|source):[^\]]*\]/g;
+// A markdown horizontal rule on its own line (`---`, `***`, `___`), e.g. the
+// separator emitted by appendDisclaimer() and renderTemplate()'s closing note.
+const HORIZONTAL_RULE_LINE = /^[ \t]*([-*_])\1{2,}[ \t]*$/gm;
+
 /** Translate markdown emphasis/links/headings/bullets to WhatsApp-friendly text. */
 export function toWhatsAppMarkdown(input: string): string {
   let t = input;
 
+  // Strip internal citation markup first so nothing below can mangle it.
+  t = t.replace(RAW_SOURCES_SECTION_PATTERN, "");
+  t = t.replace(CITATION_MARKER_PATTERN, "");
+
   // Markdown links [label](url) -> "label: url" (WhatsApp auto-links the bare URL).
   t = t.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "$1: $2");
+  // Relative / anchor links ([fatigue](/about-cancer/...), [x](#top), [y](./p))
+  // have no usable target on WhatsApp — keep the label only.
+  t = t.replace(/\[([^\]]+)\]\((?!https?:\/\/)[^\s)]*\)/g, "$1");
+
+  // Horizontal rules -> dropped (the blank-line collapse below tidies the gap).
+  t = t.replace(HORIZONTAL_RULE_LINE, "");
 
   // Code fences and inline code -> strip the backticks, keep the content.
   t = t.replace(/```[a-zA-Z0-9]*\n?/g, "").replace(/`([^`]+)`/g, "$1");


### PR DESCRIPTION
Closes #116

## What

Outbound WhatsApp messages on the live public number (2026-09-10) delivered internal markup to the patient: raw `[citation:docId:chunkId]` markers (with internal KB doc ids), an unconverted **relative** markdown link (`[fatigue](/about-cancer/treatment/side-effects/fatigue)`), and the literal `---` line emitted by `appendDisclaimer()` / `renderTemplate()`.

`apps/api/src/modules/whatsapp/whatsapp-format.ts` → `toWhatsAppMarkdown()` now applies, in this order, before the existing bold/heading/bullet translation:

1. `stripCitationMarkers` + `stripCitationDebris` from `apps/api/src/common/text-cleaning.ts` — the **same shared primitives** the web display path (`chat/display-text-cleaner.ts`) and the voice/TTS path use since #87/#106. Covers the `**Sources:**` block, complete and *unterminated* `[citation:…]`/`[source:…]` markers, `[n]` refs, and the punctuation debris a strip leaves (` .` → `.`, `, ।` → `।`). No WhatsApp-local copy of the patterns, so the three surfaces cannot drift again.
2. absolute links unchanged (`label: url`); **relative / anchor links → label only** (no usable target on WhatsApp)
3. horizontal-rule lines (`---`, `***`, `___`) dropped; the existing blank-line collapse tidies the gap

(Second commit `c362dfe` replaced the first commit's local regexes with the shared helpers after I found `common/text-cleaning.ts` on `origin/main`.) Presentation only — no clinical wording, no prompt, no safety edits. Scope: WhatsApp outbound formatting path only.

## Tests

Regression tests in `whatsapp-format.spec.ts` use the exact leaked fragments quoted in the issue (bot output only, no patient data):

- citation marker with internal `kb_en_...` doc id → stripped, sentence intact
- consecutive marked lines → all markers gone, line count preserved
- mid-sentence marker → no double space before the period
- `**Sources:**` block, `[source:...]` marker
- relative link → label only; absolute link still `label: url`; anchor / `./` links → label
- the 01:30 reply's `---` + disclaimer → rule gone, disclaimer kept, no 3+ blank-line run
- `***` / `___` and the template closing-note `---`
- negative: `- bullet`, `-- text --`, `well-known` are not treated as rules

```
cd apps/api && npx jest --testPathPatterns=whatsapp -w 2
Test Suites: 6 passed, 6 total
Tests:       81 passed, 81 total        (11 new tests; 10 fail before the fix, pass after)
npx tsc --noEmit -p tsconfig.json       → exit 0
```

## Splitter check (asked in the issue): does `WA_MAX_LEN`/`WA_MAX_MESSAGES` cut emergency content mid-bullet?

**No.** `splitForWhatsApp` is line-atomic: a line is only ever hard-wrapped if it alone exceeds 3200 chars. Verified with three new tests:

- the real S2 urgent template + emergency disclaimer (the exact composition the urgency branch in `chat.service.ts` sends) formats to **one** message with every bullet and both helpline lines intact
- the emergency fast-path response + disclaimer → one message
- S2 padded so it straddles a message boundary → every bullet appears whole in some message

The `"... Severe shortness of breath or chest..."` cut-off seen in the live transcript is **not** the splitter. It is the retrieval-snippet preview in `plan-executor.service.ts` (~line 485-496: first sentence or first 150 chars + `"..."`) used to fill the `side_effects_info` section of the chemo-prep structured template. That is a content-rendering choice in the shared pipeline, not a WhatsApp presentation bug, so it is left out of this PR.

## Not changed

- Nothing in `chat/`, `safety/`, `llm/`, `kb/`.
- The remaining WhatsApp findings from the same live test are tracked separately: #115 (Hinglish path), #117 (awareness deflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

