### PR TITLE
fix(chat): chemo-prep template no longer hijacks Hinglish red flags; speech cleanup by input modality, not channel (#115 re-scope of #121)

### DIFF
--- a/apps/api/src/modules/chat/chat.service.input-cleanup.spec.ts
+++ b/apps/api/src/modules/chat/chat.service.input-cleanup.spec.ts
@@ -1,0 +1,235 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ChatService } from "./chat.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { AnalyticsService } from "../analytics/analytics.service";
+import { SafetyService } from "../safety/safety.service";
+import { RagService } from "../rag/rag.service";
+import { LlmService } from "../llm/llm.service";
+import { EvidenceGateService } from "../evidence/evidence-gate.service";
+import { CitationService } from "../citations/citation.service";
+import { AbstentionService } from "../abstention/abstention.service";
+import { IntentClassifier } from "./intent-classifier";
+import { TemplateSelector } from "./template-selector";
+import { StructuredExtractorService } from "./structured-extractor.service";
+import { ResponseValidatorService } from "./response-validator.service";
+import { GreetingFlowService } from "./greeting-flow.service";
+import { EmpathyDetector } from "./empathy-detector";
+import { PatientStateService } from "./patient-state.service";
+import { ClinicalKeywordEnforcerService } from "../llm/clinical-keyword-enforcer";
+import { RetrievalToolService } from "../rag/retrieval-tool.service";
+import { QueryDecomposerService } from "../rag/query-decomposer.service";
+import { CrossLingualService } from "../rag/cross-lingual.service";
+import { ExecutionPlannerService } from "./execution-planner.service";
+import { PlanExecutorService } from "./plan-executor.service";
+import { OutputVerifierService } from "./output-verifier.service";
+import { ReviewService } from "../review/review.service";
+import { ObservabilityService } from "../observability/observability.service";
+
+/**
+ * Issue #115 — Phase 0 input cleanup must follow the input MODALITY, not the
+ * channel: speech-recognition output gets stutter/repeat/filler removal, typed
+ * text on any channel (WhatsApp, web) only gets medical-spelling normalisation.
+ * The texts below are the tester's own messages as quoted in the issue (no
+ * patient data).
+ *
+ * The texts below are the tester's own messages as quoted in the issue (no
+ * patient data). All LLM / RAG / DB dependencies are mocked; the point of these
+ * tests is the *control flow* of `handle()` for `channel: "whatsapp"`, not the
+ * answer content.
+ */
+
+const HINGLISH_BENIGN = "breast cancer ke early symptoms kya hote hain? kab tak dhyan dena chahiye";
+const HINGLISH_RED_FLAG =
+  "meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??";
+
+const CHUNKS = [
+  {
+    docId: "doc1",
+    chunkId: "chunk1",
+    content: "Breast cancer symptoms include lumps, nipple changes, and skin changes.",
+    document: { title: "Breast Cancer Symptoms - NCI", url: "https://example.com/a", source: "NCI", sourceType: "02_nci_core", citation: "NCI, 2025" },
+  },
+  {
+    docId: "doc2",
+    chunkId: "chunk2",
+    content: "Diagnosis requires clinical exam, mammogram, ultrasound, and biopsy.",
+    document: { title: "Breast Cancer Diagnosis - NCI", url: "https://example.com/b", source: "NCI", sourceType: "02_nci_core", citation: "NCI, 2025" },
+  },
+];
+
+function session(channel: string) {
+  return {
+    id: "wa-session",
+    createdAt: new Date(),
+    channel,
+    locale: "en",
+    userType: null,
+    status: "active",
+    userContext: null,
+    cancerType: null,
+    greetingCompleted: true,
+    emotionalState: "neutral",
+  };
+}
+
+async function buildService(opts: { channel: string }) {
+  const prisma = {
+    $queryRaw: jest.fn().mockResolvedValue([session(opts.channel)]),
+    $executeRawUnsafe: jest.fn().mockResolvedValue(1),
+    session: { findUnique: jest.fn(), update: jest.fn().mockResolvedValue({}) },
+    message: {
+      create: jest.fn().mockImplementation((args: any) => Promise.resolve({ id: "m1", ...args.data, createdAt: new Date() })),
+      findMany: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(3), // not the first message (mirrors the live session)
+    },
+    messageCitation: { create: jest.fn(), createMany: jest.fn() },
+    safetyEvent: { create: jest.fn() },
+  };
+  const rag = {
+    retrieveWithExpansion: jest.fn().mockResolvedValue(CHUNKS),
+    retrieveWithMetadata: jest.fn().mockResolvedValue(CHUNKS),
+    applyPatientStateFilter: jest.fn().mockImplementation((chunks: any[]) => chunks),
+  };
+  const llm = {
+    generateWithCitations: jest.fn().mockResolvedValue("Answer [citation:doc1:chunk1] [citation:doc2:chunk2]"),
+    generate: jest.fn().mockResolvedValue("Soft redirect text"),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ChatService,
+      { provide: PrismaService, useValue: prisma },
+      { provide: AnalyticsService, useValue: { emit: jest.fn().mockResolvedValue(undefined) } },
+      // Real rule-based safety layer: the point is that it stays "normal" for these texts.
+      { provide: SafetyService, useValue: new SafetyService() },
+      { provide: RagService, useValue: rag },
+      { provide: LlmService, useValue: llm },
+      {
+        provide: EvidenceGateService,
+        useValue: {
+          validateEvidence: jest.fn().mockImplementation((chunks: any[]) => ({
+            status: "ok",
+            approvedChunks: chunks ?? [],
+            reasonCode: null,
+            shouldAbstain: false,
+            confidence: "medium",
+            quality: "strong",
+          })),
+          generateClarifyingQuestion: jest.fn(),
+        },
+      },
+      {
+        provide: CitationService,
+        useValue: {
+          extractCitations: jest.fn().mockImplementation((text: string) => {
+            const citations: any[] = [];
+            const re = /\[citation:([^:\]]+):([^\]]+)\]/g;
+            let m: RegExpExecArray | null;
+            while ((m = re.exec(text)) !== null) {
+              citations.push({ docId: m[1], chunkId: m[2], position: m.index, citationText: m[0] });
+            }
+            return { citations, orphanCount: 0, orphanCitations: [] };
+          }),
+          validateCitations: jest.fn().mockReturnValue({ isValid: true, confidenceLevel: "GREEN", citations: [], citationDensity: 0.5 }),
+          enrichCitations: jest.fn().mockResolvedValue([]),
+        },
+      },
+      // Real rule-based urgency layer + intent classifier: these are what route the live texts.
+      { provide: AbstentionService, useValue: new AbstentionService() },
+      { provide: IntentClassifier, useFactory: (a: AbstentionService) => new IntentClassifier(a), inject: [AbstentionService] },
+      { provide: TemplateSelector, useValue: { selectAndGenerate: jest.fn().mockReturnValue({ responseText: "template", intent: "UNCLEAR_REQUEST" }) } },
+      { provide: StructuredExtractorService, useValue: new StructuredExtractorService() },
+      { provide: ResponseValidatorService, useValue: { validate: jest.fn().mockReturnValue({ shouldAbstain: false, isValid: true, ungroundedEntities: [] }) } },
+      {
+        provide: GreetingFlowService,
+        useValue: {
+          extractContextFromMessage: jest.fn().mockResolvedValue({ context: undefined, cancerType: undefined, confidence: 0.3 }),
+          needsGreetingFlow: jest.fn().mockResolvedValue(false),
+          getGreetingStep: jest.fn().mockResolvedValue(0),
+          isGreetingFlowInProgress: jest.fn().mockResolvedValue(false),
+          handleGreetingFlowInterruption: jest.fn().mockResolvedValue(undefined),
+          parseGreetingResponse: jest.fn(),
+          updateSessionContext: jest.fn().mockResolvedValue(undefined),
+        },
+      },
+      { provide: EmpathyDetector, useValue: new EmpathyDetector() },
+      { provide: PatientStateService, useValue: new PatientStateService() },
+      { provide: CrossLingualService, useValue: new CrossLingualService() },
+      { provide: OutputVerifierService, useValue: new OutputVerifierService() },
+      { provide: ClinicalKeywordEnforcerService, useValue: { enforce: (text: string) => text } },
+      { provide: QueryDecomposerService, useValue: { needsDecomposition: () => false, decompose: jest.fn() } },
+      { provide: RetrievalToolService, useValue: { multiRetrieve: jest.fn(), retrieve: jest.fn() } },
+      { provide: ExecutionPlannerService, useValue: { needsPlanning: () => false, plan: jest.fn() } },
+      { provide: PlanExecutorService, useValue: { execute: jest.fn() } },
+      {
+        provide: ReviewService,
+        useValue: {
+          copilotMode: "off",
+          review: jest.fn().mockResolvedValue({ verdict: "PASS" }),
+          persistRecord: jest.fn().mockResolvedValue(undefined),
+          buildBlockedFallback: jest.fn(),
+        },
+      },
+      {
+        provide: ObservabilityService,
+        useValue: { startTrace: () => ({}), startSpan: () => ({}), endSpan: jest.fn(), finalizeTrace: jest.fn() },
+      },
+    ],
+  }).compile();
+
+  return { chat: module.get<ChatService>(ChatService), prisma, rag, llm };
+}
+
+describe("ChatService.handle — Phase 0 input cleanup by modality (#115)", () => {
+  function persistedUserText(prisma: any): string {
+    return prisma.message.create.mock.calls.map((c: any) => c[0].data).find((d: any) => d.role === "user").text;
+  }
+
+  it("WhatsApp (typed): keeps the caregiver's words intact — 'didi' is not collapsed to 'di'", async () => {
+    const { chat, prisma, rag } = await buildService({ channel: "whatsapp" });
+    await chat.handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: HINGLISH_RED_FLAG });
+
+    // Persisted user turn and the retrieval query both see the original text.
+    expect(persistedUserText(prisma)).toBe(HINGLISH_RED_FLAG);
+    expect(persistedUserText(prisma)).toContain("meri didi");
+    for (const call of rag.retrieveWithMetadata.mock.calls) {
+      expect(call[0]).not.toMatch(/\bmeri di\b/);
+    }
+  });
+
+  it("web (typed): also left intact — web is typed input too (review on #121)", async () => {
+    const { chat, prisma } = await buildService({ channel: "web" });
+    await chat.handle({ sessionId: "wa-session", channel: "web", locale: "en", userText: "mere papa ko bahut bahut dard hai, didi ke saath hospital gaye" });
+    expect(persistedUserText(prisma)).toBe("mere papa ko bahut bahut dard hai, didi ke saath hospital gaye");
+  });
+
+  it("web (typed): medical-spelling normalisation still applies to typed text", async () => {
+    const { chat, prisma } = await buildService({ channel: "web" });
+    await chat.handle({ sessionId: "wa-session", channel: "web", locale: "en", userText: "what is keemo therapy" });
+    expect(persistedUserText(prisma)).toMatch(/chemo/i);
+    expect(persistedUserText(prisma)).not.toMatch(/keemo/i);
+  });
+
+  it("web + inputMode 'voice' (browser mic): speech-stutter cleanup runs", async () => {
+    const { chat, prisma } = await buildService({ channel: "web" });
+    await chat.handle({ sessionId: "wa-session", channel: "web", locale: "en", inputMode: "voice", userText: "telltell me about chemo chemo" });
+    expect(persistedUserText(prisma)).toBe("tell me about chemo");
+  });
+
+  it("voice channel: speech-stutter cleanup runs regardless of inputMode", async () => {
+    const { chat, prisma } = await buildService({ channel: "voice" });
+    await chat.handle({ sessionId: "wa-session", channel: "voice", locale: "en", userText: "um tell me about chemo" });
+    expect(persistedUserText(prisma)).toBe("tell me about chemo");
+  });
+
+  it("rule layer: neither Hinglish text trips the emergency fast path, safety rules or urgency guard (the #81 coverage gap — documented, not fixed here)", async () => {
+    const { chat, prisma } = await buildService({ channel: "whatsapp" });
+    for (const text of [HINGLISH_BENIGN, HINGLISH_RED_FLAG]) {
+      prisma.safetyEvent.create.mockClear();
+      const result = await chat.handle({ sessionId: "wa-session", channel: "whatsapp", locale: "en", userText: text });
+      // No rule-based escalation fired: no SafetyEvent row, and the reply is not red-flag classified.
+      expect(prisma.safetyEvent.create).not.toHaveBeenCalled();
+      expect(result.safety.classification).toBe("normal");
+    }
+  });
+});

--- a/apps/api/src/modules/chat/chat.service.ts
+++ b/apps/api/src/modules/chat/chat.service.ts
@@ -27,7 +27,7 @@ import { PatientStateService, PatientState } from "./patient-state.service";
 import { evaluateEmergencyFastPath } from "../safety/emergency-fast-path";
 import { classifyAgenticIntent, AgenticIntentResult } from "./agentic-intent-router";
 import { appendDisclaimer } from "../safety/disclaimer-engine";
-import { cleanVoiceInput } from "./input-cleaner";
+import { cleanVoiceInput, correctMedicalSpelling } from "./input-cleaner";
 // Phase 2 Agentic components
 import { RetrievalToolService } from "../rag/retrieval-tool.service";
 import { QueryDecomposerService, SessionContext } from "../rag/query-decomposer.service";
@@ -188,10 +188,15 @@ export class ChatService {
   }
 
   async handle(dto: ChatDto, signal?: AbortSignal) {
-    // ─── Phase 0: Voice Input Cleanup ────────────────────────────────
-    // Web Speech API interim results can stutter/duplicate text.
-    // Clean before any classification or persistence.
-    dto.userText = cleanVoiceInput(dto.userText);
+    // ─── Phase 0: Input Cleanup (by modality, not channel) ────────────
+    // Speech recognition output (the `voice` channel, or the web mic which
+    // sends channel "web" + inputMode "voice") can stutter, duplicate words and
+    // carry fillers: it gets the full cleanup. TYPED text on any channel must
+    // not be rewritten — the stutter/repeat rules turned a WhatsApp caregiver's
+    // "meri didi" into "meri di" and "papa" into "pa" before classification
+    // (issue #115). Typed input only gets medical-spelling normalisation.
+    const spoken = dto.channel === "voice" || dto.inputMode === "voice";
+    dto.userText = spoken ? cleanVoiceInput(dto.userText) : correctMedicalSpelling(dto.userText);
 
     const obsTrace = this.observability.startTrace('chat_turn', {
       query: dto.userText?.substring(0, 200),

--- a/apps/api/src/modules/chat/dto.ts
+++ b/apps/api/src/modules/chat/dto.ts
@@ -2,11 +2,21 @@ import { IsIn, IsOptional, IsString, IsUUID } from "class-validator";
 
 /** Channels that may enter the chat pipeline. Kept in sync with the @IsIn list below. */
 export type ChatChannel = "web" | "app" | "whatsapp" | "voice";
+/** Input modality (see ChatDto.inputMode). */
+export type InputMode = "typed" | "voice";
 
 export class ChatDto {
   @IsUUID() sessionId!: string;
   @IsString() @IsIn(["web","app","whatsapp","voice"]) channel!: ChatChannel;
   @IsOptional() @IsString() locale?: string;
   @IsOptional() @IsString() userType?: string;
+  /**
+   * How the text was produced, independent of channel. "voice" = speech
+   * recognition output (browser Web Speech API on the web channel); the
+   * `voice` channel is always spoken. Drives Phase 0 input cleanup: only spoken
+   * text gets stutter/repeat/filler removal — typed Hinglish must not be
+   * rewritten ("didi" -> "di", "papa" -> "pa", issue #115).
+   */
+  @IsOptional() @IsIn(["typed", "voice"]) inputMode?: InputMode;
   @IsString() userText!: string;
 }

--- a/apps/api/src/modules/chat/structured-output-templates.spec.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.spec.ts
@@ -91,6 +91,27 @@ describe("StructuredOutputTemplates", () => {
         const result = selectOutputTemplate("NAVIGATION", [], "chemo ke liye kaise ready hona hai");
         expect(result).toBe(CHEMO_DAY_PREP);
       });
+
+      test("Hinglish: chemo + taiyari (romanised preparation)", () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo ke liye kya taiyari karni chahiye")).toBe(CHEMO_DAY_PREP);
+        expect(selectOutputTemplate("NAVIGATION", [], "pehli chemo se pehle tayari kaise karein")).toBe(CHEMO_DAY_PREP);
+      });
+
+      // Issue #115 (live WhatsApp 2026-09-10 01:35 IST; web QA q01 same day): a
+      // caregiver reporting heavy post-chemo bleeding was answered with the routine
+      // chemo-day checklist because the bare Hinglish question word "kya" counted
+      // as a preparation cue.
+      test("REGRESSION #115: a post-chemo red-flag report is NOT a chemo-prep question", () => {
+        const liveText =
+          "meri didi chemo ke baad se bahut kamjor hai, aaj bleeding bahut zyada ho gayi aur chakkar aa raha hai. kya karu??";
+        expect(selectOutputTemplate("NAVIGATION", [], liveText)).toBeNull();
+        expect(selectOutputTemplate("EDUCATION", [], liveText)).toBeNull();
+      });
+
+      test("bare Hinglish question words do not select the chemo-prep template", () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo ke side effects kya hote hain")).toBeNull();
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo kaise kaam karti hai")).toBeNull();
+      });
     });
 
     describe("Second opinion queries → SECOND_OPINION_PREP", () => {

--- a/apps/api/src/modules/chat/structured-output-templates.spec.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.spec.ts
@@ -112,6 +112,21 @@ describe("StructuredOutputTemplates", () => {
         expect(selectOutputTemplate("NAVIGATION", [], "chemo ke side effects kya hote hain")).toBeNull();
         expect(selectOutputTemplate("NAVIGATION", [], "chemo kaise kaam karti hai")).toBeNull();
       });
+
+      // Review on #125: the English equivalents of the bug — "what to" and a bare
+      // "day" — must not be preparation cues either.
+      test("English side-effect / timing questions are NOT chemo-prep questions", () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "Chemo ke baad vomiting ho rahi hai, what to do?")).toBeNull();
+        expect(selectOutputTemplate("NAVIGATION", [], "One day after chemo I feel very weak, is this normal?")).toBeNull();
+        expect(selectOutputTemplate("EDUCATION", [], "what to do if fever comes 3 days after chemo")).toBeNull();
+      });
+
+      test("phrase-level preparation cues still select the template", () => {
+        expect(selectOutputTemplate("NAVIGATION", [], "what should I do before my first chemo")).toBe(CHEMO_DAY_PREP);
+        expect(selectOutputTemplate("NAVIGATION", [], "chemo se pehle kya karna chahiye")).toBe(CHEMO_DAY_PREP);
+        expect(selectOutputTemplate("NAVIGATION", [], "how do I get ready for chemotherapy")).toBe(CHEMO_DAY_PREP);
+        expect(selectOutputTemplate("NAVIGATION", [], "what to expect on the day of chemo")).toBe(CHEMO_DAY_PREP);
+      });
     });
 
     describe("Second opinion queries → SECOND_OPINION_PREP", () => {

--- a/apps/api/src/modules/chat/structured-output-templates.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.ts
@@ -541,8 +541,14 @@ export function selectOutputTemplate(
 
   // Chemo preparation
   const isChemo = /\b(chemo|chemotherapy)\b/i.test(lowerText) || /कीमो/.test(lowerText);
+  // A preparation cue is required. Bare Hinglish question words ("kya",
+  // "kaise") are NOT one: almost every Hinglish sentence has them, so with
+  // them here any message that mentioned chemo — including a caregiver
+  // reporting heavy post-chemo bleeding ("... chemo ke baad ... bleeding
+  // bahut zyada ... kya karu") — was answered with the routine chemo-day
+  // checklist (issue #115, live 2026-09-10; web QA q01 same day).
   const isPrep =
-    /\b(prepare|preparation|ready|day|what to|kya|kaise)\b/i.test(lowerText) ||
+    /\b(prepare|preparation|ready|day|what to|taiya?a?ri|tayy?ari)\b/i.test(lowerText) ||
     /तैयारी/.test(lowerText);
   if (isChemo && isPrep) {
     return CHEMO_DAY_PREP;

--- a/apps/api/src/modules/chat/structured-output-templates.ts
+++ b/apps/api/src/modules/chat/structured-output-templates.ts
@@ -547,8 +547,11 @@ export function selectOutputTemplate(
   // reporting heavy post-chemo bleeding ("... chemo ke baad ... bleeding
   // bahut zyada ... kya karu") — was answered with the routine chemo-day
   // checklist (issue #115, live 2026-09-10; web QA q01 same day).
+  // Phrase-level cues only (review on #125): bare "day" and "what to" were the
+  // same structural bug in English — "chemo ke baad vomiting, what to do?" and
+  // "one day after chemo I feel weak" are not preparation questions.
   const isPrep =
-    /\b(prepare|preparation|ready|day|what to|taiya?a?ri|tayy?ari)\b/i.test(lowerText) ||
+    /\b(prepare|preparation|preparing|get(ting)? ready|be ready|ready (for|hona|ho)|chemo day|day of (my |the |first )?chemo|before( my| the| your| first| pehli){0,2} chemo|chemo se pehle|what to (bring|carry|wear|eat|expect)|taiya?a?ri|tayy?ari)\b/i.test(lowerText) ||
     /तैयारी/.test(lowerText);
   if (isChemo && isPrep) {
     return CHEMO_DAY_PREP;

--- a/apps/web/src/components/ChatInterface.tsx
+++ b/apps/web/src/components/ChatInterface.tsx
@@ -8,7 +8,7 @@ import { SuchiAvatar } from "./SuchiAvatar";
 import { LoadingIndicator } from "./LoadingIndicator";
 import { ErrorDisplay } from "./ErrorDisplay";
 import { WelcomeMessage } from "./WelcomeMessage";
-import { apiService, ChatResponse, UserRole } from "../services/api";
+import { apiService, ChatResponse, UserRole, InputMode } from "../services/api";
 
 interface ChatInterfaceProps {
   sessionId: string | null;
@@ -98,7 +98,7 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ sessionId, onStart
     scrollToBottom();
   }, [messages]);
 
-  const handleSend = async (text: string) => {
+  const handleSend = async (text: string, meta?: { inputMode: InputMode }) => {
     if (conversationEnded || !sessionId) return;
 
     const userMessage: Message = {
@@ -124,7 +124,8 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ sessionId, onStart
       const response: ChatResponse = await apiService.sendMessage({
         sessionId,
         channel: "web",
-        userText: text
+        userText: text,
+        ...(meta?.inputMode ? { inputMode: meta.inputMode } : {})
       });
 
       const assistantMessage: Message = {

--- a/apps/web/src/components/MessageInput.tsx
+++ b/apps/web/src/components/MessageInput.tsx
@@ -59,9 +59,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const [showUnsupportedTooltip, setShowUnsupportedTooltip] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const baseTextRef = useRef<string>("");
-  // True once speech recognition has written into the current draft. Sent to the
-  // API as inputMode "voice" so speech cleanup runs only on spoken text (#115).
-  const usedVoiceRef = useRef(false);
+  // Provenance of the current draft (#115). Only a draft that is ENTIRELY mic
+  // output and has not been typed into is sent as inputMode "voice": the API then
+  // runs speech-stutter cleanup, which must never touch typed words ("didi" ->
+  // "di"). Typed-then-dictated or dictated-then-edited drafts are "mixed" and
+  // take the safer spelling-only path.
+  const voiceDraftRef = useRef<"none" | "pure" | "mixed">("none");
 
   useEffect(() => {
     // Check if Web Speech API is supported
@@ -72,9 +75,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const handleSend = () => {
     const trimmed = text.trim();
     if (trimmed && !disabled) {
-      if (usedVoiceRef.current) onSend(trimmed, { inputMode: "voice" });
+      if (voiceDraftRef.current === "pure") onSend(trimmed, { inputMode: "voice" });
       else onSend(trimmed);
-      usedVoiceRef.current = false;
+      voiceDraftRef.current = "none";
       setText("");
     }
   };
@@ -114,7 +117,10 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       }
 
       // Replace (not append) — show base text + full transcript so far
-      if (finalTranscript || interimTranscript) usedVoiceRef.current = true;
+      if (finalTranscript || interimTranscript) {
+        const typedPrefix = baseTextRef.current.trim() !== "";
+        voiceDraftRef.current = typedPrefix || voiceDraftRef.current === "mixed" ? "mixed" : "pure";
+      }
       setText(baseTextRef.current + finalTranscript + interimTranscript);
     };
 
@@ -158,7 +164,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     <div style={styles.container}>
       <textarea
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => {
+          // A keystroke after dictation makes the draft mixed; programmatic
+          // setText from recognition does not fire onChange.
+          if (voiceDraftRef.current !== "none") voiceDraftRef.current = "mixed";
+          setText(e.target.value);
+        }}
         onKeyPress={handleKeyPress}
         disabled={disabled}
         placeholder={placeholder}

--- a/apps/web/src/components/MessageInput.tsx
+++ b/apps/web/src/components/MessageInput.tsx
@@ -42,7 +42,8 @@ declare global {
 }
 
 interface MessageInputProps {
-  onSend: (text: string) => void;
+  /** `meta.inputMode` is "voice" only when the browser mic contributed to this message. */
+  onSend: (text: string, meta?: { inputMode: "voice" }) => void;
   disabled?: boolean;
   placeholder?: string;
 }
@@ -58,6 +59,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const [showUnsupportedTooltip, setShowUnsupportedTooltip] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const baseTextRef = useRef<string>("");
+  // True once speech recognition has written into the current draft. Sent to the
+  // API as inputMode "voice" so speech cleanup runs only on spoken text (#115).
+  const usedVoiceRef = useRef(false);
 
   useEffect(() => {
     // Check if Web Speech API is supported
@@ -68,7 +72,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const handleSend = () => {
     const trimmed = text.trim();
     if (trimmed && !disabled) {
-      onSend(trimmed);
+      if (usedVoiceRef.current) onSend(trimmed, { inputMode: "voice" });
+      else onSend(trimmed);
+      usedVoiceRef.current = false;
       setText("");
     }
   };
@@ -108,6 +114,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       }
 
       // Replace (not append) — show base text + full transcript so far
+      if (finalTranscript || interimTranscript) usedVoiceRef.current = true;
       setText(baseTextRef.current + finalTranscript + interimTranscript);
     };
 

--- a/apps/web/src/components/__tests__/MessageInput.test.tsx
+++ b/apps/web/src/components/__tests__/MessageInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MessageInput } from '../MessageInput';
 
@@ -136,6 +136,72 @@ describe('MessageInput', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
 
       expect(onSend).not.toHaveBeenCalled();
+    });
+  });
+
+  // Issue #115: the API applies speech-stutter cleanup only to spoken input, so
+  // the component must say when the browser mic contributed to a message.
+  describe('input modality flag', () => {
+    class FakeRecognition {
+      static last: FakeRecognition | null = null;
+      continuous = false;
+      interimResults = false;
+      lang = '';
+      onresult: ((e: any) => void) | null = null;
+      onerror: ((e: any) => void) | null = null;
+      onend: (() => void) | null = null;
+      start = vi.fn();
+      stop = vi.fn();
+      constructor() { FakeRecognition.last = this; }
+    }
+
+    const install = () => {
+      (window as any).SpeechRecognition = FakeRecognition;
+      FakeRecognition.last = null;
+    };
+    const uninstall = () => {
+      delete (window as any).SpeechRecognition;
+    };
+
+    it('typed text is sent without a modality flag (backward compatible)', () => {
+      const onSend = vi.fn();
+      render(<MessageInput onSend={onSend} />);
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'meri didi ko dard hai' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+      expect(onSend).toHaveBeenCalledTimes(1);
+      expect(onSend.mock.calls[0]).toEqual(['meri didi ko dard hai']);
+    });
+
+    it('text dictated through the mic is sent with inputMode "voice"', () => {
+      install();
+      try {
+        const onSend = vi.fn();
+        render(<MessageInput onSend={onSend} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Start voice input' }));
+        const rec = FakeRecognition.last!;
+        expect(rec.start).toHaveBeenCalled();
+        act(() => rec.onresult!({ results: [Object.assign([{ transcript: 'telltell me about chemo' }], { isFinal: true })] }));
+        fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+        expect(onSend).toHaveBeenCalledWith('telltell me about chemo', { inputMode: 'voice' });
+      } finally {
+        uninstall();
+      }
+    });
+
+    it('the flag resets after sending: the next typed message carries none', () => {
+      install();
+      try {
+        const onSend = vi.fn();
+        render(<MessageInput onSend={onSend} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Start voice input' }));
+        act(() => FakeRecognition.last!.onresult!({ results: [Object.assign([{ transcript: 'first' }], { isFinal: true })] }));
+        fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'second, typed' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+        expect(onSend.mock.calls[1]).toEqual(['second, typed']);
+      } finally {
+        uninstall();
+      }
     });
   });
 });

--- a/apps/web/src/components/__tests__/MessageInput.test.tsx
+++ b/apps/web/src/components/__tests__/MessageInput.test.tsx
@@ -188,6 +188,38 @@ describe('MessageInput', () => {
       }
     });
 
+    // Review on #125: a typed prefix or a manual edit means the message is no
+    // longer pure mic output, so speech cleanup must not run on it.
+    it('typed prefix + dictation is MIXED: sent without the voice flag', () => {
+      install();
+      try {
+        const onSend = vi.fn();
+        render(<MessageInput onSend={onSend} />);
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'meri didi ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Start voice input' }));
+        act(() => FakeRecognition.last!.onresult!({ results: [Object.assign([{ transcript: 'has fever after chemo' }], { isFinal: true })] }));
+        fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+        expect(onSend.mock.calls[0]).toEqual(['meri didi has fever after chemo']);
+      } finally {
+        uninstall();
+      }
+    });
+
+    it('dictation followed by a manual edit is MIXED: sent without the voice flag', () => {
+      install();
+      try {
+        const onSend = vi.fn();
+        render(<MessageInput onSend={onSend} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Start voice input' }));
+        act(() => FakeRecognition.last!.onresult!({ results: [Object.assign([{ transcript: 'meri di ko fever hai' }], { isFinal: true })] }));
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'meri didi ko fever hai' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+        expect(onSend.mock.calls[0]).toEqual(['meri didi ko fever hai']);
+      } finally {
+        uninstall();
+      }
+    });
+
     it('the flag resets after sending: the next typed message carries none', () => {
       install();
       try {

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -23,12 +23,16 @@ export interface CreateSessionResponse {
   createdAt: string;
 }
 
+export type InputMode = "typed" | "voice";
+
 export interface ChatRequest {
   sessionId: string;
   channel: "web" | "app" | "whatsapp";
   userText: string;
   locale?: string;
   userType?: string;
+  /** "voice" when the text came from the browser mic (Web Speech API); lets the API apply speech cleanup only to spoken input. */
+  inputMode?: InputMode;
 }
 
 export interface ChatResponse {


### PR DESCRIPTION
Refs #115. **Re-scope of #121** per its review ("RE-SCOPE before making ready"): only the two deterministic fixes, with the typed-input fix made channel-complete. No safety-module, keyword-list, prompt or patient-facing copy changes. Recommend closing #121 in favour of this PR.

## 1. `selectOutputTemplate`: bare `kya` / `kaise` counted as chemo-*preparation* cues

Any message mentioning chemo plus a Hinglish question word got the "Before Your Chemo Session" checklist — including a caregiver reporting heavy post-chemo bleeding and dizziness (live WhatsApp 2026-09-10 01:35 IST; web QA q01 same day; **still reproduced on revision `00416`** on 2026-09-11). A real preparation cue is now required (`prepare|preparation|ready|day|what to|taiyari|tayari|तैयारी`). Regression test uses the exact live text; positive Hinglish prep cases (`taiyari`, `tayari`) added.

After this the red-flag text falls to the navigate soft-redirect rather than escalating — that is the #81 keyword gap; the SCCF proposal from #121 §4 is now on #81.

## 2. Phase 0 input cleanup: by **modality**, not channel

`cleanVoiceInput` (stutter/repeat/filler removal for Web Speech API output) ran on every channel and rewrote typed Hinglish before classification: `meri didi` → `meri di`, `papa` → `pa`, `bahut bahut` → `bahut`. #121 exempted WhatsApp only; the review pointed out web is typed input too.

| input | cleanup |
|---|---|
| channel `voice` | `cleanVoiceInput` |
| any channel with new optional `ChatDto.inputMode = "voice"` | `cleanVoiceInput` |
| everything else (typed: web, WhatsApp, app) | `correctMedicalSpelling` only |

The web mic path (Web Speech API → sent as channel `web`) now tags its messages: `MessageInput` remembers that recognition wrote into the draft → `onSend(text, { inputMode: "voice" })` → `ChatInterface` → `/v1/chat` `inputMode`. Typed messages send **no flag**, so the API contract and existing callers are unchanged; the flag resets after each send.

## Dropped from #121 (not lost)

The shared `timeout-fallback.ts`, the WhatsApp per-turn bound and the reuse of the web timeout guidance on WhatsApp. Root cause of those timeouts was CPU throttling of the fire-and-forget turn, fixed in #119 and deployed as `00416` (ledger since deploy: 15/15 processed, 0 failed, ~5 s turns). Reusing the guidance copy would also have expanded patient-facing text to a new channel. The work is preserved in `195d7b2` on `fix/115-whatsapp-hinglish-pipeline` if wanted as a separate belt-and-braces PR.

## Verification

- New `chat.service.input-cleanup.spec.ts` (real `SafetyService`/`IntentClassifier`, mocked LLM/RAG/DB): WhatsApp typed text intact; **web typed text intact**; web + `inputMode: "voice"` cleaned; `voice` channel cleaned; typed text still gets medical-spelling fixes; rule-layer gap documented.
- `structured-output-templates.spec.ts`: #115 regression + Hinglish prep positives + bare-question-word negatives.
- `MessageInput.test.tsx`: typed → no flag (backward compatible), mic → `{ inputMode: "voice" }`, flag resets.
- API: **56 suites / 1046 tests** green; web `MessageInput` 19/19; `tsc --noEmit` clean in both apps.
- Line endings preserved (CRLF files kept CRLF) so the diff is the change only: 8 files, +132/−12, plus one new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
