### PR TITLE
fix(whatsapp,chat): CPU-starved turns, timeout→false S2 escalation, citation leak, awareness deflection (#115 #116 #117)

### DIFF
--- a/apps/api/src/modules/chat/mode-detector.spec.ts
+++ b/apps/api/src/modules/chat/mode-detector.spec.ts
@@ -22,6 +22,18 @@ describe("ModeDetector - identify questions", () => {
       expect(ModeDetector.detectMode("how to detect breast cancer")).toBe("explain");
     });
 
+    // Issue #117 — live prod repro (web and WhatsApp): this awareness question
+    // was routed to NAVIGATE and answered with "I can't list symptoms".
+    test("early warning signs + 'I want to know what to look for' -> EXPLAIN", () => {
+      expect(
+        ModeDetector.detectMode("What are the early warning signs of breast cancer? I want to know what to look for."),
+      ).toBe("explain");
+    });
+
+    test("signs of cancer + a real personal report still -> NAVIGATE", () => {
+      expect(ModeDetector.detectMode("what are the signs of breast cancer? I have found a lump")).toBe("navigate");
+    });
+
     test("can I identify if my mother has cancer -> NAVIGATE (personal reference)", () => {
       expect(ModeDetector.detectMode("can I identify if my mother has cancer")).toBe("navigate");
     });
@@ -29,9 +41,27 @@ describe("ModeDetector - identify questions", () => {
 
   describe("hasPersonalDiagnosisSignal", () => {
     test("detects first-person pronouns", () => {
-      expect(ModeDetector.hasPersonalDiagnosisSignal("I want to know")).toBe(true);
+      expect(ModeDetector.hasPersonalDiagnosisSignal("I think I have a lump")).toBe(true);
       expect(ModeDetector.hasPersonalDiagnosisSignal("my symptoms")).toBe(true);
       expect(ModeDetector.hasPersonalDiagnosisSignal("me personally")).toBe(true);
+    });
+
+    // Issue #117: "I want to know what to look for" is informational framing,
+    // not a personal symptom report. The bare "I" must not flip an awareness
+    // question into Navigate mode (which soft-redirects with no KB content).
+    test("informational framing with a first-person verb is NOT a personal signal", () => {
+      expect(ModeDetector.hasPersonalDiagnosisSignal("I want to know")).toBe(false);
+      expect(ModeDetector.hasPersonalDiagnosisSignal("I would like to learn about the signs")).toBe(false);
+      expect(ModeDetector.hasPersonalDiagnosisSignal("please tell me the warning signs")).toBe(false);
+      expect(ModeDetector.hasPersonalDiagnosisSignal("can you explain to me how it is detected")).toBe(false);
+    });
+
+    test("informational framing does not mask a real personal signal", () => {
+      expect(ModeDetector.hasPersonalDiagnosisSignal("I want to know if my lump is cancer")).toBe(true);
+      expect(ModeDetector.hasPersonalDiagnosisSignal("tell me what to do, I have a lump")).toBe(true);
+      // Codex review on #119: a bare "help me" can be the only personal signal.
+      expect(ModeDetector.hasPersonalDiagnosisSignal("how can you tell if cancer treatment will help me?")).toBe(true);
+      expect(ModeDetector.hasPersonalDiagnosisSignal("help me understand the warning signs")).toBe(false);
     });
 
     test("detects second-person direct questions", () => {

--- a/apps/api/src/modules/chat/mode-detector.ts
+++ b/apps/api/src/modules/chat/mode-detector.ts
@@ -192,6 +192,22 @@ export class ModeDetector {
    * - Symptom framing: I have, I got, I feel, experiencing, suffering from
    */
   static hasPersonalDiagnosisSignal(text: string): boolean {
+    // Phrases that use a first-person pronoun purely as informational framing
+    // ("I want to know what to look for", "please tell me the signs", "explain
+    // to me"). Remove them before matching so the bare "I"/"me" inside them does
+    // not read as a personal symptom report. Issue #117: "What are the early
+    // warning signs of breast cancer? I want to know what to look for." was
+    // routed to Navigate mode and soft-redirected with no KB content.
+    const informationalFraming = [
+      /\b(i|we)\s+(want|would like|need|wish|'d like|would love)\s+to\s+(know|learn|understand|find out|be aware)\b/gi,
+      // Only the genuinely informational forms: a bare "help me" / "let me" can be
+      // the sole personal signal ("will this treatment help me?") and must stay.
+      /\b(please\s+)?(tell|give|explain\s+to|show)\s+me\b/gi,
+      /\bhelp\s+me\s+(understand|learn|know)\b/gi,
+      /\blet\s+me\s+know\b/gi,
+    ];
+    const stripped = informationalFraming.reduce((t, p) => t.replace(p, " "), text);
+
     const personalSignals = [
       // First-person pronouns
       /\b(i|i'm|im|me|my|mine)\b/i,
@@ -206,7 +222,7 @@ export class ModeDetector {
       // Hindi family references
       /मदर|फादर|माँ|मम्मी|पापा|पत्नी|बच्चा|बेटा|बेटी/,
     ];
-    return personalSignals.some(pattern => pattern.test(text));
+    return personalSignals.some(pattern => pattern.test(stripped));
   }
 
   /**

--- a/apps/api/src/modules/whatsapp/whatsapp-format.spec.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp-format.spec.ts
@@ -37,6 +37,25 @@ describe("toWhatsAppMarkdown", () => {
   it("collapses excessive blank lines", () => {
     expect(toWhatsAppMarkdown("a\n\n\n\nb")).toBe("a\n\nb");
   });
+
+  // Issue #116 — delivered verbatim to a patient on the live number.
+  it("keeps only the label of a relative markdown link", () => {
+    expect(
+      toWhatsAppMarkdown("The most common side effect is [fatigue](/about-cancer/treatment/side-effects/fatigue), which is tiredness."),
+    ).toBe("The most common side effect is fatigue, which is tiredness.");
+  });
+
+  it("drops horizontal-rule lines", () => {
+    expect(toWhatsAppMarkdown("Any questions?\n\n---\n\nThis is general information.")).toBe(
+      "Any questions?\n\nThis is general information.",
+    );
+    expect(toWhatsAppMarkdown("a\n***\nb")).toBe("a\n\nb");
+  });
+
+  it("does not treat a bullet or bold text as a horizontal rule", () => {
+    expect(toWhatsAppMarkdown("- item")).toBe("• item");
+    expect(toWhatsAppMarkdown("**bold**")).toBe("*bold*");
+  });
 });
 
 describe("splitForWhatsApp", () => {

--- a/apps/api/src/modules/whatsapp/whatsapp-format.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp-format.ts
@@ -17,6 +17,14 @@ export function toWhatsAppMarkdown(input: string): string {
   // Markdown links [label](url) -> "label: url" (WhatsApp auto-links the bare URL).
   t = t.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "$1: $2");
 
+  // Relative links [label](/path) — common in KB content copied from NCI — have
+  // no usable URL on WhatsApp. Keep the label only (issue #116).
+  t = t.replace(/\[([^\]]+)\]\((?!https?:\/\/)[^\s)]*\)/g, "$1");
+
+  // Horizontal rules (---, ***, ___) are markdown-only; delivered literally they
+  // are just noise between paragraphs. Drop the line (issue #116).
+  t = t.replace(/^[ \t]*([-*_])(?:[ \t]*\1){2,}[ \t]*$/gm, "");
+
   // Code fences and inline code -> strip the backticks, keep the content.
   t = t.replace(/```[a-zA-Z0-9]*\n?/g, "").replace(/`([^`]+)`/g, "$1");
 

--- a/apps/api/src/modules/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp.service.spec.ts
@@ -212,6 +212,22 @@ describe("WhatsAppService", () => {
       expect(svc.sendText).toHaveBeenCalledWith("9199", expect.stringContaining("something went wrong"));
     });
 
+    // Issue #116: raw `[citation:docId:chunkId]` markers and the "**Sources:**"
+    // section reached a patient. The HTTP controller strips them; this channel
+    // bypasses the controller and must strip them itself.
+    it("strips citation markers and the raw Sources section before replying", async () => {
+      chat.handle.mockResolvedValueOnce({
+        responseText:
+          "Chemo can cause fatigue [citation:kb_en_a_v1:kb_en_a_v1::chunk::0].\n\n" +
+          "**Sources:** [citation:kb_en_a_v1:kb_en_a_v1::chunk::0] [citation:kb_en_b_v1:kb_en_b_v1::chunk::2]",
+      });
+      await svc.processInbound([{ wamid: "w-cite", from: "9199", text: "chemo side effects?" }]);
+      const sent = (svc.sendText as jest.Mock).mock.calls[0][1] as string;
+      expect(sent).not.toContain("[citation:");
+      expect(sent).not.toContain("Sources:");
+      expect(sent).toBe("Chemo can cause fatigue.");
+    });
+
     it("self-heals a deleted session: re-mints and retries once", async () => {
       // Active contact pointing at a session row that no longer exists.
       prisma.whatsAppContact.findUnique.mockResolvedValueOnce({

--- a/apps/api/src/modules/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp.service.ts
@@ -2,6 +2,7 @@ import { ForbiddenException, Injectable, Logger } from "@nestjs/common";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { PrismaService } from "../prisma/prisma.service";
 import { ChatService } from "../chat/chat.service";
+import { cleanResponseForDisplay } from "../chat/display-text-cleaner";
 import { SessionsService } from "../sessions/sessions.service";
 import { detectLocale, formatForWhatsApp } from "./whatsapp-format";
 import { InboundMessage, MetaMessage, MetaWebhookBody } from "./whatsapp.types";
@@ -257,7 +258,11 @@ export class WhatsAppService {
           throw err;
         }
       }
-      await this.sendText(msg.from, result.responseText);
+      // Citations are for auditors, not readers (OD-003). The HTTP path strips
+      // markers in ChatController; this channel bypasses the controller, so it
+      // must strip them itself or raw `[citation:...]` ids reach the patient
+      // (issue #116). The raw text stays in the DB for evaluation.
+      await this.sendText(msg.from, cleanResponseForDisplay(result.responseText));
       await this.markLedger(msg.wamid, "processed");
     } catch (err: any) {
       this.logger.error(`Failed to process WhatsApp message ${msg.wamid}: ${err?.message}`, err?.stack);

--- a/cloudbuild.gated.yaml
+++ b/cloudbuild.gated.yaml
@@ -93,6 +93,10 @@ steps:
       - '512Mi'
       - '--cpu'
       - '1'
+      # WhatsApp turns run AFTER the webhook has ACKed (fire-and-forget), so with
+      # request-scoped CPU the instance is throttled while the turn runs and the
+      # pipeline times out (issues #115/#116/#117). Keep CPU allocated always.
+      - '--no-cpu-throttling'
       - '--min-instances'
       - '0'
       - '--max-instances'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -77,6 +77,10 @@ steps:
       - '512Mi'
       - '--cpu'
       - '1'
+      # WhatsApp turns run AFTER the webhook has ACKed (fire-and-forget), so with
+      # request-scoped CPU the instance is throttled while the turn runs and the
+      # pipeline times out (issues #115/#116/#117). Keep CPU allocated always.
+      - '--no-cpu-throttling'
       - '--timeout'
       - '300'
       - '--min-instances'


### PR DESCRIPTION
Addresses #115. Closes #116. Closes #117.

## What this PR fixes

- **WhatsApp CPU starvation (#115):** bakes `--no-cpu-throttling` into both Cloud Build deploy configs. The config-only mitigation is already live; the code changes below still require a normal deploy from `main`.
- **Patient-facing citation/markup leakage (#116):** the WhatsApp path now runs the shared display cleaner before formatting/sending; relative markdown links keep only their label and horizontal-rule lines are removed.
- **Awareness-question deflection (#117):** informational framing such as `I want to know`, `let me know`, and `help me understand/learn/know` no longer turns a general awareness question into Navigate mode. A bare `help me` remains a personal signal, and `will this treatment help me?` is covered by a regression test expecting Navigate.

## Rebase / timeout wording

This branch was rebased onto `main` at `5a2d4f7`. `main` already fixed the timeout→false-S2 path in #97 using the existing A3 technical-failure template, so this PR adds **no new patient-facing timeout/emergency wording**.

## Scope of #115

This PR **addresses but does not fully close #115**. The known Hinglish/Devanagari emergency-pattern miss (`bleeding bahut zyada + chakkar`, etc.) remains tracked under #81 and needs its own safety remediation. The live WhatsApp replay below should be recorded on #115 after deployment.

## Post-deploy replay

Replay these against the public WhatsApp number after deploying `main`:

1. `breast cancer ke early symptoms kya hote hain? kab tak dhyan dena chahiye`
   - expected: normal awareness answer; no timeout/fallback, no false emergency escalation, no citation/markdown debris.
2. `What are the early warning signs of breast cancer? I want to know what to look for.`
   - expected: Explain/awareness answer rather than the no-KB soft redirect.
3. `meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??`
   - expected for this PR: no CPU-starvation failure/fallback. Emergency-pattern correctness for this Hinglish red flag remains #81.

## Verification on head `952a457`

- Chat + WhatsApp Jest: **26 suites / 509 tests pass**
- `tsc --noEmit`: clean
- Deploy config parity: OK
- GitHub required checks: **API unit tests** and **Build + config parity** green

## Follow-on

Durable queued processing is tracked in #120 (Cloud Tasks + authenticated worker). Once that path is proven, `--no-cpu-throttling` can be removed and request-based billing restored.