### PR TITLE
fix(deploy,chat): ship a real hospitals.json in the API image; health reports a missing directory as degraded (#123)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -85,8 +85,16 @@ apps/web/test-results/
 eval/results/
 eval/reports/
 
-# Landing page (separate deployment)
-apps/landing/
+# Landing page (separate deployment) — excluded EXCEPT the hospital directory,
+# which is the canonical source that cloudbuild's `stage-hospitals` step copies
+# into apps/api/data/ for the API image (issue #123). gitignore semantics cannot
+# re-include a file under an excluded directory, so exclude contents level by level.
+apps/landing/*
+!apps/landing/src/
+apps/landing/src/*
+!apps/landing/src/content/
+apps/landing/src/content/*
+!apps/landing/src/content/hospitals.json
 
 
 

--- a/apps/api/src/common/hospital-directory-file.spec.ts
+++ b/apps/api/src/common/hospital-directory-file.spec.ts
@@ -1,0 +1,73 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  getHospitalDirectoryStatus,
+  readHospitalDirectoryFile,
+  recordHospitalDirectoryStatus,
+  resetHospitalDirectoryStatusForTests,
+} from "./hospital-directory-file";
+
+function tmpCwd(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "suchi-hospdir-"));
+  fs.mkdirSync(path.join(dir, "data"));
+  return dir;
+}
+
+describe("readHospitalDirectoryFile (issue #123)", () => {
+  it("reads a regular file", () => {
+    const cwd = tmpCwd();
+    fs.writeFileSync(path.join(cwd, "data/hospitals.json"), JSON.stringify({ hospitals: [{ id: "a" }, { id: "b" }] }));
+    const out = readHospitalDirectoryFile(cwd);
+    expect(out.hospitals).toHaveLength(2);
+    expect(out.resolvedVia).toBe("file");
+  });
+
+  it("follows a Windows pseudo-symlink (one-line relative path)", () => {
+    const cwd = tmpCwd();
+    fs.mkdirSync(path.join(cwd, "landing"));
+    fs.writeFileSync(path.join(cwd, "landing/hospitals.json"), JSON.stringify({ hospitals: [{ id: "a" }] }));
+    fs.writeFileSync(path.join(cwd, "data/hospitals.json"), "../landing/hospitals.json");
+    const out = readHospitalDirectoryFile(cwd);
+    expect(out.hospitals).toHaveLength(1);
+    expect(out.resolvedVia).toBe("pseudo-symlink");
+  });
+
+  it("throws on a missing file — the production shape (ENOENT)", () => {
+    const cwd = tmpCwd();
+    expect(() => readHospitalDirectoryFile(cwd)).toThrow(/ENOENT/);
+  });
+
+  it("throws on a dangling real symlink — the exact image shape", () => {
+    const cwd = tmpCwd();
+    fs.symlinkSync("../../landing/src/content/hospitals.json", path.join(cwd, "data/hospitals.json"));
+    expect(() => readHospitalDirectoryFile(cwd)).toThrow(/ENOENT/);
+  });
+
+  it("throws on an empty hospitals array instead of loading nothing silently", () => {
+    const cwd = tmpCwd();
+    fs.writeFileSync(path.join(cwd, "data/hospitals.json"), JSON.stringify({ hospitals: [] }));
+    expect(() => readHospitalDirectoryFile(cwd)).toThrow(/empty/);
+  });
+
+  it("throws when the hospitals key is missing", () => {
+    const cwd = tmpCwd();
+    fs.writeFileSync(path.join(cwd, "data/hospitals.json"), JSON.stringify({ nope: [] }));
+    expect(() => readHospitalDirectoryFile(cwd)).toThrow(/no "hospitals" array/);
+  });
+});
+
+describe("hospital directory status registry", () => {
+  beforeEach(() => resetHospitalDirectoryStatusForTests());
+
+  it("starts as not loaded", () => {
+    expect(getHospitalDirectoryStatus()).toMatchObject({ loaded: false, count: 0 });
+  });
+
+  it("records a load result with a timestamp", () => {
+    recordHospitalDirectoryStatus({ loaded: true, count: 83, path: "/app/data/hospitals.json", error: null });
+    const s = getHospitalDirectoryStatus();
+    expect(s).toMatchObject({ loaded: true, count: 83, error: null });
+    expect(s.checkedAt).toMatch(/^\d{4}-/);
+  });
+});

--- a/apps/api/src/common/hospital-directory-file.ts
+++ b/apps/api/src/common/hospital-directory-file.ts
@@ -1,0 +1,89 @@
+/**
+ * Single loader for the hospital directory file used by both
+ * `HospitalDirectoryService` (chat hospital search) and
+ * `WhatsAppNavigatorFlowService`.
+ *
+ * Canonical source: `apps/landing/src/content/hospitals.json`.
+ * `apps/api/data/hospitals.json` is a git symlink to it for local dev and Jest;
+ * in the Cloud Run image `cloudbuild`'s `stage-hospitals` step replaces the
+ * symlink with a real copy (a symlink would dangle — Docker context is apps/api).
+ *
+ * Issue #123: for ten days every production revision started with an EMPTY
+ * directory because the miss was a WARN and both services fell back silently.
+ * This module makes the outcome observable: callers log at ERROR and the
+ * health endpoint reports `hospitalDirectory` from the status recorded here.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+export interface HospitalDirectoryFile {
+  /** Path that was read (after pseudo-symlink resolution). */
+  path: string;
+  /** Raw entries from the `hospitals` array — callers filter tier/status. */
+  hospitals: unknown[];
+  resolvedVia: "file" | "pseudo-symlink";
+}
+
+export interface HospitalDirectoryStatus {
+  loaded: boolean;
+  count: number;
+  path: string | null;
+  error: string | null;
+  checkedAt: string | null;
+}
+
+let status: HospitalDirectoryStatus = {
+  loaded: false,
+  count: 0,
+  path: null,
+  error: "not loaded yet",
+  checkedAt: null,
+};
+
+/** Where the directory is expected relative to `cwd` (`/app` on Cloud Run, `apps/api` in Jest). */
+export function hospitalDirectoryPath(cwd: string = process.cwd()): string {
+  return path.resolve(cwd, "data/hospitals.json");
+}
+
+/**
+ * Read and parse the directory. Throws (with a message that names the path) on
+ * a missing file, a dangling symlink, invalid JSON, or an empty `hospitals`
+ * array — silence is what let #123 survive five revisions.
+ */
+export function readHospitalDirectoryFile(cwd: string = process.cwd()): HospitalDirectoryFile {
+  const jsonPath = hospitalDirectoryPath(cwd);
+  let raw = fs.readFileSync(jsonPath, "utf-8").trim();
+  let resolvedPath = jsonPath;
+  let resolvedVia: HospitalDirectoryFile["resolvedVia"] = "file";
+
+  // Windows Git without symlink support checks the link out as a one-line text
+  // file containing the relative target. Follow it.
+  if (raw.startsWith("..") && !raw.includes("\n")) {
+    resolvedPath = path.resolve(path.dirname(jsonPath), raw);
+    raw = fs.readFileSync(resolvedPath, "utf-8");
+    resolvedVia = "pseudo-symlink";
+  }
+
+  const parsed = JSON.parse(raw) as { hospitals?: unknown };
+  if (!Array.isArray(parsed.hospitals)) {
+    throw new Error(`${resolvedPath}: no "hospitals" array`);
+  }
+  if (parsed.hospitals.length === 0) {
+    throw new Error(`${resolvedPath}: "hospitals" array is empty`);
+  }
+  return { path: resolvedPath, hospitals: parsed.hospitals, resolvedVia };
+}
+
+/** Record the outcome of a load attempt so `/v1/health` can report it. */
+export function recordHospitalDirectoryStatus(next: Omit<HospitalDirectoryStatus, "checkedAt">): void {
+  status = { ...next, checkedAt: new Date().toISOString() };
+}
+
+export function getHospitalDirectoryStatus(): HospitalDirectoryStatus {
+  return { ...status };
+}
+
+/** Test hook. */
+export function resetHospitalDirectoryStatusForTests(): void {
+  status = { loaded: false, count: 0, path: null, error: "not loaded yet", checkedAt: null };
+}

--- a/apps/api/src/modules/chat/hospital-directory.service.ts
+++ b/apps/api/src/modules/chat/hospital-directory.service.ts
@@ -13,8 +13,11 @@
  */
 
 import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
-import * as fs from "fs";
-import * as path from "path";
+import {
+  hospitalDirectoryPath,
+  readHospitalDirectoryFile,
+  recordHospitalDirectoryStatus,
+} from "../../common/hospital-directory-file";
 
 // ─── Public Types ──────────────────────────────────────────────
 
@@ -120,34 +123,38 @@ export class HospitalDirectoryService implements OnModuleInit {
   // ─── Lifecycle ────────────────────────────────────────────────
 
   onModuleInit(): void {
-    // Single canonical path: apps/api/data/hospitals.json is a symlink to
-    // apps/landing/src/content/hospitals.json.
-    //   - Jest: process.cwd() = apps/api/
-    //   - Cloud Run: process.cwd() = /app  (cloudbuild stages the file there)
-    const jsonPath = path.resolve(process.cwd(), "data/hospitals.json");
-
+    // Canonical file + resolution rules live in common/hospital-directory-file.ts
+    // (shared with WhatsAppNavigatorFlowService). On Cloud Run cwd is /app and
+    // cloudbuild's stage-hospitals step materialises the file as a regular copy.
+    const jsonPath = hospitalDirectoryPath();
     try {
-      const raw = fs.readFileSync(jsonPath, "utf-8");
-      const parsed = JSON.parse(raw);
-      const allHospitals: (HospitalSearchResult & { national_referral?: boolean })[] =
-        parsed.hospitals ?? [];
+      const file = readHospitalDirectoryFile();
+      const allHospitals = file.hospitals as (HospitalSearchResult & { national_referral?: boolean })[];
       const active = allHospitals.filter((h) => h.tier !== "D");
       this.nationalHospitals = active
         .filter((h) => h.national_referral === true)
         .map((h) => ({ ...h, national_referral: true as const }));
       this.hospitals = active.filter((h) => h.national_referral !== true);
+      recordHospitalDirectoryStatus({ loaded: true, count: allHospitals.length, path: file.path, error: null });
       this.logger.log({
         event: "hospital_directory_loaded",
-        path: jsonPath,
+        path: file.path,
+        resolvedVia: file.resolvedVia,
         total: allHospitals.length,
         regional: this.hospitals.length,
         national: this.nationalHospitals.length,
         tierDFiltered: allHospitals.length - active.length,
       });
     } catch (err: any) {
-      this.logger.warn({
+      // ERROR, not WARN: with an empty directory every hospital-navigation answer
+      // silently loses the curated, scored, PMJAY-flagged centres (issue #123 —
+      // this was the production state for ten days across five revisions).
+      // /v1/health reports status "degraded" from the recorded status.
+      recordHospitalDirectoryStatus({ loaded: false, count: 0, path: jsonPath, error: String(err?.message ?? err) });
+      this.logger.error({
         event: "hospital_directory_not_found",
         path: jsonPath,
+        error: err?.message,
         message: "Hospital directory unavailable — falling back to KB markdown for navigation queries",
       });
       this.hospitals = [];

--- a/apps/api/src/modules/health/health.service.spec.ts
+++ b/apps/api/src/modules/health/health.service.spec.ts
@@ -1,0 +1,37 @@
+import { HealthService } from "./health.service";
+import {
+  recordHospitalDirectoryStatus,
+  resetHospitalDirectoryStatusForTests,
+} from "../../common/hospital-directory-file";
+
+describe("HealthService", () => {
+  const okPrisma = { $queryRaw: jest.fn().mockResolvedValue([{ "?column?": 1 }]) } as any;
+  const deadPrisma = { $queryRaw: jest.fn().mockRejectedValue(new Error("connection refused")) } as any;
+
+  beforeEach(() => resetHospitalDirectoryStatusForTests());
+
+  it("is ok when the database answers and the hospital directory is loaded", async () => {
+    recordHospitalDirectoryStatus({ loaded: true, count: 83, path: "/app/data/hospitals.json", error: null });
+    const out = await new HealthService(okPrisma).check();
+    expect(out.status).toBe("ok");
+    expect(out.database).toBe("connected");
+    expect(out.hospitalDirectory).toMatchObject({ loaded: true, count: 83 });
+  });
+
+  // Issue #123: this is the state production sat in for ten days while
+  // /v1/health said "ok". It must now be visible.
+  it("is degraded (not ok) when the database answers but the directory did not load", async () => {
+    recordHospitalDirectoryStatus({ loaded: false, count: 0, path: "/app/data/hospitals.json", error: "ENOENT" });
+    const out = await new HealthService(okPrisma).check();
+    expect(out.status).toBe("degraded");
+    expect(out.database).toBe("connected");
+    expect(out.hospitalDirectory).toMatchObject({ loaded: false, error: "ENOENT" });
+  });
+
+  it("is error when the database is unreachable, regardless of the directory", async () => {
+    recordHospitalDirectoryStatus({ loaded: true, count: 83, path: "/app/data/hospitals.json", error: null });
+    const out = await new HealthService(deadPrisma).check();
+    expect(out.status).toBe("error");
+    expect(out.database).toBe("disconnected");
+  });
+});

--- a/apps/api/src/modules/health/health.service.ts
+++ b/apps/api/src/modules/health/health.service.ts
@@ -1,6 +1,16 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
+import { getHospitalDirectoryStatus } from "../../common/hospital-directory-file";
 
+/**
+ * `status` semantics:
+ *   - "ok"       — database reachable AND the hospital directory loaded
+ *   - "degraded" — database reachable but a non-fatal dependency is missing
+ *                  (today: the hospital directory, issue #123). Still HTTP 200 so
+ *                  the Cloud Run startup probe is unaffected, but the gated
+ *                  pipeline refuses to promote a revision that is not "ok".
+ *   - "error"    — database unreachable
+ */
 @Injectable()
 export class HealthService {
   private readonly logger = new Logger(HealthService.name);
@@ -8,42 +18,24 @@ export class HealthService {
   constructor(private readonly prisma: PrismaService) {}
 
   async check() {
+    const hospitalDirectory = getHospitalDirectoryStatus();
     try {
       // Check database connectivity
       await this.prisma.$queryRaw`SELECT 1`;
       return {
-        status: "ok",
+        status: hospitalDirectory.loaded ? "ok" : "degraded",
         timestamp: new Date().toISOString(),
-        database: "connected"
+        database: "connected",
+        hospitalDirectory,
       };
     } catch (error) {
       this.logger.error(`Health check failed: ${error.message}`);
       return {
         status: "error",
         timestamp: new Date().toISOString(),
-        database: "disconnected"
+        database: "disconnected",
+        hospitalDirectory,
       };
     }
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/apps/api/src/modules/whatsapp-navigator/whatsapp-navigator-flow.service.ts
+++ b/apps/api/src/modules/whatsapp-navigator/whatsapp-navigator-flow.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
-import * as fs from "fs";
-import * as path from "path";
+import { hospitalDirectoryPath, readHospitalDirectoryFile } from "../../common/hospital-directory-file";
 import {
   AffordabilityLevel,
   CancerTypeGroup,
@@ -93,29 +92,16 @@ export class WhatsAppNavigatorFlowService implements OnModuleInit {
   }
 
   private loadHospitals(): void {
-    // Single canonical path: apps/api/data/hospitals.json is a symlink to
-    // apps/landing/src/content/hospitals.json.
-    //   - Jest: process.cwd() = apps/api/
-    //   - Cloud Run: process.cwd() = /app  (cloudbuild stages the file there)
-    const jsonPath = path.resolve(process.cwd(), "data/hospitals.json");
-
+    // Shared loader (common/hospital-directory-file.ts) — same file, same
+    // pseudo-symlink handling as HospitalDirectoryService. A miss here is the
+    // #123 shape (dangling symlink in the image) and is logged at ERROR; the
+    // health status is recorded by HospitalDirectoryService, which loads first.
     try {
-      let raw = fs.readFileSync(jsonPath, "utf-8").trim();
-
-      // Handle Windows Git pseudo-symlinks if Git didn't create a real symlink
-      if (raw.startsWith("..") && !raw.includes("\n")) {
-        const absoluteTarget = path.resolve(path.dirname(jsonPath), raw);
-        this.logger.log(`Detected pseudo-symlink for hospitals.json. Resolving to target: ${absoluteTarget}`);
-        raw = fs.readFileSync(absoluteTarget, "utf-8");
-      }
-
-      const parsed = JSON.parse(raw) as { hospitals: Hospital[] };
-      this.hospitals = (parsed.hospitals ?? []).filter(
-        (h) => h.status === "active"
-      );
-      this.logger.log(`Loaded ${this.hospitals.length} active hospitals`);
+      const file = readHospitalDirectoryFile();
+      this.hospitals = (file.hospitals as Hospital[]).filter((h) => h.status === "active");
+      this.logger.log(`Loaded ${this.hospitals.length} active hospitals from ${file.path}`);
     } catch (err: any) {
-      this.logger.error(`Failed to load hospitals.json from ${jsonPath}: ${err.message}`);
+      this.logger.error(`Failed to load hospitals.json from ${hospitalDirectoryPath()}: ${err.message}`);
       this.hospitals = [];
     }
   }

--- a/cloudbuild.gated.yaml
+++ b/cloudbuild.gated.yaml
@@ -3,9 +3,37 @@
 # Eval gate removed — use the /eval slash command locally before merging instead
 
 steps:
+  # hospitals.json: the canonical source is apps/landing/src/content/hospitals.json
+  # (the navigator approve flow appends there). apps/api/data/hospitals.json is a
+  # git SYMLINK to it for local dev/Jest. A symlink copied into the API image
+  # dangles (the Docker context is apps/api only), which left production with an
+  # EMPTY hospital directory on every revision until 2026-09-12 (issue #123).
+  # So: replace the symlink with a real file and FAIL THE BUILD if the result is
+  # not a regular, non-empty hospitals.json.
+  - name: 'ubuntu'
+    id: 'stage-hospitals'
+    args:
+      - 'bash'
+      - '-c'
+      - |
+        set -euo pipefail
+        src=apps/landing/src/content/hospitals.json
+        dst=apps/api/data/hospitals.json
+        test -f "$src" || { echo "FATAL: $src missing from build upload (check .gcloudignore)"; exit 1; }
+        mkdir -p apps/api/data
+        rm -f "$dst"
+        cp "$src" "$dst"
+        test -f "$dst" && ! test -L "$dst" || { echo "FATAL: $dst is not a regular file"; exit 1; }
+        grep -q '"hospitals"' "$dst" || { echo "FATAL: $dst has no hospitals array"; exit 1; }
+        count=$(grep -c '"id":' "$dst")
+        [ "$count" -ge 50 ] || { echo "FATAL: only $count hospital ids in $dst"; exit 1; }
+        echo "Staged $dst as a regular file with $count hospital ids"
+        ls -la "$dst"
+
   # 1) Build API Docker image
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-api'
+    waitFor: ['stage-hospitals']
     dir: 'apps/api'
     args:
       - 'build'
@@ -134,7 +162,9 @@ steps:
         echo "Checking health at: $health_url"
 
         for i in $(seq 1 60); do
-          if curl -fsS "$health_url" >/dev/null 2>&1; then
+          # Require status "ok" in the body: "degraded" (e.g. hospital directory
+          # not loaded, issue #123) is HTTP 200 but must NOT be promoted.
+          if curl -fsS "$health_url" 2>/dev/null | grep -q '"status":"ok"'; then
             echo "✅ Candidate revision is healthy"
             exit 0
           fi

--- a/cloudbuild.gated.yaml
+++ b/cloudbuild.gated.yaml
@@ -8,12 +8,12 @@ steps:
   # git SYMLINK to it for local dev/Jest. A symlink copied into the API image
   # dangles (the Docker context is apps/api only), which left production with an
   # EMPTY hospital directory on every revision until 2026-09-12 (issue #123).
-  # So: replace the symlink with a real file and FAIL THE BUILD if the result is
-  # not a regular, non-empty hospitals.json.
-  - name: 'ubuntu'
+  # So: replace the symlink with a real file and FAIL THE BUILD unless the result
+  # is a regular file whose JSON parses to a non-trivial hospitals array.
+  - name: 'node:20-slim'
     id: 'stage-hospitals'
+    entrypoint: 'bash'
     args:
-      - 'bash'
       - '-c'
       - |
         set -euo pipefail
@@ -24,10 +24,12 @@ steps:
         rm -f "$dst"
         cp "$src" "$dst"
         test -f "$dst" && ! test -L "$dst" || { echo "FATAL: $dst is not a regular file"; exit 1; }
-        grep -q '"hospitals"' "$dst" || { echo "FATAL: $dst has no hospitals array"; exit 1; }
-        count=$(grep -c '"id":' "$dst")
-        [ "$count" -ge 50 ] || { echo "FATAL: only $count hospital ids in $dst"; exit 1; }
-        echo "Staged $dst as a regular file with $count hospital ids"
+        node -e '
+          const d = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+          if (!Array.isArray(d.hospitals)) { console.error("FATAL: no hospitals array"); process.exit(1); }
+          if (d.hospitals.length < 50) { console.error("FATAL: only " + d.hospitals.length + " hospitals"); process.exit(1); }
+          console.log("Staged " + process.argv[1] + " as a regular file with " + d.hospitals.length + " hospitals");
+        ' "$dst"
         ls -la "$dst"
 
   # 1) Build API Docker image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,12 +6,32 @@
 # This allows both manual (gcloud builds submit) and trigger-based deployments.
 
 steps:
-  # hospitals.json is committed at apps/api/data/hospitals.json (canonical source).
-  # This step syncs from apps/landing/src/content/ when present (keeps both in sync),
-  # and falls back gracefully when the landing app is excluded from the build tarball.
+  # hospitals.json: the canonical source is apps/landing/src/content/hospitals.json
+  # (the navigator approve flow appends there). apps/api/data/hospitals.json is a
+  # git SYMLINK to it for local dev/Jest. A symlink copied into the API image
+  # dangles (the Docker context is apps/api only), which left production with an
+  # EMPTY hospital directory on every revision until 2026-09-12 (issue #123).
+  # So: replace the symlink with a real file and FAIL THE BUILD if the result is
+  # not a regular, non-empty hospitals.json.
   - name: 'ubuntu'
     id: 'stage-hospitals'
-    args: ['bash', '-c', 'mkdir -p apps/api/data && if [ -f apps/landing/src/content/hospitals.json ]; then cp apps/landing/src/content/hospitals.json apps/api/data/hospitals.json && echo "Synced hospitals.json from landing app"; else echo "hospitals.json already present at apps/api/data/hospitals.json (committed copy)"; fi && ls -la apps/api/data/hospitals.json']
+    args:
+      - 'bash'
+      - '-c'
+      - |
+        set -euo pipefail
+        src=apps/landing/src/content/hospitals.json
+        dst=apps/api/data/hospitals.json
+        test -f "$src" || { echo "FATAL: $src missing from build upload (check .gcloudignore)"; exit 1; }
+        mkdir -p apps/api/data
+        rm -f "$dst"
+        cp "$src" "$dst"
+        test -f "$dst" && ! test -L "$dst" || { echo "FATAL: $dst is not a regular file"; exit 1; }
+        grep -q '"hospitals"' "$dst" || { echo "FATAL: $dst has no hospitals array"; exit 1; }
+        count=$(grep -c '"id":' "$dst")
+        [ "$count" -ge 50 ] || { echo "FATAL: only $count hospital ids in $dst"; exit 1; }
+        echo "Staged $dst as a regular file with $count hospital ids"
+        ls -la "$dst"
 
   # Build API Docker image
   - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,12 +11,12 @@ steps:
   # git SYMLINK to it for local dev/Jest. A symlink copied into the API image
   # dangles (the Docker context is apps/api only), which left production with an
   # EMPTY hospital directory on every revision until 2026-09-12 (issue #123).
-  # So: replace the symlink with a real file and FAIL THE BUILD if the result is
-  # not a regular, non-empty hospitals.json.
-  - name: 'ubuntu'
+  # So: replace the symlink with a real file and FAIL THE BUILD unless the result
+  # is a regular file whose JSON parses to a non-trivial hospitals array.
+  - name: 'node:20-slim'
     id: 'stage-hospitals'
+    entrypoint: 'bash'
     args:
-      - 'bash'
       - '-c'
       - |
         set -euo pipefail
@@ -27,10 +27,12 @@ steps:
         rm -f "$dst"
         cp "$src" "$dst"
         test -f "$dst" && ! test -L "$dst" || { echo "FATAL: $dst is not a regular file"; exit 1; }
-        grep -q '"hospitals"' "$dst" || { echo "FATAL: $dst has no hospitals array"; exit 1; }
-        count=$(grep -c '"id":' "$dst")
-        [ "$count" -ge 50 ] || { echo "FATAL: only $count hospital ids in $dst"; exit 1; }
-        echo "Staged $dst as a regular file with $count hospital ids"
+        node -e '
+          const d = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+          if (!Array.isArray(d.hospitals)) { console.error("FATAL: no hospitals array"); process.exit(1); }
+          if (d.hospitals.length < 50) { console.error("FATAL: only " + d.hospitals.length + " hospitals"); process.exit(1); }
+          console.log("Staged " + process.argv[1] + " as a regular file with " + d.hospitals.length + " hospitals");
+        ' "$dst"
         ls -la "$dst"
 
   # Build API Docker image


### PR DESCRIPTION
Closes #123.

## What was wrong

Production has run with an **empty hospital directory on every revision since at least 2026-09-01**. Startup logs on `00411`…`00416` all show:

```
ERROR [WhatsAppNavigatorFlowService] Failed to load hospitals.json from /app/data/hospitals.json: ENOENT
WARN  [HospitalDirectoryService] { event: "hospital_directory_not_found" }
```

Chain: `apps/api/data/hospitals.json` is a git **symlink** → `apps/landing/src/content/hospitals.json`; `.gcloudignore` excluded `apps/landing/` entirely; so the build upload carried only the symlink; the old `stage-hospitals` step took its "already present (committed copy)" branch and `ls -la`'d the symlink as success; Docker `COPY . .` (context `apps/api`) copied a link that dangles inside the image. Both loaders swallowed the miss and served zero hospitals, while `/v1/health` said `ok`. `cloudbuild.gated.yaml` had **no staging step at all**.

Consequence: #95 / #99 / #103 reason about a directory that is never loaded in prod, and the WhatsApp navigator has no hospitals.

## Changes

| Layer | Change |
|---|---|
| `.gcloudignore` | Exclude `apps/landing` level by level so exactly **one** file, `apps/landing/src/content/hospitals.json`, is uploaded. Verified: `gcloud meta list-files-for-upload` now lists that file and nothing else from landing. |
| `cloudbuild.yaml` `stage-hospitals` | `rm` the symlink, `cp` the canonical file, then **fail the build** unless the result is a regular (non-symlink) file with a `hospitals` array and ≥ 50 ids. No silent fallback branch. |
| `cloudbuild.gated.yaml` | Same staging step added (`build-api` waits for it). Health gate now requires `"status":"ok"` in the body, not just HTTP 200, so a degraded candidate is never promoted. |
| `common/hospital-directory-file.ts` (new) | One loader for both services: path resolution, Windows pseudo-symlink handling (moved from the navigator), throws on missing / dangling / invalid / empty. Plus a status registry the health endpoint reads — no DI coupling between `HealthModule` and `ChatModule`. |
| `HospitalDirectoryService`, `WhatsAppNavigatorFlowService` | Use the shared loader; the miss is logged at **ERROR** with the path and cause; status recorded. Empty fallback kept so the app still boots. |
| `HealthService` | Adds `hospitalDirectory: {loaded, count, path, error, checkedAt}` and returns `status: "degraded"` when the DB is fine but the directory is not loaded. Still HTTP 200 — the Cloud Run startup probe is TCP-only, so nothing restart-loops. |

## Verification

- New `hospital-directory-file.spec.ts` (regular file, pseudo-symlink, ENOENT, **dangling real symlink** — the exact image shape, empty array, missing key) and `health.service.spec.ts` (ok / degraded / error).
- Full API suite: **57 suites / 1048 tests green**; `tsc --noEmit` clean; `scripts/check_deploy_config_parity.py` OK.
- Staging step dry-run on a replica layout: symlink → regular file, `83 hospital ids`, exit 0; with the source removed → `FATAL … missing from build upload`, exit 1.

## After merge

Deploy, then confirm on the new revision: startup log `hospital_directory_loaded` with `total: 83`, `/v1/health` → `status: "ok"` with `hospitalDirectory.loaded: true`, and a prod web ask for a cancer hospital near Darbhanga returns HBCH Muzaffarpur (the #95 acceptance case, which cannot pass today for this reason).

## Notes

- Overlaps `health.service.ts` with #98's `/v1/health/retrieval` work — whichever lands second gets a small rebase; both add fields, neither changes the DB check.
- `navigator-approve.service.ts` resolves `data/hospitals.json` first when appending an approved hospital; in the image that path was a dangling link, so it fell through its candidate list. Worth a look once this ships — not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
