### PR TITLE
fix(whatsapp): bound each turn, answer budget timeouts with guidance, stop mangling typed Hinglish (#115) — REQUIRES SCCF REVIEW for the Hinglish red-flag gap

### DIFF
--- a/apps/api/src/modules/chat/chat.controller.ts
+++ b/apps/api/src/modules/chat/chat.controller.ts
@@ -3,11 +3,18 @@ import { Throttle } from "@nestjs/throttler";
 import { ChatDto } from "./dto";
 import { ChatService } from "./chat.service";
 import { cleanResponseForDisplay } from "./display-text-cleaner";
+import {
+  CHAT_TURN_TIMEOUT_MS,
+  isChatTimeoutError,
+  REQUEST_TIMEOUT_ERROR,
+  TIMEOUT_GUIDANCE_TEXT,
+} from "./timeout-fallback";
 
 @Controller("chat")
 export class ChatController {
   private readonly logger = new Logger(ChatController.name);
-  private readonly REQUEST_TIMEOUT_MS = 55000; // 55 seconds — aligned with bounded LLM budget so timeout fallback returns before Cloud Run cap
+  // Shared with the WhatsApp worker (timeout-fallback.ts) so both channels bound a turn identically.
+  private readonly REQUEST_TIMEOUT_MS = CHAT_TURN_TIMEOUT_MS;
 
   constructor(private readonly chat: ChatService) {}
 
@@ -25,7 +32,7 @@ export class ChatController {
         this.chat.handle(dto, abortController.signal),
         new Promise((_, reject) => {
           abortController.signal.addEventListener('abort', () =>
-            reject(new Error('REQUEST_TIMEOUT'))
+            reject(new Error(REQUEST_TIMEOUT_ERROR))
           );
         }),
       ]) as any;
@@ -41,20 +48,12 @@ export class ChatController {
     } catch (error: any) {
       this.logger.error(`Chat error: ${error.message}`, error.stack);
       
-      // Handle timeout errors gracefully
-      if (error.message === 'REQUEST_TIMEOUT' || 
-          error.message?.includes('timeout') || 
-          error.message?.includes('LLM generation timeout') ||
-          error.message?.includes('aborted')) {
+      // Handle timeout errors gracefully (same predicate + copy as the WhatsApp worker)
+      if (isChatTimeoutError(error)) {
         this.logger.warn(`Request timeout after ${this.REQUEST_TIMEOUT_MS}ms for session ${dto.sessionId}`);
         throw new GatewayTimeoutException({
           sessionId: dto.sessionId,
-          responseText: "I'm sorry — my response is taking longer than expected. " +
-            "In the meantime, here are some general steps you can take:\n\n" +
-            "1. **Talk to a doctor**: If you have symptoms or concerns about cancer, the most important step is seeing a healthcare professional.\n" +
-            "2. **Indian Cancer Society Helpline**: Call 1800-22-1951 (toll-free) for guidance.\n" +
-            "3. **Emergency**: If you're experiencing severe symptoms (coughing blood, sudden severe pain, difficulty breathing), call 112 or 108 for an ambulance.\n\n" +
-            "Please try asking your question again — I should be able to give you a more detailed, referenced answer.",
+          responseText: TIMEOUT_GUIDANCE_TEXT,
           safety: { classification: "normal" as const, actions: [] },
           error: "timeout"
         });

--- a/apps/api/src/modules/chat/chat.service.ts
+++ b/apps/api/src/modules/chat/chat.service.ts
@@ -27,7 +27,7 @@ import { PatientStateService, PatientState } from "./patient-state.service";
 import { evaluateEmergencyFastPath } from "../safety/emergency-fast-path";
 import { classifyAgenticIntent, AgenticIntentResult } from "./agentic-intent-router";
 import { appendDisclaimer } from "../safety/disclaimer-engine";
-import { cleanVoiceInput } from "./input-cleaner";
+import { cleanVoiceInput, correctMedicalSpelling } from "./input-cleaner";
 // Phase 2 Agentic components
 import { RetrievalToolService } from "../rag/retrieval-tool.service";
 import { QueryDecomposerService, SessionContext } from "../rag/query-decomposer.service";
@@ -191,7 +191,14 @@ export class ChatService {
     // ─── Phase 0: Voice Input Cleanup ────────────────────────────────
     // Web Speech API interim results can stutter/duplicate text.
     // Clean before any classification or persistence.
-    dto.userText = cleanVoiceInput(dto.userText);
+    //
+    // WhatsApp text is typed, never speech-interim, so it only gets the
+    // spelling corrections. The stutter/repeat collapse is wrong for typed
+    // Hindi/Hinglish: it rewrites reduplicated kinship terms and emphasis
+    // ("didi" → "di", "papa" → "pa", "bahut bahut" → "bahut"), mutating the
+    // caregiver's own words before classification and persistence (issue #115).
+    dto.userText =
+      dto.channel === "whatsapp" ? correctMedicalSpelling(dto.userText) : cleanVoiceInput(dto.userText);
 
     const obsTrace = this.observability.startTrace('chat_turn', {
       query: dto.userText?.substring(0, 200),

--- a/apps/api/src/modules/chat/chat.service.whatsapp-inbound.spec.ts
+++ b/apps/api/src/modules/chat/chat.service.whatsapp-inbound.spec.ts
@@ -1,0 +1,245 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ChatService } from "./chat.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { AnalyticsService } from "../analytics/analytics.service";
+import { SafetyService } from "../safety/safety.service";
+import { RagService } from "../rag/rag.service";
+import { LlmService } from "../llm/llm.service";
+import { EvidenceGateService } from "../evidence/evidence-gate.service";
+import { CitationService } from "../citations/citation.service";
+import { AbstentionService } from "../abstention/abstention.service";
+import { IntentClassifier } from "./intent-classifier";
+import { TemplateSelector } from "./template-selector";
+import { StructuredExtractorService } from "./structured-extractor.service";
+import { ResponseValidatorService } from "./response-validator.service";
+import { GreetingFlowService } from "./greeting-flow.service";
+import { EmpathyDetector } from "./empathy-detector";
+import { PatientStateService } from "./patient-state.service";
+import { ClinicalKeywordEnforcerService } from "../llm/clinical-keyword-enforcer";
+import { RetrievalToolService } from "../rag/retrieval-tool.service";
+import { QueryDecomposerService } from "../rag/query-decomposer.service";
+import { CrossLingualService } from "../rag/cross-lingual.service";
+import { ExecutionPlannerService } from "./execution-planner.service";
+import { PlanExecutorService } from "./plan-executor.service";
+import { OutputVerifierService } from "./output-verifier.service";
+import { ReviewService } from "../review/review.service";
+import { ObservabilityService } from "../observability/observability.service";
+import { isChatTimeoutError } from "./timeout-fallback";
+
+/**
+ * Issue #115 — what actually reaches the WhatsApp worker from `ChatService.handle`
+ * for the Hinglish texts sent on the live public number (2026-09-10).
+ *
+ * The texts below are the tester's own messages as quoted in the issue (no
+ * patient data). All LLM / RAG / DB dependencies are mocked; the point of these
+ * tests is the *control flow* of `handle()` for `channel: "whatsapp"`, not the
+ * answer content.
+ */
+
+const HINGLISH_BENIGN = "breast cancer ke early symptoms kya hote hain? kab tak dhyan dena chahiye";
+const HINGLISH_RED_FLAG =
+  "meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??";
+
+const CHUNKS = [
+  {
+    docId: "doc1",
+    chunkId: "chunk1",
+    content: "Breast cancer symptoms include lumps, nipple changes, and skin changes.",
+    document: { title: "Breast Cancer Symptoms - NCI", url: "https://example.com/a", source: "NCI", sourceType: "02_nci_core", citation: "NCI, 2025" },
+  },
+  {
+    docId: "doc2",
+    chunkId: "chunk2",
+    content: "Diagnosis requires clinical exam, mammogram, ultrasound, and biopsy.",
+    document: { title: "Breast Cancer Diagnosis - NCI", url: "https://example.com/b", source: "NCI", sourceType: "02_nci_core", citation: "NCI, 2025" },
+  },
+];
+
+function session(channel: string) {
+  return {
+    id: "wa-session",
+    createdAt: new Date(),
+    channel,
+    locale: "en",
+    userType: null,
+    status: "active",
+    userContext: null,
+    cancerType: null,
+    greetingCompleted: true,
+    emotionalState: "neutral",
+  };
+}
+
+async function buildService(opts: { channel: string; ragDelayMs?: number }) {
+  const prisma = {
+    $queryRaw: jest.fn().mockResolvedValue([session(opts.channel)]),
+    $executeRawUnsafe: jest.fn().mockResolvedValue(1),
+    session: { findUnique: jest.fn(), update: jest.fn().mockResolvedValue({}) },
+    message: {
+      create: jest.fn().mockImplementation((args: any) => Promise.resolve({ id: "m1", ...args.data, createdAt: new Date() })),
+      findMany: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(3), // not the first message (mirrors the live session)
+    },
+    messageCitation: { create: jest.fn(), createMany: jest.fn() },
+    safetyEvent: { create: jest.fn() },
+  };
+  const rag = {
+    retrieveWithExpansion: jest.fn().mockResolvedValue(CHUNKS),
+    retrieveWithMetadata: jest.fn().mockImplementation(async () => {
+      if (opts.ragDelayMs) {
+        // Fake-timer clock: model a slow retrieval stage without waiting for it.
+        jest.advanceTimersByTime(opts.ragDelayMs);
+      }
+      return CHUNKS;
+    }),
+    applyPatientStateFilter: jest.fn().mockImplementation((chunks: any[]) => chunks),
+  };
+  const llm = {
+    generateWithCitations: jest.fn().mockResolvedValue("Answer [citation:doc1:chunk1] [citation:doc2:chunk2]"),
+    generate: jest.fn().mockResolvedValue("Soft redirect text"),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ChatService,
+      { provide: PrismaService, useValue: prisma },
+      { provide: AnalyticsService, useValue: { emit: jest.fn().mockResolvedValue(undefined) } },
+      // Real rule-based safety layer: the point is that it stays "normal" for these texts.
+      { provide: SafetyService, useValue: new SafetyService() },
+      { provide: RagService, useValue: rag },
+      { provide: LlmService, useValue: llm },
+      {
+        provide: EvidenceGateService,
+        useValue: {
+          validateEvidence: jest.fn().mockImplementation((chunks: any[]) => ({
+            status: "ok",
+            approvedChunks: chunks ?? [],
+            reasonCode: null,
+            shouldAbstain: false,
+            confidence: "medium",
+            quality: "strong",
+          })),
+          generateClarifyingQuestion: jest.fn(),
+        },
+      },
+      {
+        provide: CitationService,
+        useValue: {
+          extractCitations: jest.fn().mockImplementation((text: string) => {
+            const citations: any[] = [];
+            const re = /\[citation:([^:\]]+):([^\]]+)\]/g;
+            let m: RegExpExecArray | null;
+            while ((m = re.exec(text)) !== null) {
+              citations.push({ docId: m[1], chunkId: m[2], position: m.index, citationText: m[0] });
+            }
+            return { citations, orphanCount: 0, orphanCitations: [] };
+          }),
+          validateCitations: jest.fn().mockReturnValue({ isValid: true, confidenceLevel: "GREEN", citations: [], citationDensity: 0.5 }),
+          enrichCitations: jest.fn().mockResolvedValue([]),
+        },
+      },
+      // Real rule-based urgency layer + intent classifier: these are what route the live texts.
+      { provide: AbstentionService, useValue: new AbstentionService() },
+      { provide: IntentClassifier, useFactory: (a: AbstentionService) => new IntentClassifier(a), inject: [AbstentionService] },
+      { provide: TemplateSelector, useValue: { selectAndGenerate: jest.fn().mockReturnValue({ responseText: "template", intent: "UNCLEAR_REQUEST" }) } },
+      { provide: StructuredExtractorService, useValue: new StructuredExtractorService() },
+      { provide: ResponseValidatorService, useValue: { validate: jest.fn().mockReturnValue({ shouldAbstain: false, isValid: true, ungroundedEntities: [] }) } },
+      {
+        provide: GreetingFlowService,
+        useValue: {
+          extractContextFromMessage: jest.fn().mockResolvedValue({ context: undefined, cancerType: undefined, confidence: 0.3 }),
+          needsGreetingFlow: jest.fn().mockResolvedValue(false),
+          getGreetingStep: jest.fn().mockResolvedValue(0),
+          isGreetingFlowInProgress: jest.fn().mockResolvedValue(false),
+          handleGreetingFlowInterruption: jest.fn().mockResolvedValue(undefined),
+          parseGreetingResponse: jest.fn(),
+          updateSessionContext: jest.fn().mockResolvedValue(undefined),
+        },
+      },
+      { provide: EmpathyDetector, useValue: new EmpathyDetector() },
+      { provide: PatientStateService, useValue: new PatientStateService() },
+      { provide: CrossLingualService, useValue: new CrossLingualService() },
+      { provide: OutputVerifierService, useValue: new OutputVerifierService() },
+      { provide: ClinicalKeywordEnforcerService, useValue: { enforce: (text: string) => text } },
+      { provide: QueryDecomposerService, useValue: { needsDecomposition: () => false, decompose: jest.fn() } },
+      { provide: RetrievalToolService, useValue: { multiRetrieve: jest.fn(), retrieve: jest.fn() } },
+      { provide: ExecutionPlannerService, useValue: { needsPlanning: () => false, plan: jest.fn() } },
+      { provide: PlanExecutorService, useValue: { execute: jest.fn() } },
+      {
+        provide: ReviewService,
+        useValue: {
+          copilotMode: "off",
+          review: jest.fn().mockResolvedValue({ verdict: "PASS" }),
+          persistRecord: jest.fn().mockResolvedValue(undefined),
+          buildBlockedFallback: jest.fn(),
+        },
+      },
+      {
+        provide: ObservabilityService,
+        useValue: { startTrace: () => ({}), startSpan: () => ({}), endSpan: jest.fn(), finalizeTrace: jest.fn() },
+      },
+    ],
+  }).compile();
+
+  return { chat: module.get<ChatService>(ChatService), prisma, rag, llm };
+}
+
+describe("ChatService.handle on channel=whatsapp — Hinglish inbound (#115)", () => {
+  afterEach(() => jest.useRealTimers());
+
+  it("keeps the caregiver's typed words intact: 'didi' is not collapsed to 'di' on WhatsApp", async () => {
+    const { chat, prisma, rag } = await buildService({ channel: "whatsapp" });
+    await chat.handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: HINGLISH_RED_FLAG });
+
+    // Persisted user turn and the retrieval query both see the original text.
+    const userTurn = prisma.message.create.mock.calls.map((c: any) => c[0].data).find((d: any) => d.role === "user");
+    expect(userTurn.text).toBe(HINGLISH_RED_FLAG);
+    expect(userTurn.text).toContain("meri didi");
+    for (const call of rag.retrieveWithMetadata.mock.calls) {
+      expect(call[0]).not.toMatch(/\bmeri di\b/);
+    }
+  });
+
+  it("still applies the voice-stutter cleanup on the web channel (unchanged behaviour)", async () => {
+    const { chat, prisma } = await buildService({ channel: "web" });
+    await chat.handle({ sessionId: "wa-session", channel: "web", locale: "en", userText: "telltell me about chemo" });
+    const userTurn = prisma.message.create.mock.calls.map((c: any) => c[0].data).find((d: any) => d.role === "user");
+    expect(userTurn.text).toBe("tell me about chemo");
+  });
+
+  it("rule layer: neither Hinglish text trips the emergency fast path, safety rules or urgency guard (the #81 coverage gap)", async () => {
+    const { chat, prisma } = await buildService({ channel: "whatsapp" });
+    for (const text of [HINGLISH_BENIGN, HINGLISH_RED_FLAG]) {
+      prisma.safetyEvent.create.mockClear();
+      const result = await chat.handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: text });
+      // No rule-based escalation fired: no SafetyEvent row, and the reply is not red-flag classified.
+      expect(prisma.safetyEvent.create).not.toHaveBeenCalled();
+      expect(result.safety.classification).toBe("normal");
+    }
+  });
+
+  it("REPRODUCTION: a slow pre-LLM stage makes handle() throw the 'LLM generation timeout' budget error that the WhatsApp worker used to answer with FALLBACK_REPLY", async () => {
+    jest.useFakeTimers();
+    // Retrieval alone eats 31s of the 45s turn budget → llmWithDeadline refuses to start
+    // the generation (MIN_BUDGET_FOR_LLM_MS = 15s) and throws instead of returning.
+    const { chat, llm } = await buildService({ channel: "whatsapp", ragDelayMs: 31_000 });
+
+    await expect(
+      chat.handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: HINGLISH_BENIGN }),
+    ).rejects.toThrow(/LLM generation timeout: no budget left/);
+
+    expect(llm.generateWithCitations).not.toHaveBeenCalled();
+    // …and it is exactly the class the shared predicate (web controller + WhatsApp worker) recognises.
+    await chat
+      .handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: HINGLISH_BENIGN })
+      .catch((err) => expect(isChatTimeoutError(err)).toBe(true));
+  });
+
+  it("the same text completes normally when the pre-LLM stage is fast", async () => {
+    jest.useFakeTimers();
+    const { chat } = await buildService({ channel: "whatsapp", ragDelayMs: 1_000 });
+    const result = await chat.handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: HINGLISH_BENIGN });
+    expect(result.responseText).toBeTruthy();
+    expect(result.safety.classification).toBe("normal");
+  });
+});

--- a/apps/api/src/modules/chat/structured-output-templates.spec.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.spec.ts
@@ -91,6 +91,27 @@ describe("StructuredOutputTemplates", () => {
         const result = selectOutputTemplate("NAVIGATION", [], "chemo ke liye kaise ready hona hai");
         expect(result).toBe(CHEMO_DAY_PREP);
       });
+
+      test("Hinglish: chemo + taiyari (romanised preparation)", () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo ke liye kya taiyari karni chahiye")).toBe(CHEMO_DAY_PREP);
+        expect(selectOutputTemplate("NAVIGATION", [], "pehli chemo se pehle tayari kaise karein")).toBe(CHEMO_DAY_PREP);
+      });
+
+      // Issue #115 (live WhatsApp 2026-09-10 01:35 IST; web QA q01 same day): a
+      // caregiver reporting heavy post-chemo bleeding was answered with the routine
+      // chemo-day checklist because the bare Hinglish question word "kya" counted
+      // as a preparation cue.
+      test("REGRESSION #115: a post-chemo red-flag report is NOT a chemo-prep question", () => {
+        const liveText =
+          "meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??";
+        expect(selectOutputTemplate("NAVIGATION", [], liveText)).toBeNull();
+        expect(selectOutputTemplate("EDUCATION", [], liveText)).toBeNull();
+      });
+
+      test("bare Hinglish question words do not select the chemo-prep template", () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo ke side effects kya hote hain")).toBeNull();
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo kaise kaam karti hai")).toBeNull();
+      });
     });
 
     describe("Second opinion queries → SECOND_OPINION_PREP", () => {

--- a/apps/api/src/modules/chat/structured-output-templates.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.ts
@@ -541,8 +541,14 @@ export function selectOutputTemplate(
 
   // Chemo preparation
   const isChemo = /\b(chemo|chemotherapy)\b/i.test(lowerText) || /कीमो/.test(lowerText);
+  // A preparation cue is required. Bare Hinglish question words ("kya",
+  // "kaise") are NOT one: almost every Hinglish sentence has them, so with
+  // them here any message that mentioned chemo — including a caregiver
+  // reporting heavy post-chemo bleeding ("... chemo ke baad ... bleeding
+  // bahut zyada ... kya karu") — was answered with the routine chemo-day
+  // checklist (issue #115, live 2026-09-10; web QA q01 same day).
   const isPrep =
-    /\b(prepare|preparation|ready|day|what to|kya|kaise)\b/i.test(lowerText) ||
+    /\b(prepare|preparation|ready|day|what to|taiya?a?ri|tayy?ari)\b/i.test(lowerText) ||
     /तैयारी/.test(lowerText);
   if (isChemo && isPrep) {
     return CHEMO_DAY_PREP;

--- a/apps/api/src/modules/chat/timeout-fallback.ts
+++ b/apps/api/src/modules/chat/timeout-fallback.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared timeout handling for every channel that fronts `ChatService.handle`.
+ *
+ * `ChatService` deliberately throws when a turn runs out of LLM budget
+ * (`llmWithDeadline` → "LLM generation timeout: …") or when the caller's
+ * AbortSignal fires. The web controller has always converted that class of
+ * error into a 504 carrying `TIMEOUT_GUIDANCE_TEXT`; the WhatsApp path did not,
+ * and answered the same error with a generic "something went wrong" (issue
+ * #115). Both channels now share the classifier and the copy below so they
+ * cannot drift again.
+ *
+ * The wording is the pre-existing web controller copy moved here verbatim —
+ * no clinical or escalation wording was authored in this file. Rewording it is
+ * an SCCF decision (AGENTS.md §1.3; docs/RELIABILITY_BACKLOG.md P1-11).
+ */
+
+/** Sentinel message for the per-request abort raced against `ChatService.handle`. */
+export const REQUEST_TIMEOUT_ERROR = "REQUEST_TIMEOUT";
+
+/**
+ * Per-turn wall-clock cap for one chat turn as seen by the channel. Aligned
+ * with `ChatService`'s bounded LLM budget so the fallback returns before the
+ * Cloud Run request cap. Shared by the web controller and the WhatsApp worker.
+ */
+export const CHAT_TURN_TIMEOUT_MS = 55_000;
+
+/** Patient-facing copy returned when a turn times out (moved from chat.controller.ts, unchanged). */
+export const TIMEOUT_GUIDANCE_TEXT =
+  "I'm sorry — my response is taking longer than expected. " +
+  "In the meantime, here are some general steps you can take:\n\n" +
+  "1. **Talk to a doctor**: If you have symptoms or concerns about cancer, the most important step is seeing a healthcare professional.\n" +
+  "2. **Indian Cancer Society Helpline**: Call 1800-22-1951 (toll-free) for guidance.\n" +
+  "3. **Emergency**: If you're experiencing severe symptoms (coughing blood, sudden severe pain, difficulty breathing), call 112 or 108 for an ambulance.\n\n" +
+  "Please try asking your question again — I should be able to give you a more detailed, referenced answer.";
+
+/**
+ * True for the error class `ChatService` raises when a turn ran out of time:
+ * the channel-level abort race, `llmWithDeadline` budget exhaustion, and
+ * upstream aborts. Same predicate the web controller has used since the
+ * bounded-budget work; extracted so WhatsApp applies the identical rule.
+ */
+export function isChatTimeoutError(error: unknown): boolean {
+  const message = (error as { message?: unknown } | null)?.message;
+  if (typeof message !== "string") return false;
+  return (
+    message === REQUEST_TIMEOUT_ERROR ||
+    message.includes("timeout") ||
+    message.includes("LLM generation timeout") ||
+    message.includes("aborted")
+  );
+}

--- a/apps/api/src/modules/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp.service.spec.ts
@@ -1,6 +1,13 @@
 import { ForbiddenException } from "@nestjs/common";
 import { createHmac } from "node:crypto";
-import { inboundLedgerId, INBOUND_LEDGER_EVENT, WhatsAppService } from "./whatsapp.service";
+import {
+  FALLBACK_REPLY,
+  inboundLedgerId,
+  INBOUND_LEDGER_EVENT,
+  WA_TURN_TIMEOUT_MS,
+  WhatsAppService,
+} from "./whatsapp.service";
+import { TIMEOUT_GUIDANCE_TEXT } from "../chat/timeout-fallback";
 import { MetaWebhookBody } from "./whatsapp.types";
 
 /**
@@ -181,6 +188,7 @@ describe("WhatsAppService", () => {
       await svc.processInbound([{ wamid: "w1", from: "9199", text: "what is chemo?" }]);
       expect(chat.handle).toHaveBeenCalledWith(
         expect.objectContaining({ sessionId: "sess-new", channel: "whatsapp", userText: "what is chemo?" }),
+        expect.any(AbortSignal),
       );
       expect(svc.sendText).toHaveBeenCalledWith("9199", "Here is some info.");
     });
@@ -226,7 +234,10 @@ describe("WhatsAppService", () => {
       await svc.processInbound([{ wamid: "heal1", from: "9199", text: "hi" }]);
 
       expect(chat.handle).toHaveBeenCalledTimes(2);
-      expect(chat.handle).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: "sess-new" }));
+      expect(chat.handle).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sessionId: "sess-new" }),
+        expect.any(AbortSignal),
+      );
       expect(sessions.create).toHaveBeenCalled();
       expect(svc.sendText).toHaveBeenCalledWith("9199", "Recovered.");
     });
@@ -236,6 +247,83 @@ describe("WhatsAppService", () => {
       await svc.processInbound([{ wamid: "noretry", from: "9199", text: "hi" }]);
       expect(chat.handle).toHaveBeenCalledTimes(1);
       expect(svc.sendText).toHaveBeenCalledWith("9199", expect.stringContaining("something went wrong"));
+    });
+
+    // Issue #115 — live public number, 2026-09-10: Hinglish turns ran 90–130s and
+    // then delivered FALLBACK_REPLY, because ChatService's budget errors were
+    // treated like any other exception and nothing bounded the turn.
+    describe("timeout handling (#115)", () => {
+      const HINGLISH_RED_FLAG =
+        "meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??";
+
+      it("passes the inbound text to ChatService unmodified, with an AbortSignal", async () => {
+        await svc.processInbound([{ wamid: "sig1", from: "9199", text: HINGLISH_RED_FLAG }]);
+        expect(chat.handle).toHaveBeenCalledWith(
+          expect.objectContaining({ channel: "whatsapp", userText: HINGLISH_RED_FLAG }),
+          expect.any(AbortSignal),
+        );
+      });
+
+      it("answers a ChatService LLM-budget timeout with the timeout guidance, not the generic fallback", async () => {
+        // The exact error class llmWithDeadline raises once a slow turn has eaten the budget.
+        chat.handle.mockRejectedValueOnce(new Error("LLM generation timeout: no budget left for explain-mode-llm1"));
+        await svc.processInbound([{ wamid: "budget1", from: "9199", text: HINGLISH_RED_FLAG }]);
+
+        expect(svc.sendText).toHaveBeenCalledTimes(1);
+        expect(svc.sendText).toHaveBeenCalledWith("9199", TIMEOUT_GUIDANCE_TEXT);
+        expect(svc.sendText).not.toHaveBeenCalledWith("9199", FALLBACK_REPLY);
+        // The guidance is the web channel's existing copy: it carries the helplines.
+        expect(TIMEOUT_GUIDANCE_TEXT).toContain("112");
+        expect(TIMEOUT_GUIDANCE_TEXT).toContain("108");
+        expect(ledger.rows.get(inboundLedgerId("budget1")).payload.status).toBe("failed");
+      });
+
+      it("bounds a hung turn at WA_TURN_TIMEOUT_MS, aborts the pipeline and still replies", async () => {
+        jest.useFakeTimers();
+        try {
+          let seenSignal: AbortSignal | undefined;
+          chat.handle.mockImplementationOnce(
+            (_dto: any, signal: AbortSignal) =>
+              new Promise(() => {
+                seenSignal = signal; // never settles — simulates a pipeline that ran away
+              }),
+          );
+
+          const run = svc.processInbound([{ wamid: "hang1", from: "9199", text: HINGLISH_RED_FLAG }]);
+          await Promise.resolve(); // let resolveSession + handle start
+          await jest.advanceTimersByTimeAsync(WA_TURN_TIMEOUT_MS + 1);
+          await run;
+
+          expect(WA_TURN_TIMEOUT_MS).toBe(55_000); // same cap as the web controller
+          expect(seenSignal?.aborted).toBe(true);
+          expect(svc.sendText).toHaveBeenCalledTimes(1);
+          expect(svc.sendText).toHaveBeenCalledWith("9199", TIMEOUT_GUIDANCE_TEXT);
+          expect(ledger.rows.get(inboundLedgerId("hang1")).payload).toMatchObject({
+            status: "failed",
+            error: "REQUEST_TIMEOUT",
+          });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it("keeps the generic fallback for non-timeout failures", async () => {
+        chat.handle.mockRejectedValueOnce(new Error("Gemini returned no output"));
+        await svc.processInbound([{ wamid: "other1", from: "9199", text: HINGLISH_RED_FLAG }]);
+        expect(svc.sendText).toHaveBeenCalledWith("9199", FALLBACK_REPLY);
+      });
+
+      it("does not fire the timeout after a turn that completed in time", async () => {
+        jest.useFakeTimers();
+        try {
+          await svc.processInbound([{ wamid: "fast1", from: "9199", text: "what is chemo?" }]);
+          await jest.advanceTimersByTimeAsync(WA_TURN_TIMEOUT_MS * 2);
+          expect(svc.sendText).toHaveBeenCalledTimes(1);
+          expect(svc.sendText).toHaveBeenCalledWith("9199", "Here is some info.");
+        } finally {
+          jest.useRealTimers();
+        }
+      });
     });
   });
 

--- a/apps/api/src/modules/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/modules/whatsapp/whatsapp.service.ts
@@ -3,11 +3,25 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { PrismaService } from "../prisma/prisma.service";
 import { ChatService } from "../chat/chat.service";
 import { SessionsService } from "../sessions/sessions.service";
+import {
+  CHAT_TURN_TIMEOUT_MS,
+  isChatTimeoutError,
+  REQUEST_TIMEOUT_ERROR,
+  TIMEOUT_GUIDANCE_TEXT,
+} from "../chat/timeout-fallback";
 import { detectLocale, formatForWhatsApp } from "./whatsapp-format";
 import { InboundMessage, MetaMessage, MetaWebhookBody } from "./whatsapp.types";
 
-const FALLBACK_REPLY =
+export const FALLBACK_REPLY =
   "Sorry, something went wrong on our side. Please try sending your message again.";
+
+/**
+ * Per-turn wall-clock cap for one WhatsApp turn (issue #115). Same value the
+ * web controller races against `ChatService.handle`; before this the WhatsApp
+ * worker had no bound at all, so a slow turn ran 90–130s and then surfaced as
+ * the generic FALLBACK_REPLY.
+ */
+export const WA_TURN_TIMEOUT_MS = CHAT_TURN_TIMEOUT_MS;
 
 /** Ledger row marker in `AnalyticsEvent.eventName` (see `claimInbound`). */
 export const INBOUND_LEDGER_EVENT = "whatsapp_inbound";
@@ -244,7 +258,7 @@ export class WhatsAppService {
       let sessionId = await this.resolveSession(msg.from, locale);
       let result;
       try {
-        result = await this.chat.handle({ sessionId, channel: "whatsapp", locale, userText: msg.text });
+        result = await this.handleWithTimeout(sessionId, locale, msg.text);
       } catch (err: any) {
         // Self-heal a stale/deleted session (the stored sessionId no longer
         // exists in the DB) — mint a fresh session and retry ONCE. Without
@@ -252,7 +266,7 @@ export class WhatsAppService {
         if (isInvalidSessionError(err)) {
           this.logger.warn(`Stale session ${sessionId} for WhatsApp contact — re-minting and retrying`);
           sessionId = await this.resolveSession(msg.from, locale, true);
-          result = await this.chat.handle({ sessionId, channel: "whatsapp", locale, userText: msg.text });
+          result = await this.handleWithTimeout(sessionId, locale, msg.text);
         } else {
           throw err;
         }
@@ -260,9 +274,42 @@ export class WhatsAppService {
       await this.sendText(msg.from, result.responseText);
       await this.markLedger(msg.wamid, "processed");
     } catch (err: any) {
-      this.logger.error(`Failed to process WhatsApp message ${msg.wamid}: ${err?.message}`, err?.stack);
+      // Timeout-class failures (the channel cap above, or ChatService's own
+      // "LLM generation timeout" budget errors) get the same guidance the web
+      // channel has always returned for them, instead of a bare "try again"
+      // (issue #115). Everything else keeps the generic fallback.
+      const timedOut = isChatTimeoutError(err);
+      this.logger.error(
+        `Failed to process WhatsApp message ${msg.wamid} (${timedOut ? "timeout" : "error"}): ${err?.message}`,
+        err?.stack,
+      );
       await this.markLedger(msg.wamid, "failed", err?.message);
-      await this.sendText(msg.from, FALLBACK_REPLY).catch(() => undefined);
+      await this.sendText(msg.from, timedOut ? TIMEOUT_GUIDANCE_TEXT : FALLBACK_REPLY).catch(() => undefined);
+    }
+  }
+
+  /**
+   * `ChatService.handle` bounded to `WA_TURN_TIMEOUT_MS`, mirroring the web
+   * controller: the AbortSignal lets the pipeline stop its own LLM calls, and
+   * the race guarantees the contact hears back even if it does not. Rejects
+   * with `REQUEST_TIMEOUT_ERROR` on the cap so the caller can classify it.
+   */
+  private async handleWithTimeout(sessionId: string, locale: string, userText: string) {
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        abortController.abort();
+        reject(new Error(REQUEST_TIMEOUT_ERROR));
+      }, WA_TURN_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([
+        this.chat.handle({ sessionId, channel: "whatsapp", locale, userText }, abortController.signal),
+        timeout,
+      ]);
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
Refs #115 (P0). Draft: the code fixes below are complete and tested; the PR is a draft because the **missed escalation of a Hinglish red flag is the #81 / QA0904-1 safety-keyword gap and needs SCCF review** (proposal at the bottom). Nothing in `safety/`, keyword lists, prompts or escalation wording is edited here.

## 1. Reproduction and diagnosis

All four live inbound texts were run, byte-exact from the tester's dump (`~/.hermes/suchi-whatsapp/runs/2026-09-10/raw_messages.jsonl`), through the rule layer and the routing layer in-repo. Findings, most certain first.

### 1a. Outcome #4 (01:35, 38.2s) — red flag answered with the chemo-prep checklist: **deterministic code bug, reproduced, fixed**

`meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??`

| layer | result |
|---|---|
| `evaluateEmergencyFastPath` | `isEmergency: false` |
| `SafetyService.evaluate` | `normal` |
| `AbstentionService.hasUrgencyIndicators` | `false` |
| `IntentClassifier` | `PERSONAL_SYMPTOMS` → agentic `NAVIGATION` |
| `ExecutionPlannerService.needsPlanning` | `true` |
| `selectOutputTemplate` (`structured-output-templates.ts:544`) | **`chemo_day_prep`** because `isChemo` (“chemo”) && `isPrep` matched the bare question word **`kya`** |

So the Phase-3 structured path (`chat.service.ts` ~1093-1225) rendered the "Before Your Chemo Session" template with `safetyClassification: "normal"`. This is channel-independent: the web QA run the same night (`2026-09-10T19-02-52_seed444043013`, **q01**, identical text) got the same "Before Your Chemo Session" content. Fixed by requiring a real preparation cue (`prepare|preparation|ready|day|what to|taiyari|tayari|तैयारी`); regression test uses the exact live text. **After this fix the text is still not escalated** — it falls to the navigate-mode soft redirect — because every rule layer above returns non-urgent. That residual is the SCCF item (§4).

### 1b. Outcomes #2 and #3 (90.5s / 130.8s → `FALLBACK_REPLY`): **timeout-class error escaping `handle()`, reproduced**

- The only LLM-call errors that propagate out of `ChatService.handle` are the budget wrapper's: `llmWithDeadline` (`chat.service.ts:119-148`) throws `LLM generation timeout: no budget left for <label>` when fewer than 15s of the 45s turn budget remain, or `… exceeded …ms budget` when a generation outlasts it. `LlmService.generateWithCitations` itself never throws on Gemini failure (returns abstention text, `llm.service.ts:1084,1193`).
- The web controller has always caught this class and returned a 504 with helpline guidance (`chat.controller.ts` `isChatTimeoutError` branch). The WhatsApp worker (`whatsapp.service.ts` `processOne`) treated it like any exception → `FALLBACK_REPLY`. Reproduced in `chat.service.whatsapp-inbound.spec.ts`: a 31s pre-LLM stage on `channel: "whatsapp"` makes `handle()` reject with `LLM generation timeout: no budget left…`, and `whatsapp.service.spec.ts` shows that reply was the generic fallback.
- Turn lengths: production sets `LLM_TIMEOUT_MS=45000` (`cloudbuild.yaml:91`); each of the unbounded `generateWithCitations` retries at `chat.service.ts:2032/2240/2490` can run up to 45s, and nothing bounded the WhatsApp turn as a whole. RAG + one 45s generation + one 45s retry ≈ 90-130s, matching the live timings. The web run the same night finished in 12-18s; the WhatsApp test was ~1h later on a `min-instances: 0` service, so an underprovisioned/cold instance is the likely reason those turns were slow at all — **not established; needs Cloud Logging** (see §3).

### 1c. Outcome #1 (01:27, 92.5s) — benign Hinglish question escalated to S2: **strongest hypothesis: the public number was serving a revision without the #94/#97 fix**

- Rule layer for `breast cancer ke early symptoms kya hote hain? kab tak dhyan dena chahiye`: fast-path `false`, safety `normal`, urgency `false`, intent `INFORMATIONAL_SYMPTOMS`, mode `explain`. No rule-based path on `origin/main` can produce S2 for it.
- The delivered reply is **1055 chars and ends exactly at the S2 template's last sentence**: no disclaimer, no "Next steps", no sources. Every S2 producer on `origin/main` appends a disclaimer (`persistAssistantMessage` / `appendDisclaimer`). The only code that ever emitted bare S2 via `prisma.message.create` without a disclaimer was the pre-RAG budget-exhausted branch, which returned `ResponseTemplates.S2(...)` until `913f26c` (#97, merged **2026-09-09 02:02 IST**) changed it to `A3` — issue #94, the "Hii" false escalation. That branch fires when >30s elapse **before RAG**, i.e. exactly a slow turn — and its twin outcome when the turn is a bit faster is the §1b budget throw. This explains the "same input, escalate once / fail next time" non-determinism as *timing*, not randomness.
- I could not confirm the deployed revision (`gcloud` unauthenticated here; deploy + traffic promotion are manual per `docs/DEPLOYMENT.md`). **Operator check:** `gcloud run revisions list --service suchi-api --region us-central1` and confirm whether the revision serving traffic at 2026-09-10 01:25 IST contains `913f26c`. If it predates it, outcome #1 is #94 recurring on the public number and is already fixed on `main` pending deploy.

### 1d. Hinglish text was being mutated before classification: **code bug, fixed**

`cleanVoiceInput` (`input-cleaner.ts:114`) ran for every channel. Its stutter rule `\b(\w{2,})\1\b` rewrites `didi`→`di`, `papa`→`pa`, `mama`→`ma`, and the repeat rule drops Hindi emphasis (`bahut bahut`). The live red-flag text was persisted and classified as `meri di chemo ke baad…`. WhatsApp input is typed, never speech-interim, so it now gets only `correctMedicalSpelling`. Web/voice unchanged (test covers both).

### 1e. Answers to the issue's questions

1. **Non-determinism:** timing-dependent branches (§1b/§1c), not randomness in classification — every classifier on this path is rule-based (`empathyDetector`, `greetingFlow.extractContextFromMessage`, `crossLingual` are rule-only; verified).
2. **Does WhatsApp skip a Hindi/Hinglish normalisation the web applies?** No. Both channels call the same `ChatService.handle`; the only normalisation is `normalizeForMatch` inside `SafetyService`, applied identically. `detectLocale` (`whatsapp-format.ts`) returns `en` for romanised Hinglish (Devanagari-only check), which affects disclaimer language, not routing. The web/WhatsApp divergence on the benign text is §1c, not normalisation.
3. **Per-turn timeout:** there was none on WhatsApp. Now `WA_TURN_TIMEOUT_MS = CHAT_TURN_TIMEOUT_MS = 55s` with an AbortSignal, mirroring the web controller.
4. **Should the catch reply "try again" to a suspected emergency?** Rule-detected emergencies never reach the catch (they return before any LLM call), so the only emergencies that can land there are ones the rule layer cannot see — the Hinglish gap. Detecting them needs new keywords → SCCF (§4). What this PR does: timeout-class failures now get the web channel's existing guidance (which includes 112/108 conditionally) instead of "try again".

## 2. Code changes

| file | change |
|---|---|
| `chat/timeout-fallback.ts` (new) | `TIMEOUT_GUIDANCE_TEXT` (moved verbatim from the controller), `CHAT_TURN_TIMEOUT_MS`, `isChatTimeoutError()` |
| `chat/chat.controller.ts` | uses the shared constants — behaviour identical |
| `whatsapp/whatsapp.service.ts` | `handleWithTimeout` races `chat.handle(dto, signal)` against the 55s cap; catch classifies timeout vs other; ledger records the error class |
| `chat/chat.service.ts:194` | WhatsApp: `correctMedicalSpelling` only, no stutter collapse |
| `chat/structured-output-templates.ts:544` | `isPrep` no longer matches bare `kya`/`kaise`; adds romanised `taiyari/tayari` |

**Judgment calls to review:** (a) reusing the web timeout copy on WhatsApp — it is existing patient-facing production text, not new wording, but backlog P1-11 notes rewording that copy is an SCCF call, so flagging that it now appears on a second channel; (b) tightening the chemo-prep selector changes routing for Hinglish chemo questions on all channels (they now go through the normal LLM/evidence path instead of the static checklist).

## 3. Tests

```
cd apps/api
npx jest --testPathPatterns="whatsapp|structured-output-templates|chat.service.whatsapp-inbound" -w 2
  → 8 suites, 132 tests, all pass (12 new; the two budget/fallback tests fail on origin/main)
npx jest --silent -w 2        → Test Suites: 53 passed, Tests: 988 passed
npx tsc --noEmit -p tsconfig.json → exit 0
```

New/changed specs: `whatsapp/whatsapp.service.spec.ts` (timeout guidance for `LLM generation timeout`, 55s cap aborts a hung turn and still replies, generic error unchanged, text passed unmodified + AbortSignal), `chat/chat.service.whatsapp-inbound.spec.ts` (didi preserved on whatsapp / stutter cleanup kept on web; rule layer stays `normal` for both Hinglish texts; the budget-throw reproduction), `chat/structured-output-templates.spec.ts` (exact live red-flag text → no template; romanised prep still routes).

**Not reproduced in-repo:** the actual production exception text and the served revision. Operator evidence to collect: Cloud Logging `resource.type="cloud_run_revision" AND textPayload:("Failed to process WhatsApp message" OR "LLM generation timeout" OR "budget exhausted")` for 2026-09-09 19:50–20:10 UTC, and the ledger rows `SELECT id, payload FROM "AnalyticsEvent" WHERE "eventName"='whatsapp_inbound' AND payload->>'status'='failed' AND payload->>'receivedAt' BETWEEN '2026-09-09T19:50' AND '2026-09-09T20:10'` (metadata only; no text/phone stored).

## 4. REQUIRES SCCF REVIEW — proposal, not authored here

The Hinglish red flag (`bleeding bahut zyada ho gayi aur chakkar aa raha hai` after chemo) returns non-urgent from all three detection layers (fast path, safety rules, `hasUrgencyIndicators`), while its English twin (`bleeding heavily and feels dizzy`) fires `hasUrgencyIndicators` → S2. Same class as #81 / QA0904-1. Proposed for medical review (do not patch blind):

1. `abstention.service.ts:43-71` `hasUrgencyIndicators` — add romanised-Hindi bleeding/dizziness/fainting patterns, e.g. `(khoon|khun|bleeding)\s+(bahut|zyada|jyada|bahut zyada|ruk nahi)`, `chakkar (aa|a) rah[ai]`, `behosh`, `saans (nahi|lene me)`, `bahut kamzor/kamjor` **+ chemo context**. Note the layer is `\b`-anchored ASCII, so Devanagari equivalents need a separate decision (QA0904-1 point 3).
2. `emergency-fast-path.ts` — a post-treatment bleeding + dizziness cluster in romanised Hindi.
3. Fallback wording: a failure reply that always carries "If this is an emergency call 112 / 108" (new copy → SCCF), so a pipeline failure never answers a possible emergency with only "try again".

## 5. Out of scope / not touched
#81/#53/#41 keyword lists, #110 Tier1, #86, #108; `kb/**`, prompts, safety module. #116 (markup leak) is PR #118; #117 is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
