### PR TITLE
security(eval): remove committed DeepSeek key literals; CI guard against credential-shaped literals (#127)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -67,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: No credential-shaped literals in tracked files (issue #127)
+        run: python3 scripts/check_no_secret_literals.py
+
       - name: Check deploy pipeline config parity
         run: python3 scripts/check_deploy_config_parity.py
 

--- a/eval/QUICK_START.md
+++ b/eval/QUICK_START.md
@@ -46,8 +46,9 @@ If you prefer to create secrets manually:
 # Set project
 export PROJECT_ID=$(gcloud config get-value project)
 
-# Create Deepseek API key secret
-echo -n "sk-6bc325dec38c4d4c95f9f4ecb185e1dc" | gcloud secrets create deepseek-api-key \
+# Create Deepseek API key secret — paste it at the hidden prompt; never write a key into a file in this repo
+read -r -s -p "Deepseek API key: " DEEPSEEK_API_KEY && echo
+echo -n "$DEEPSEEK_API_KEY" | gcloud secrets create deepseek-api-key \
     --project=$PROJECT_ID \
     --data-file=- \
     --replication-policy="automatic"

--- a/eval/docs/SECRETS_SETUP.md
+++ b/eval/docs/SECRETS_SETUP.md
@@ -34,8 +34,9 @@ Create secrets for your API keys:
 # Set your project ID
 export PROJECT_ID=$(gcloud config get-value project)
 
-# Deepseek API Key
-echo -n "sk-6bc325dec38c4d4c95f9f4ecb185e1dc" | gcloud secrets create deepseek-api-key \
+# Deepseek API Key — paste it at the hidden prompt; never write a key into a file in this repo
+read -r -s -p "Deepseek API key: " DEEPSEEK_API_KEY && echo
+echo -n "$DEEPSEEK_API_KEY" | gcloud secrets create deepseek-api-key \
     --project=$PROJECT_ID \
     --data-file=- \
     --replication-policy="automatic"

--- a/eval/run-batch-simple.ps1
+++ b/eval/run-batch-simple.ps1
@@ -13,9 +13,12 @@ $deepseekKey = gcloud secrets versions access latest --secret="deepseek-api-key"
 if ($LASTEXITCODE -eq 0) {
     $env:DEEPSEEK_API_KEY = $deepseekKey.Trim()
     Write-Host "✓ API key loaded" -ForegroundColor Green
+} elseif (-not [string]::IsNullOrWhiteSpace($env:DEEPSEEK_API_KEY)) {
+    # No key literal in this repo (issue #127): only an already-exported key is accepted.
+    Write-Host "⚠ Secret Manager unavailable — using DEEPSEEK_API_KEY from the environment" -ForegroundColor Yellow
 } else {
-    $env:DEEPSEEK_API_KEY = "sk-6bc325dec38c4d4c95f9f4ecb185e1dc"
-    Write-Host "⚠ Using fallback key" -ForegroundColor Yellow
+    Write-Host "ERROR: Could not load deepseek-api-key from Secret Manager and DEEPSEEK_API_KEY is not set." -ForegroundColor Red
+    exit 1
 }
 
 $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"

--- a/eval/run-batches.ps1
+++ b/eval/run-batches.ps1
@@ -22,12 +22,17 @@ try {
         $env:DEEPSEEK_API_KEY = $deepseekKey.Trim()
         Write-Host "✓ Deepseek API key loaded" -ForegroundColor Green
     } else {
-        Write-Host "⚠ Warning: Could not load from Secret Manager. Using hardcoded key." -ForegroundColor Yellow
-        $env:DEEPSEEK_API_KEY = "sk-6bc325dec38c4d4c95f9f4ecb185e1dc"
+        throw "gcloud exited $LASTEXITCODE"
     }
 } catch {
-    Write-Host "⚠ Warning: Could not load from Secret Manager. Using hardcoded key." -ForegroundColor Yellow
-    $env:DEEPSEEK_API_KEY = "sk-6bc325dec38c4d4c95f9f4ecb185e1dc"
+    # No key literal in this repo (issue #127). Fall back ONLY to a key the caller
+    # already exported; otherwise stop, never guess.
+    if ([string]::IsNullOrWhiteSpace($env:DEEPSEEK_API_KEY)) {
+        Write-Host "ERROR: Could not load deepseek-api-key from Secret Manager ($_) and DEEPSEEK_API_KEY is not set." -ForegroundColor Red
+        Write-Host "       Run 'gcloud auth login' or export DEEPSEEK_API_KEY in this shell first." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Warning: Secret Manager unavailable — using DEEPSEEK_API_KEY from the environment." -ForegroundColor Yellow
 }
 
 # Define 20 cancers grouped into 5 batches of 4 cancers each

--- a/eval/run-eval.ps1
+++ b/eval/run-eval.ps1
@@ -17,12 +17,17 @@ try {
         $env:DEEPSEEK_API_KEY = $deepseekKey.Trim()
         Write-Host "Deepseek API key loaded" -ForegroundColor Green
     } else {
-        Write-Host "Warning: Could not load from Secret Manager. Using hardcoded key." -ForegroundColor Yellow
-        $env:DEEPSEEK_API_KEY = "sk-6bc325dec38c4d4c95f9f4ecb185e1dc"
+        throw "gcloud exited $LASTEXITCODE"
     }
 } catch {
-    Write-Host "Warning: Could not load from Secret Manager. Using hardcoded key." -ForegroundColor Yellow
-    $env:DEEPSEEK_API_KEY = "sk-6bc325dec38c4d4c95f9f4ecb185e1dc"
+    # No key literal in this repo (issue #127). Fall back ONLY to a key the caller
+    # already exported; otherwise stop, never guess.
+    if ([string]::IsNullOrWhiteSpace($env:DEEPSEEK_API_KEY)) {
+        Write-Host "ERROR: Could not load deepseek-api-key from Secret Manager ($_) and DEEPSEEK_API_KEY is not set." -ForegroundColor Red
+        Write-Host "       Run 'gcloud auth login' or export DEEPSEEK_API_KEY in this shell first." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Warning: Secret Manager unavailable — using DEEPSEEK_API_KEY from the environment." -ForegroundColor Yellow
 }
 
 # API is already configured in default.json to use GCloud

--- a/eval/scripts/add-deepseek-secret.ps1
+++ b/eval/scripts/add-deepseek-secret.ps1
@@ -38,9 +38,14 @@ if (-not $SkipPrompt) {
     [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
     Write-Host ""
 } else {
-    # Fallback for automation (not recommended for production)
-    $ApiKey = "sk-6bc325dec38c4d4c95f9f4ecb185e1dc"
-    Write-Host "⚠ Using default API key from script (not recommended for production)" -ForegroundColor Yellow
+    # Automation path: the key must come from the environment. This script used to
+    # carry a literal key here (issue #127) — never again.
+    $ApiKey = $env:DEEPSEEK_API_KEY
+    if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+        Write-Host "ERROR: -SkipPrompt requires DEEPSEEK_API_KEY to be set in the environment" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Using DEEPSEEK_API_KEY from the environment" -ForegroundColor Yellow
     Write-Host ""
 }
 

--- a/eval/setup-deepseek.ps1
+++ b/eval/setup-deepseek.ps1
@@ -35,14 +35,27 @@ if (-not $apiEnabled) {
     }
 }
 
-# Create Deepseek API key secret
+# Create Deepseek API key secret. The value comes from the environment or a
+# hidden prompt — never from this file (issue #127: two keys were committed here).
+$deepseekKey = $env:DEEPSEEK_API_KEY
+if ([string]::IsNullOrWhiteSpace($deepseekKey)) {
+    Write-Host "Enter your Deepseek API key (input will be hidden):" -ForegroundColor Yellow
+    $secureKey = Read-Host -AsSecureString
+    $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureKey)
+    $deepseekKey = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
+}
+if ([string]::IsNullOrWhiteSpace($deepseekKey)) {
+    Write-Host "ERROR: No Deepseek API key provided (set DEEPSEEK_API_KEY or enter it at the prompt)" -ForegroundColor Red
+    exit 1
+}
 Write-Host "Creating deepseek-api-key secret..." -ForegroundColor Yellow
 $secretExists = gcloud secrets describe deepseek-api-key --project=$projectId 2>$null
 if ($secretExists) {
     Write-Host "Secret already exists. Updating with new version..." -ForegroundColor Yellow
-    echo -n "sk-6bc325dec38c4d4c95f9f4ecb185e1dc" | gcloud secrets versions add deepseek-api-key --project=$projectId --data-file=-
+    $deepseekKey | gcloud secrets versions add deepseek-api-key --project=$projectId --data-file=-
 } else {
-    echo -n "sk-6bc325dec38c4d4c95f9f4ecb185e1dc" | gcloud secrets create deepseek-api-key --project=$projectId --data-file=- --replication-policy="automatic"
+    $deepseekKey | gcloud secrets create deepseek-api-key --project=$projectId --data-file=- --replication-policy="automatic"
 }
 
 if ($LASTEXITCODE -eq 0) {

--- a/scripts/check_no_secret_literals.py
+++ b/scripts/check_no_secret_literals.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Fail if any git-tracked file contains a credential-shaped literal.
+
+Why this exists (issue #127): two DeepSeek API keys sat in seven tracked eval
+scripts and docs of this PUBLIC repo for months. Both were revoked, but the
+pattern - "hardcode the key as a fallback" - is what leaks the *next* key.
+This check runs in CI ("Build + config parity" job) and can be run locally:
+
+    python3 scripts/check_no_secret_literals.py
+
+It scans only files tracked by git (so node_modules, build output and local
+worktrees are never scanned) and never prints a matched value - only the file,
+line and pattern name.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    # OpenAI / DeepSeek style
+    ("sk- api key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    # Google API key
+    ("google api key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
+    # Google OAuth access token
+    ("google oauth token", re.compile(r"\bya29\.[0-9A-Za-z_-]{20,}\b")),
+    # Meta / WhatsApp Graph token
+    ("meta graph token", re.compile(r"\bEAA[A-Za-z0-9]{40,}\b")),
+    # GitHub tokens
+    ("github token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{30,}\b")),
+    ("github fine-grained token", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{40,}\b")),
+    # Slack
+    ("slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+    # Private keys
+    ("private key block", re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----")),
+    # Postgres URL with an inline password
+    ("database url with password", re.compile(r"postgres(?:ql)?://[^:\s/]+:[^@\s]{6,}@")),
+]
+
+# Files that legitimately contain matching *shapes* (documentation of the
+# patterns themselves). Keep this list short and explicit.
+ALLOWLIST_FILES = {
+    "scripts/check_no_secret_literals.py",
+    # Redaction unit test: its fixtures are deliberately key-shaped fakes that
+    # the report generator must scrub. Reviewed 2026-09-12.
+    "eval/runner/report-generator.redaction.test.ts",
+}
+
+# A database URL is only a finding when the password is not an obvious
+# placeholder (docs and .env.example legitimately show postgres://user:PASSWORD@).
+DB_URL = re.compile(r"postgres(?:ql)?://([^:\s/]+):([^@\s]{6,})@")
+PLACEHOLDER_PASSWORD = re.compile(
+    r"(password|passw|\bpass\b|changeme|change_me|your|example|xxx|secret|placeholder|redacted|\$|<|\{)", re.I
+)
+COMMON_DEFAULT_PASSWORDS = {"postgres", "password", "localhost", "changeme", "admin", "root"}
+
+
+def db_url_is_placeholder(line: str) -> bool:
+    m = DB_URL.search(line)
+    if not m:
+        return True
+    user, pw = m.group(1), m.group(2)
+    return bool(PLACEHOLDER_PASSWORD.search(pw)) or pw == user or pw.lower() in COMMON_DEFAULT_PASSWORDS
+
+# Binary-ish or generated content we never want to open.
+SKIP_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".pdf", ".woff", ".woff2", ".ttf", ".mp3", ".mp4", ".wav", ".zip", ".gz", ".lock")
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(["git", "ls-files", "-z"], check=True, capture_output=True).stdout
+    return [p for p in out.decode("utf-8", "surrogateescape").split("\0") if p]
+
+
+def main() -> int:
+    hits: list[str] = []
+    for path in tracked_files():
+        if path in ALLOWLIST_FILES or path.endswith(SKIP_SUFFIXES):
+            continue
+        try:
+            with open(path, "rb") as fh:
+                data = fh.read()
+        except (FileNotFoundError, IsADirectoryError):
+            continue  # symlink to outside the tree, or deleted in the working copy
+        if b"\0" in data[:4096]:
+            continue  # binary
+        text = data.decode("utf-8", "replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for name, pat in PATTERNS:
+                if not pat.search(line):
+                    continue
+                if name == "database url with password" and db_url_is_placeholder(line):
+                    continue
+                hits.append(f"{path}:{lineno}: {name}")
+    if hits:
+        print("FAIL: credential-shaped literal(s) in tracked files (values not shown):")
+        for h in hits:
+            print("  " + h)
+        print("\nFix: read the value from the environment or Secret Manager; see issue #127.")
+        return 1
+    print("OK: no credential-shaped literals in tracked files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #127.

## What

Two **revoked** DeepSeek API keys were committed to this public repo — key A in seven tracked eval scripts/docs in `HEAD`, key B in history only. The live key in Secret Manager never appeared in the repo (fingerprint check in #127). This PR removes every literal from the tree and adds a guard so the pattern cannot come back.

| File | Before | After |
|---|---|---|
| `eval/run-eval.ps1`, `eval/run-batches.ps1`, `eval/run-batch-simple.ps1` | Secret Manager failure → **hardcoded key** | Secret Manager failure → `DEEPSEEK_API_KEY` from the environment if the caller exported it, else **stop with an error** |
| `eval/setup-deepseek.ps1` | piped a **literal key** into `gcloud secrets create/add` | value from `DEEPSEEK_API_KEY` or a hidden `Read-Host -AsSecureString` prompt |
| `eval/scripts/add-deepseek-secret.ps1` | `-SkipPrompt` → baked-in key | `-SkipPrompt` requires `DEEPSEEK_API_KEY` |
| `eval/QUICK_START.md`, `eval/docs/SECRETS_SETUP.md` | `echo -n "sk-…" \| gcloud secrets create` | `read -s -p … DEEPSEEK_API_KEY` then `echo -n "$DEEPSEEK_API_KEY" \| …` |

`git grep -E 'sk-[A-Za-z0-9]{20,}'` on this branch: **0 hits** (was 10 across 7 files).

## Guard: `scripts/check_no_secret_literals.py`

Scans **git-tracked files only** for credential-shaped literals — `sk-…`, Google `AIza…`, `ya29.…`, Meta `EAA…`, GitHub `gh*_` / `github_pat_`, Slack `xox*-`, PEM private-key blocks, and `postgres://user:password@` URLs whose password is not an obvious placeholder (`PASSWORD`, `changeme`, `${…}`, equals the username, common defaults…). It **never prints a matched value**, only `file:line: pattern`. Allowlist: itself and `eval/runner/report-generator.redaction.test.ts` (whose fixtures are deliberately key-shaped fakes).

- On `origin/main`: flags the eval files → exit 1 (verified).
- On this branch: `OK` → exit 0.
- Wired into `.github/workflows/deploy-api.yml` "Build + config parity" as the first step.

## Also done

- GitHub secret-scanning alert **#1** (`deepseek_api_key`, path `suchi_phase1_pack/eval/run-eval.ps1`, open since 2026-01-07) → **resolved as revoked** via the API, with a comment pointing here.

## Not done — maintainer's call

- **History purge** of keys A/B. Both are dead (HTTP 401), so this is hygiene, not exposure; it rewrites history and needs a coordinated force-push plus a re-clone by everyone. If wanted, `git filter-repo --replace-text` with the two fingerprinted values is the tool; happy to prepare the exact command.
- The other historical hits (`suchi_phase1_pack/eval/reports/tier1-*.json`) are covered by the same purge decision.

## Unblocks

#79 OPS-1: its statement that the key "is not in any git-tracked file" becomes true once this merges; the incident plan there can then be reduced to "revoked ✓, removed from tree ✓, purge history: decision".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
