### PR TITLE
fix(rag,db): non-blocking FTS restore — plain column + trigger, batched backfill, CONCURRENT index; probe accepts both shapes (#92 follow-up)

### DIFF
--- a/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
+++ b/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
@@ -1,4 +1,4 @@
--- Restore full-text search on KbChunk (issue #92).
+-- Restore full-text search on KbChunk (issue #92) — NON-BLOCKING implementation.
 --
 -- HISTORY
 --   20260120163141_add_fts_to_kbchunk  added `content_tsv` as a STORED generated
@@ -17,44 +17,92 @@
 --                                      since, costing long queries 45% and short queries
 --                                      20% of their retrieval scoring weight.
 --
--- This migration restores the 2026-02-18 definition exactly: a STORED generated column
--- over to_tsvector('simple', content), matching websearch_to_tsquery('simple', ...) in
--- src/modules/rag/kb-fts.sql.ts, plus the GIN index the query plan needs.
+-- INCIDENT 2026-09-12 (why this file is NOT a GENERATED column any more)
+--   The first version of this migration re-added `content_tsv` as
+--   `GENERATED ALWAYS AS (...) STORED`. On Postgres that is a full table rewrite
+--   under an ACCESS EXCLUSIVE lock, and the rewrite rebuilds EVERY index on the
+--   table — including the pgvector HNSW index on `embedding`. On production
+--   (suchi-db, db-f1-micro, ~74k rows of 1.4 KB text + 768-d vectors) it ran
+--   for 15+ minutes; all retrieval queries queued behind the lock, the
+--   connection pool filled, /v1/health stopped answering and chat turns timed
+--   out. The statement was terminated; nothing was changed. Never run a
+--   rewriting ALTER on "KbChunk" again.
 --
--- Safe to re-run. The DO block rebuilds the column when it exists in any shape other
--- than "STORED generated, 'simple' config" — which covers three real states:
---   * the 2026-01-20 'english' generated column (a DB that never got 20260218), and
---   * a plain, never-populated `content_tsv tsvector` column, which is what
---     `prisma migrate diff` emits from schema.prisma (Prisma cannot express GENERATED),
---     i.e. what a freshly `db push`-ed database would have.
--- Rebuilding is cheap: the column is derived from `content`, so nothing is lost.
+-- WHAT THIS FILE DOES INSTEAD
+--   1. Adds `content_tsv` as a PLAIN, nullable tsvector with no default — a
+--      catalog-only change, no rewrite, milliseconds.
+--   2. Installs a BEFORE INSERT OR UPDATE OF content trigger that keeps the
+--      column current, so rows written while the backfill runs are covered.
+--   3. Backfills and builds the GIN index ONLY on small tables (<= 5000 rows:
+--      dev databases, CI, the PGlite regression test). On a production-sized
+--      table it deliberately stops with a NOTICE: the backfill must run in
+--      small committed batches and the index must be built CONCURRENTLY
+--      (which cannot run inside a transaction). That procedure is
+--      `scripts/sql/kb_fts_safe_rollout.py`, documented in
+--      docs/OPERATIONS_RUNBOOK.md §4a; it ends with
+--      `prisma migrate resolve --applied 20260908000000_restore_kb_chunk_fts`.
+--
+--   A database that still carries the legacy GENERATED column (never ran
+--   20260606) is left exactly as it is: Postgres maintains that shape itself and
+--   the boot probe (KbFtsHealthService) accepts either shape.
+--
+-- Safe to re-run. Every statement is conditional or IF NOT EXISTS.
+
+SET lock_timeout = '5s';
+
+-- Trigger function: same expression, same 'simple' config, as the query in
+-- src/modules/rag/kb-fts.sql.ts (websearch_to_tsquery('simple', ...)).
+CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger
+LANGUAGE plpgsql AS $fn$
+BEGIN
+  NEW.content_tsv := to_tsvector('simple', NEW.content);
+  RETURN NEW;
+END
+$fn$;
 
 DO $$
 DECLARE
-  needs_rebuild boolean;
+  col_generated "char";   -- attgenerated: 's' = STORED generated, '' = plain, NULL = column absent
+  row_count     bigint;
 BEGIN
-  SELECT NOT (
-      a.attgenerated = 's'
-      AND pg_get_expr(d.adbin, d.adrelid) LIKE '%''simple''%'
-    )
-    INTO needs_rebuild
+  SELECT a.attgenerated
+    INTO col_generated
   FROM pg_attribute a
-  LEFT JOIN pg_attrdef d
-    ON d.adrelid = a.attrelid
-   AND d.adnum = a.attnum
   WHERE a.attrelid = to_regclass('"KbChunk"')
     AND a.attname = 'content_tsv'
     AND NOT a.attisdropped;
 
-  IF needs_rebuild THEN
-    RAISE NOTICE 'KbChunk.content_tsv exists but is not a STORED generated tsvector over the ''simple'' config — rebuilding it.';
-    DROP INDEX IF EXISTS kb_chunk_content_tsv_idx;
-    ALTER TABLE "KbChunk" DROP COLUMN content_tsv;
+  IF col_generated IS NULL THEN
+    -- Plain, nullable, no default: metadata-only, no table rewrite.
+    ALTER TABLE "KbChunk" ADD COLUMN IF NOT EXISTS content_tsv tsvector;
+    col_generated := '';
+  END IF;
+
+  SELECT count(*) INTO row_count FROM "KbChunk";
+
+  IF col_generated = 's' THEN
+    RAISE NOTICE 'KbChunk.content_tsv is a legacy STORED generated column — leaving it (Postgres maintains it); no trigger installed.';
+    DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";
+  ELSE
+    -- Trigger BEFORE the backfill, so nothing written during the backfill is missed.
+    DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";
+    CREATE TRIGGER kbchunk_content_tsv_trg
+      BEFORE INSERT OR UPDATE OF content ON "KbChunk"
+      FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
+
+    IF row_count <= 5000 THEN
+      UPDATE "KbChunk"
+         SET content_tsv = to_tsvector('simple', content)
+       WHERE content_tsv IS NULL;
+    ELSE
+      RAISE NOTICE 'KbChunk has % rows: backfill deliberately NOT run here. Run scripts/sql/kb_fts_safe_rollout.py (batched backfill, then CREATE INDEX CONCURRENTLY, then prisma migrate resolve).', row_count;
+    END IF;
+  END IF;
+
+  IF row_count <= 5000 THEN
+    -- Small table: a plain (SHARE-locking) build takes milliseconds.
+    CREATE INDEX IF NOT EXISTS kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (content_tsv);
+  ELSE
+    RAISE NOTICE 'GIN index kb_chunk_content_tsv_idx deliberately NOT built here on a % row table — build it with CREATE INDEX CONCURRENTLY after the backfill (scripts/sql/kb_fts_safe_rollout.py).', row_count;
   END IF;
 END$$;
-
-ALTER TABLE "KbChunk"
-  ADD COLUMN IF NOT EXISTS content_tsv tsvector
-  GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED;
-
-CREATE INDEX IF NOT EXISTS kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (content_tsv);

--- a/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
+++ b/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
@@ -36,7 +36,9 @@
 --   3. Backfills and builds the GIN index ONLY on small tables (<= 5000 rows:
 --      dev databases, CI, the PGlite regression test) — i.e. the migration either
 --      COMPLETES or FAILS. On a production-sized table it RAISES an exception
---      (nothing is committed), so `prisma migrate deploy` cannot record it as
+--      and, because the whole file is one DO block, nothing at all is committed
+--      (Prisma 5 does not wrap migration.sql in a transaction; separate
+--      statements would not roll back together), so `prisma migrate deploy` cannot record it as
 --      applied while the column is still unpopulated and unindexed. The
 --      production procedure is `scripts/sql/kb_fts_safe_rollout.py`
 --      (docs/OPERATIONS_RUNBOOK.md §4a): it bootstraps the same column + trigger
@@ -53,21 +55,25 @@
 
 SET lock_timeout = '5s';
 
--- Trigger function: same expression, same 'simple' config, as the query in
--- src/modules/rag/kb-fts.sql.ts (websearch_to_tsquery('simple', ...)).
-CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger
-LANGUAGE plpgsql AS $fn$
-BEGIN
-  NEW.content_tsv := to_tsvector('simple', NEW.content);
-  RETURN NEW;
-END
-$fn$;
-
-DO $$
+-- Everything is ONE DO block on purpose. Prisma 5 does not wrap a PostgreSQL
+-- migration.sql in a transaction, so with separate statements a raise in the guard
+-- below would still leave any earlier statement committed. Inside a single DO block
+-- an exception rolls back the whole block: no function, no column, no trigger.
+DO $do$
 DECLARE
   col_generated "char";   -- attgenerated: 's' = STORED generated, '' = plain, NULL = column absent
   row_count     bigint;
 BEGIN
+  -- Trigger function: same expression, same 'simple' config, as the query in
+  -- src/modules/rag/kb-fts.sql.ts (websearch_to_tsquery('simple', ...)).
+  CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger
+  LANGUAGE plpgsql AS $fn$
+  BEGIN
+    NEW.content_tsv := to_tsvector('simple', NEW.content);
+    RETURN NEW;
+  END
+  $fn$;
+
   SELECT a.attgenerated
     INTO col_generated
   FROM pg_attribute a
@@ -120,4 +126,5 @@ BEGIN
   END IF;
   -- Large table: reaching here means the rollout script already populated the
   -- column and built a valid index (checked above), so there is nothing to do.
-END$$;
+END
+$do$;

--- a/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
+++ b/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
@@ -34,13 +34,16 @@
 --   2. Installs a BEFORE INSERT OR UPDATE OF content trigger that keeps the
 --      column current, so rows written while the backfill runs are covered.
 --   3. Backfills and builds the GIN index ONLY on small tables (<= 5000 rows:
---      dev databases, CI, the PGlite regression test). On a production-sized
---      table it deliberately stops with a NOTICE: the backfill must run in
---      small committed batches and the index must be built CONCURRENTLY
---      (which cannot run inside a transaction). That procedure is
---      `scripts/sql/kb_fts_safe_rollout.py`, documented in
---      docs/OPERATIONS_RUNBOOK.md §4a; it ends with
+--      dev databases, CI, the PGlite regression test) — i.e. the migration either
+--      COMPLETES or FAILS. On a production-sized table it RAISES an exception
+--      (nothing is committed), so `prisma migrate deploy` cannot record it as
+--      applied while the column is still unpopulated and unindexed. The
+--      production procedure is `scripts/sql/kb_fts_safe_rollout.py`
+--      (docs/OPERATIONS_RUNBOOK.md §4a): it bootstraps the same column + trigger
+--      itself, backfills in committed batches, builds the index CONCURRENTLY
+--      (which cannot run inside a transaction), verifies, and only then runs
 --      `prisma migrate resolve --applied 20260908000000_restore_kb_chunk_fts`.
+--      Re-running this file after the script has finished is a harmless no-op.
 --
 --   A database that still carries the legacy GENERATED column (never ran
 --   20260606) is left exactly as it is: Postgres maintains that shape itself and
@@ -80,6 +83,20 @@ BEGIN
 
   SELECT count(*) INTO row_count FROM "KbChunk";
 
+  -- Safety invariant (review on the #92 follow-up): this file must never leave a
+  -- half-done state that Prisma then records as "applied". A production-sized table
+  -- is refused here unless the rollout script has already completed the work
+  -- (column populated + valid GIN index), in which case everything below is a no-op.
+  IF row_count > 5000 AND col_generated <> 's' THEN
+    IF EXISTS (SELECT 1 FROM "KbChunk" WHERE content_tsv IS NULL)
+       OR NOT EXISTS (SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+                      WHERE c.relname = 'kb_chunk_content_tsv_idx' AND i.indisvalid AND i.indisready) THEN
+      RAISE EXCEPTION USING
+        MESSAGE = format('KbChunk has %s rows: refusing to backfill/index inside a migration (that is a table rewrite — see the 2026-09-12 outage). Run scripts/sql/kb_fts_safe_rollout.py --execute, which bootstraps column + trigger, backfills in batches, builds the GIN index CONCURRENTLY and then marks this migration applied.', row_count),
+        HINT = 'docs/OPERATIONS_RUNBOOK.md §4a';
+    END IF;
+  END IF;
+
   IF col_generated = 's' THEN
     RAISE NOTICE 'KbChunk.content_tsv is a legacy STORED generated column — leaving it (Postgres maintains it); no trigger installed.';
     DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";
@@ -94,15 +111,13 @@ BEGIN
       UPDATE "KbChunk"
          SET content_tsv = to_tsvector('simple', content)
        WHERE content_tsv IS NULL;
-    ELSE
-      RAISE NOTICE 'KbChunk has % rows: backfill deliberately NOT run here. Run scripts/sql/kb_fts_safe_rollout.py (batched backfill, then CREATE INDEX CONCURRENTLY, then prisma migrate resolve).', row_count;
     END IF;
   END IF;
 
   IF row_count <= 5000 THEN
     -- Small table: a plain (SHARE-locking) build takes milliseconds.
     CREATE INDEX IF NOT EXISTS kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (content_tsv);
-  ELSE
-    RAISE NOTICE 'GIN index kb_chunk_content_tsv_idx deliberately NOT built here on a % row table — build it with CREATE INDEX CONCURRENTLY after the backfill (scripts/sql/kb_fts_safe_rollout.py).', row_count;
   END IF;
+  -- Large table: reaching here means the rollout script already populated the
+  -- column and built a valid index (checked above), so there is nothing to do.
 END$$;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -165,20 +165,13 @@ model KbChunk {
   content    String
   embedding  Unsupported("vector(768)")? // pgvector for semantic search
 
-  /// Full-text search vector for the lexical arm of hybrid retrieval.
-  ///
-  /// DO NOT REMOVE. In the database this is a STORED GENERATED column
-  /// (`GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED`), created by raw
-  /// migration SQL — Prisma cannot express generated columns, so it is declared here
-  /// as Unsupported() purely so a schema diff sees it and does not emit a DROP.
-  ///
-  /// It was invisible to Prisma before, and migration 20260606000000 duly dropped it;
-  /// `RagService.fullTextSearchWithMetadata` then failed silently for three months
-  /// (issue #92). Migration 20260908000000_restore_kb_chunk_fts restored it and also
-  /// repairs the shape a Prisma-generated schema would produce, because
-  /// `prisma migrate diff` renders this field as a plain, never-populated
-  /// `content_tsv tsvector`. `KbFtsHealthService` verifies at boot that the live
-  /// column really is generated on the 'simple' config.
+  /// DO NOT REMOVE. Full-text-search vector, owned by raw migration SQL (20260908000000_restore_kb_chunk_fts):
+  /// a PLAIN tsvector kept current by trigger kbchunk_content_tsv_trg. Deliberately NOT a
+  /// STORED generated column — that rewrites the whole table and every index (incl. the
+  /// pgvector HNSW index) and caused a 15-minute retrieval outage on 2026-09-12.
+  /// Declared here only so a schema diff cannot drop it again; `prisma migrate diff` renders
+  /// it as a bare `content_tsv tsvector`, which the migration then equips with the trigger.
+  /// `KbFtsHealthService` verifies at boot that the live column really is maintained.
   content_tsv Unsupported("tsvector")?
 
   createdAt  DateTime @default(now())

--- a/apps/api/src/modules/rag/kb-fts-health.service.ts
+++ b/apps/api/src/modules/rag/kb-fts-health.service.ts
@@ -7,16 +7,19 @@ import {
   KB_FTS_OWNERSHIP_NOTE,
   KB_FTS_PROBE_SQL,
   KB_FTS_TABLE,
+  KB_FTS_TRIGGER,
   KbFtsProbeRow,
 } from "./kb-fts.sql";
 
 /**
  * Health of the lexical (FTS) arm of hybrid retrieval.
  *
- * - `ok`            — column exists, is a STORED generated tsvector on the expected config, index present.
- * - `degraded`      — queryable but not in the expected shape (e.g. GIN index missing → slow but correct).
- * - `unavailable`   — the column/table the query needs is missing, or present but not generated
- *                     (always NULL). The lexical arm contributes nothing.
+ * - `ok`            — column exists, is maintained (by the enabled trigger, or as a legacy STORED
+ *                     generated column) on the expected config, GIN index present and valid.
+ * - `degraded`      — queryable but not in the expected shape (GIN index missing or invalid → slow
+ *                     but correct; config mismatch → far fewer matches).
+ * - `unavailable`   — the column/table the query needs is missing, or present but maintained by
+ *                     nothing (always NULL). The lexical arm contributes nothing.
  * - `unknown`       — the probe could not run (DB unreachable at boot). Not a verdict.
  */
 export type KbFtsStatus = "ok" | "degraded" | "unavailable" | "unknown";
@@ -102,30 +105,41 @@ export class KbFtsHealthService implements OnModuleInit {
         return this.getHealth();
       }
 
-      if (!row.columnGenerated) {
+      // How is the column kept current? Either Postgres does it (legacy STORED
+      // generated column) or the maintenance trigger does (current shape — a
+      // generated column rewrites the whole table and caused the 2026-09-12 outage).
+      // A plain column with neither is `prisma migrate diff` output: always NULL.
+      const maintainedBy: "generated column" | "trigger" | null = row.columnGenerated
+        ? "generated column"
+        : row.triggerEnabled
+          ? "trigger"
+          : null;
+      if (!maintainedBy) {
         this.set(
           "unavailable",
-          `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" exists but is not a STORED GENERATED column, so it is ` +
-            `always NULL and every lexical query returns zero rows. This is what a schema built by ` +
-            `\`prisma migrate diff\`/\`db push\` produces. Run migration 20260908000000_restore_kb_chunk_fts.`
+          `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" exists but nothing maintains it (not GENERATED, and ` +
+            `trigger ${KB_FTS_TRIGGER} is missing or disabled), so it is always NULL and every lexical ` +
+            `query returns zero rows. This is what a schema built by \`prisma migrate diff\`/\`db push\` ` +
+            `produces. Run migration 20260908000000_restore_kb_chunk_fts.`
         );
         this.logUnavailable();
         return this.getHealth();
       }
 
-      const expr = row.generationExpr ?? "";
+      const expr = (row.columnGenerated ? row.generationExpr : row.triggerFunctionDef) ?? "";
       if (!expr.includes(`'${KB_FTS_CONFIG}'`)) {
         this.set(
           "degraded",
-          `"${KB_FTS_COLUMN}" is generated as ${expr || "<unknown>"} but queries use ` +
-            `websearch_to_tsquery('${KB_FTS_CONFIG}', …). Mismatched text-search configs match far ` +
-            `fewer rows (and no Hindi/Hinglish at all).`
+          `"${KB_FTS_COLUMN}" is maintained by ${maintainedBy} with ${expr ? "a definition that does not use" : "an unreadable definition for"} ` +
+            `'${KB_FTS_CONFIG}', but queries use websearch_to_tsquery('${KB_FTS_CONFIG}', …). Mismatched ` +
+            `text-search configs match far fewer rows (and no Hindi/Hinglish at all).`
         );
         this.logger.error({
           event: "kb_fts_config_mismatch",
           message: this.detail,
           expectedConfig: KB_FTS_CONFIG,
-          generationExpr: expr,
+          maintainedBy,
+          definition: expr.slice(0, 300),
         });
         return this.getHealth();
       }
@@ -140,7 +154,18 @@ export class KbFtsHealthService implements OnModuleInit {
         return this.getHealth();
       }
 
-      this.set("ok", `${KB_FTS_COLUMN} generated on '${KB_FTS_CONFIG}', ${KB_FTS_INDEX} present`);
+      if (!row.indexValid) {
+        this.set(
+          "degraded",
+          `GIN index ${KB_FTS_INDEX} exists but is INVALID — an interrupted CREATE INDEX CONCURRENTLY ` +
+            `leaves this behind. The planner ignores it (sequential scans). DROP INDEX ${KB_FTS_INDEX} ` +
+            `and rebuild it CONCURRENTLY.`
+        );
+        this.logger.error({ event: "kb_fts_index_invalid", message: this.detail, index: KB_FTS_INDEX });
+        return this.getHealth();
+      }
+
+      this.set("ok", `${KB_FTS_COLUMN} maintained by ${maintainedBy} on '${KB_FTS_CONFIG}', ${KB_FTS_INDEX} present and valid`);
       this.logger.log({
         event: "kb_fts_health_ok",
         message: `Lexical retrieval arm ready: ${this.detail}`,
@@ -201,15 +226,15 @@ export class KbFtsHealthService implements OnModuleInit {
    * A lexical query completed without throwing.
    *
    * Execution success is NOT evidence that the schema is repaired. A plain,
-   * non-generated `content_tsv` column — what `prisma migrate diff` emits, and
+   * unmaintained `content_tsv` column — what `prisma migrate diff` emits, and
    * precisely what the restore migration exists to repair — satisfies this
    * query, returns zero rows, and throws nothing. Clearing an `unavailable`
    * verdict on that basis would report a dead lexical arm as healthy, which is
    * the exact masking this service exists to prevent.
    *
    * So a success never sets `ok` directly. It only schedules a re-probe, which
-   * checks `attgenerated` and the generation expression and is the sole
-   * authority on the verdict. Throttled and never awaited, so the retrieval
+   * checks how the column is maintained (trigger or generation expression) and
+   * is the sole authority on the verdict. Throttled and never awaited, so the retrieval
    * path is not slowed.
    */
   recordQuerySuccess(): void {

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -475,6 +475,60 @@ describe("KB full-text search (issue #92)", () => {
     });
   });
 
+  describe("on a production-sized table the migration refuses instead of rewriting (review on the #92 follow-up)", () => {
+    // The 2026-09-12 outage: a STORED generated column rewrote the whole table.
+    // The safeguard is that migration.sql can never leave a large table half-done
+    // and be recorded as applied — it either completes (small table) or raises.
+    let big: PgliteDatabase;
+    const restoreSql = () => ftsMigrationsInOrder().find((m) => m.name === RESTORE_MIGRATION)!.sql;
+
+    beforeAll(async () => {
+      big = await buildDatabase(proc);
+      // Undo the restore so the column is absent, then make the table "large".
+      await big.exec(`DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";`);
+      await big.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
+      await big.exec(`ALTER TABLE "KbChunk" DROP COLUMN IF EXISTS ${KB_FTS_COLUMN};`);
+      await big.exec(`
+        INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
+        SELECT 'bulk-' || g, '${DOC_ID}', 1000 + g, 'filler chunk ' || g, now() FROM generate_series(1, 5001) g;
+      `);
+    });
+
+    afterAll(async () => {
+      await big?.close();
+    });
+
+    it("raises (nothing committed) when the column is unpopulated, so prisma migrate deploy cannot record it", async () => {
+      const err = await big.exec(restoreSql()).then(() => null).catch((e) => e);
+      expect(err).not.toBeNull();
+      expect(String((err as Error).message)).toMatch(/refusing to backfill\/index inside a migration/);
+      // DO-block failure rolls the whole statement back: no column, no trigger.
+      const probe = (await big.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
+      expect(probe.columnPresent).toBe(false);
+      expect(probe.triggerEnabled).toBe(false);
+    });
+
+    it("is a harmless no-op once the rollout script has populated the column and built a valid index", async () => {
+      // What scripts/sql/kb_fts_safe_rollout.py does, minus batching/CONCURRENTLY (PGlite).
+      await big.exec(`ALTER TABLE "KbChunk" ADD COLUMN ${KB_FTS_COLUMN} tsvector;`);
+      await big.exec(`
+        CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger LANGUAGE plpgsql AS $fn$
+        BEGIN NEW.${KB_FTS_COLUMN} := to_tsvector('${KB_FTS_CONFIG}', NEW.content); RETURN NEW; END $fn$;
+        CREATE TRIGGER kbchunk_content_tsv_trg BEFORE INSERT OR UPDATE OF content ON "KbChunk"
+          FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
+      `);
+      await big.exec(`UPDATE "KbChunk" SET ${KB_FTS_COLUMN} = to_tsvector('${KB_FTS_CONFIG}', content) WHERE ${KB_FTS_COLUMN} IS NULL;`);
+      await big.exec(`CREATE INDEX ${KB_FTS_INDEX} ON "KbChunk" USING GIN (${KB_FTS_COLUMN});`);
+
+      await expect(big.exec(restoreSql())).resolves.toBeDefined();
+      const probe = (await big.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
+      expect(probe.triggerEnabled).toBe(true);
+      expect(probe.indexValid).toBe(true);
+      const nulls = await big.query<{ n: number }>(`SELECT count(*)::int AS n FROM "KbChunk" WHERE ${KB_FTS_COLUMN} IS NULL`);
+      expect(nulls[0].n).toBe(0);
+    });
+  });
+
   it("declares content_tsv in schema.prisma so a schema diff cannot drop it again", () => {
     const schema = fs.readFileSync(SCHEMA_PATH, "utf8");
     const fromModel = schema.slice(schema.indexOf("model KbChunk {"));

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -486,6 +486,7 @@ describe("KB full-text search (issue #92)", () => {
       big = await buildDatabase(proc);
       // Undo the restore so the column is absent, then make the table "large".
       await big.exec(`DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";`);
+      await big.exec(`DROP FUNCTION IF EXISTS kbchunk_content_tsv_maintain();`);
       await big.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
       await big.exec(`ALTER TABLE "KbChunk" DROP COLUMN IF EXISTS ${KB_FTS_COLUMN};`);
       await big.exec(`
@@ -502,10 +503,16 @@ describe("KB full-text search (issue #92)", () => {
       const err = await big.exec(restoreSql()).then(() => null).catch((e) => e);
       expect(err).not.toBeNull();
       expect(String((err as Error).message)).toMatch(/refusing to backfill\/index inside a migration/);
-      // DO-block failure rolls the whole statement back: no column, no trigger.
+      // The file is one DO block, so the raise rolls everything back: no column,
+      // no trigger, and not even the helper function (Prisma 5 does not wrap
+      // migration.sql in a transaction, so this atomicity has to come from the file).
       const probe = (await big.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
       expect(probe.columnPresent).toBe(false);
       expect(probe.triggerEnabled).toBe(false);
+      const fn = await big.query<{ n: number }>(
+        `SELECT count(*)::int AS n FROM pg_proc WHERE proname = 'kbchunk_content_tsv_maintain'`
+      );
+      expect(fn[0].n).toBe(0);
     });
 
     it("is a harmless no-op once the rollout script has populated the column and built a valid index", async () => {

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -185,18 +185,38 @@ describe("KB full-text search (issue #92)", () => {
     expect(last.sql).toContain(`to_tsvector('${KB_FTS_CONFIG}', content)`);
   });
 
-  it("leaves content_tsv present, STORED GENERATED and on the 'simple' config after replaying the real migrations", async () => {
+  it("leaves content_tsv present, trigger-maintained on the 'simple' config, with a VALID GIN index after replaying the real migrations", async () => {
     const rows = await db.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL);
     expect(rows).toHaveLength(1);
 
     const probe = rows[0];
     expect(probe.tablePresent).toBe(true);
     expect(probe.columnPresent).toBe(true);
-    // Existence alone is not enough: a plain column stays NULL forever and the
-    // lexical arm returns zero rows without ever raising an error.
-    expect(probe.columnGenerated).toBe(true);
-    expect(probe.generationExpr).toContain(`'${KB_FTS_CONFIG}'`);
+    // Existence alone is not enough: an unmaintained column stays NULL forever and
+    // the lexical arm returns zero rows without ever raising an error. The current
+    // shape is a plain column + trigger (a STORED generated column rewrites the
+    // table and every index — the 2026-09-12 outage), so the probe must see the
+    // trigger and its 'simple' config.
+    expect(probe.columnGenerated).toBe(false);
+    expect(probe.triggerEnabled).toBe(true);
+    expect(probe.triggerFunctionDef).toContain(`'${KB_FTS_CONFIG}'`);
     expect(probe.indexPresent).toBe(true);
+    expect(probe.indexValid).toBe(true);
+  });
+
+  it("the trigger keeps content_tsv current on INSERT and on UPDATE OF content", async () => {
+    await db.exec(`INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
+                   VALUES ('chunk-trigger', '${DOC_ID}', 99, 'Mammography screening every two years', now());`);
+    const inserted = await db.query<{ populated: boolean }>(
+      `SELECT ${KB_FTS_COLUMN} IS NOT NULL AS populated FROM "KbChunk" WHERE id = 'chunk-trigger'`
+    );
+    expect(inserted[0].populated).toBe(true);
+    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["mammography", 12])).map((r) => r.id)).toContain("chunk-trigger");
+
+    await db.exec(`UPDATE "KbChunk" SET content = 'Colposcopy after an abnormal Pap smear' WHERE id = 'chunk-trigger';`);
+    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["mammography", 12])).map((r) => r.id)).not.toContain("chunk-trigger");
+    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["Pap smear", 12])).map((r) => r.id)).toContain("chunk-trigger");
+    await db.exec(`DELETE FROM "KbChunk" WHERE id = 'chunk-trigger';`);
   });
 
   it("returns ranked rows for the shipped lexical query", async () => {
@@ -241,15 +261,17 @@ describe("KB full-text search (issue #92)", () => {
     expect(ftsHealth.getHealth().schemaFailureCount).toBe(0);
   });
 
-  it("repairs a schema built from schema.prisma, where Prisma renders content_tsv as a plain column", async () => {
-    // `prisma migrate diff` / `db push` cannot express GENERATED, so a database created
-    // straight from the datamodel gets a `content_tsv tsvector` that is always NULL.
-    // The restore migration must rebuild it, not skip it via IF NOT EXISTS.
+  it("repairs a schema built from schema.prisma, where Prisma renders content_tsv as a plain, unmaintained column", async () => {
+    // `prisma migrate diff` / `db push` gives a `content_tsv tsvector` that nothing
+    // maintains, so it is always NULL. The restore migration must equip that existing
+    // column with the trigger (and backfill it), not skip it via IF NOT EXISTS.
     const fresh = await buildDatabase(proc, { simulateFreshDbPush: true });
     try {
       const probe = (await fresh.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
-      expect(probe.columnGenerated).toBe(true);
-      expect(probe.generationExpr).toContain(`'${KB_FTS_CONFIG}'`);
+      expect(probe.columnGenerated).toBe(false);
+      expect(probe.triggerEnabled).toBe(true);
+      expect(probe.triggerFunctionDef).toContain(`'${KB_FTS_CONFIG}'`);
+      expect(probe.indexValid).toBe(true);
 
       const rows = await fresh.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
       expect(rows.map((r) => r.id)).toContain("chunk-hpv");
@@ -346,7 +368,7 @@ describe("KB full-text search (issue #92)", () => {
     });
   });
 
-  describe("when content_tsv is present but not generated (always NULL)", () => {
+  describe("when content_tsv is present but nothing maintains it (always NULL)", () => {
     // The masking case: the column exists, so the query executes and throws
     // nothing — it just returns zero rows forever. Query success must never be
     // read as proof that the schema is healthy.
@@ -364,6 +386,7 @@ describe("KB full-text search (issue #92)", () => {
       const probe = (await unrepaired.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
       expect(probe.columnPresent).toBe(true);
       expect(probe.columnGenerated).toBe(false);
+      expect(probe.triggerEnabled).toBe(false);
 
       const rows = await unrepaired.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
       expect(rows).toHaveLength(0);
@@ -404,6 +427,26 @@ describe("KB full-text search (issue #92)", () => {
         expect(health.isUnavailable()).toBe(true);
       } finally {
         jest.restoreAllMocks();
+      }
+    });
+
+    it("reports 'degraded' (not ok) when the GIN index is left INVALID by an interrupted concurrent build", async () => {
+      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+      const invalid = await buildDatabase(proc);
+      try {
+        // Simulate what a cancelled CREATE INDEX CONCURRENTLY leaves behind.
+        await invalid.exec(`UPDATE pg_index SET indisvalid = false WHERE indexrelid = '${KB_FTS_INDEX}'::regclass;`);
+        const probe = (await invalid.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
+        expect(probe.indexPresent).toBe(true);
+        expect(probe.indexValid).toBe(false);
+
+        const health = await new KbFtsHealthService(invalid.asPrisma()).probe();
+        expect(health.status).toBe("degraded");
+        expect(health.detail).toMatch(/INVALID/);
+      } finally {
+        jest.restoreAllMocks();
+        await invalid.close();
       }
     });
 

--- a/apps/api/src/modules/rag/kb-fts.sql.ts
+++ b/apps/api/src/modules/rag/kb-fts.sql.ts
@@ -21,8 +21,14 @@
 /** Table carrying the FTS column. */
 export const KB_FTS_TABLE = "KbChunk";
 
-/** Generated tsvector column. Defined in raw migration SQL only — see KB_FTS_OWNERSHIP_NOTE. */
+/** tsvector column. Defined in raw migration SQL only — see KB_FTS_OWNERSHIP_NOTE. */
 export const KB_FTS_COLUMN = "content_tsv";
+
+/** Trigger that keeps a plain `content_tsv` current (BEFORE INSERT OR UPDATE OF content). */
+export const KB_FTS_TRIGGER = "kbchunk_content_tsv_trg";
+
+/** The trigger's function; its body carries the text-search config, like a generation expression would. */
+export const KB_FTS_TRIGGER_FN = "kbchunk_content_tsv_maintain";
 
 /** GIN index over the tsvector column. */
 export const KB_FTS_INDEX = "kb_chunk_content_tsv_idx";
@@ -35,10 +41,14 @@ export const KB_FTS_INDEX = "kb_chunk_content_tsv_idx";
 export const KB_FTS_CONFIG = "simple";
 
 export const KB_FTS_OWNERSHIP_NOTE =
-  `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" is a STORED GENERATED column created by raw ` +
-  `migration SQL (20260908000000_restore_kb_chunk_fts). Prisma cannot express generated ` +
-  `columns, so schema.prisma declares it as Unsupported("tsvector") purely to stop a ` +
-  `schema diff from dropping it again. Never "clean it up" out of either place.`;
+  `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" is a plain tsvector kept current by trigger ${KB_FTS_TRIGGER} ` +
+  `(function ${KB_FTS_TRIGGER_FN}), both created by raw migration SQL ` +
+  `(20260908000000_restore_kb_chunk_fts); a legacy STORED GENERATED shape is also accepted. ` +
+  `It is NOT a generated column on purpose: a STORED generated column rewrites the whole table ` +
+  `and every index (incl. the pgvector HNSW index) and caused a 15-minute retrieval outage on ` +
+  `2026-09-12. Prisma cannot express either shape, so schema.prisma declares it as ` +
+  `Unsupported("tsvector") purely to stop a schema diff from dropping it again. Never "clean it ` +
+  `up" out of either place.`;
 
 /**
  * The lexical retrieval query.
@@ -74,9 +84,12 @@ export const KB_FTS_SEARCH_SQL = `
 /**
  * Schema probe: reports whether the objects `KB_FTS_SEARCH_SQL` depends on exist
  * AND are shaped correctly. Existence alone is not enough — `prisma migrate diff`
- * emits `content_tsv tsvector` *without* the GENERATED clause, which would leave a
- * column that is always NULL and an FTS arm that returns zero rows forever without
- * ever raising an error. Hence the `attgenerated` / generation-expression checks.
+ * emits `content_tsv tsvector` with nothing maintaining it, which leaves a column
+ * that is always NULL and an FTS arm that returns zero rows forever without ever
+ * raising an error. So the probe reports HOW the column is maintained — a STORED
+ * generation expression (legacy) or the enabled `KB_FTS_TRIGGER` (current) — and
+ * whether the GIN index is not just present but VALID (an interrupted
+ * `CREATE INDEX CONCURRENTLY` leaves an invalid index behind).
  */
 export const KB_FTS_PROBE_SQL = `
   SELECT
@@ -85,8 +98,23 @@ export const KB_FTS_PROBE_SQL = `
     COALESCE(a.attgenerated = 's', false) AS "columnGenerated",
     pg_get_expr(d.adbin, d.adrelid) AS "generationExpr",
     EXISTS (
+      SELECT 1 FROM pg_trigger t
+      WHERE t.tgrelid = to_regclass('"${KB_FTS_TABLE}"')
+        AND t.tgname = '${KB_FTS_TRIGGER}'
+        AND NOT t.tgisinternal
+        AND t.tgenabled <> 'D'
+    ) AS "triggerEnabled",
+    (
+      SELECT pg_get_functiondef(p.oid) FROM pg_proc p WHERE p.proname = '${KB_FTS_TRIGGER_FN}' LIMIT 1
+    ) AS "triggerFunctionDef",
+    EXISTS (
       SELECT 1 FROM pg_indexes WHERE indexname = '${KB_FTS_INDEX}'
-    ) AS "indexPresent"
+    ) AS "indexPresent",
+    COALESCE((
+      SELECT i.indisvalid AND i.indisready
+      FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+      WHERE c.relname = '${KB_FTS_INDEX}'
+    ), false) AS "indexValid"
   FROM (SELECT 1) probe
   LEFT JOIN pg_attribute a
     ON a.attrelid = to_regclass('"${KB_FTS_TABLE}"')
@@ -100,9 +128,15 @@ export const KB_FTS_PROBE_SQL = `
 export interface KbFtsProbeRow {
   tablePresent: boolean;
   columnPresent: boolean;
+  /** Legacy shape: STORED generated column (Postgres maintains it). */
   columnGenerated: boolean;
   generationExpr: string | null;
+  /** Current shape: plain column kept current by the enabled maintenance trigger. */
+  triggerEnabled: boolean;
+  triggerFunctionDef: string | null;
   indexPresent: boolean;
+  /** pg_index.indisvalid AND indisready — false for an interrupted concurrent build. */
+  indexValid: boolean;
 }
 
 /**

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -125,6 +125,51 @@ Rules that apply to **any** deploy path:
    both cloudbuild files (and `deploy-api.yml` if it stays enabled).
 2. Verify local checks pass: run configuration parity check (`python scripts/check_deploy_config_parity.py`), ensure tests pass, `prisma migrate status` is clean, no doubled route prefixes, and the health check responds with 200. Refer to `docs/DEPLOYMENT.md` for details.
 3. Deploys are a human decision; agents open PRs only (see `AGENTS.md`).
+4. A migration that touches `KbChunk` must follow §4a — no table rewrites in
+   traffic hours, ever.
+
+## 4a. Schema changes on `KbChunk` — never a table rewrite
+
+`"KbChunk"` is ~74k rows of 1.4 KB text plus a 768-d `embedding` vector each,
+with a pgvector HNSW index. On suchi-db (`db-f1-micro`) **any statement that
+rewrites the table is a production outage**: the rewrite runs under an
+ACCESS EXCLUSIVE lock and rebuilds every index including the HNSW one. Measured
+2026-09-12: `ALTER TABLE "KbChunk" ADD COLUMN … GENERATED ALWAYS … STORED` ran
+15+ minutes, 20 retrieval queries queued behind it, the connection pool filled
+(`remaining connection slots are reserved`), `/v1/health` stopped answering and
+chat turns timed out until the backend was terminated. Statements that rewrite:
+adding a column with a volatile/non-null default or a STORED generated
+expression, changing a column type, `VACUUM FULL`, `CLUSTER`.
+
+Safe pattern (what `20260908000000_restore_kb_chunk_fts` now does):
+
+1. `SET lock_timeout = '5s'` — a metadata change that cannot get its lock aborts
+   instead of queueing behind a long transaction.
+2. Add the column **plain and nullable, no default** (catalog-only).
+3. Install the maintenance **trigger before backfilling**, so rows written
+   during the backfill are covered.
+4. Backfill in **small committed batches** (1 000–2 000 rows, short sleep
+   between), never one transaction. Watch DB CPU / connections / lock waiters.
+5. Build the index **after** the backfill with `CREATE INDEX CONCURRENTLY`
+   (outside any transaction — Prisma migrations cannot contain it).
+6. Verify `COUNT(*) WHERE col IS NULL = 0`, `pg_index.indisvalid`, and a live
+   query; only then `prisma migrate resolve --applied <migration>`.
+
+Scripted for the FTS column:
+
+```bash
+# Terminal 1: cloud-sql-proxy … --port 5433   (see §1)
+# Terminal 2, repo root, low-traffic window (night IST):
+export DATABASE_URL="$(gcloud secrets versions access latest --secret=database-url)"
+python3 scripts/sql/kb_fts_safe_rollout.py            # dry run: state + plan
+python3 scripts/sql/kb_fts_safe_rollout.py --execute  # column+trigger → batched backfill → CONCURRENT index → verify → resolve
+curl -s https://suchi-api-lxiveognla-uc.a.run.app/v1/health/retrieval   # fullTextSearch.status: ok
+```
+
+If something is already holding a lock on `KbChunk` for minutes, find it with
+`SELECT pid, now()-query_start, left(query,80) FROM pg_stat_activity WHERE
+state='active' ORDER BY query_start;` and `pg_terminate_backend(pid)` — a
+cancelled DDL rolls back cleanly.
 
 ## 5. Production health checks
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -155,6 +155,13 @@ Safe pattern (what `20260908000000_restore_kb_chunk_fts` now does):
 6. Verify `COUNT(*) WHERE col IS NULL = 0`, `pg_index.indisvalid`, and a live
    query; only then `prisma migrate resolve --applied <migration>`.
 
+The FTS migration `20260908000000_restore_kb_chunk_fts` enforces this: on a table
+with more than 5 000 rows it **raises** (nothing committed) unless the column is
+already populated and the GIN index valid, so `prisma migrate deploy` — including
+the gated pipeline's migration job — cannot record it as applied ahead of the
+backfill. The script below does the bootstrap itself and resolves the migration
+at the end; after that the file is a no-op.
+
 Scripted for the FTS column:
 
 ```bash

--- a/docs/RELIABILITY_BACKLOG.md
+++ b/docs/RELIABILITY_BACKLOG.md
@@ -505,6 +505,35 @@ more, and should be decided together with QA0904-1.
 
 ---
 
+## Incident 2026-09-12 — `KbChunk` table rewrite blocked retrieval for ~15 minutes
+
+**What happened.** Applying the first version of migration
+`20260908000000_restore_kb_chunk_fts` (PR #98) to production re-added
+`content_tsv` as a `GENERATED ALWAYS … STORED` column. Postgres rewrote the
+whole `"KbChunk"` table under an ACCESS EXCLUSIVE lock and rebuilt every index,
+including the pgvector HNSW index. On `db-f1-micro` this ran 15+ minutes
+(10:48–11:03 UTC). Twenty retrieval queries queued behind the lock, the pool hit
+`remaining connection slots are reserved`, `/v1/health` stopped answering, and
+8 web turns hit `REQUEST_TIMEOUT` (0 WhatsApp turns failed — the channel was
+quiet). The backend was terminated with `pg_terminate_backend`; the table, the
+HNSW index and `_prisma_migrations` were unchanged. The on-demand backup taken
+beforehand was not needed.
+
+**Why it was not caught earlier.** The PGlite regression test replays the
+migration against a 3-row table, where the same statement takes milliseconds.
+Rewrite cost is a function of table size and index count, which no unit test
+sees.
+
+**Fix.** The migration was rewritten (same name — no persistent database had
+recorded it) to a plain nullable column + `BEFORE INSERT OR UPDATE OF content`
+trigger, with backfill and `CREATE INDEX CONCURRENTLY` moved to
+`scripts/sql/kb_fts_safe_rollout.py`; the health probe accepts the trigger
+shape and checks `pg_index.indisvalid`. Procedure and the "never rewrite
+`KbChunk`" rule: `docs/OPERATIONS_RUNBOOK.md` §4a.
+
+**Still to do.** Run the rollout script in a night-IST window, then confirm
+`GET /v1/health/retrieval` reports `ok`.
+
 ## Human decisions required (cannot be resolved by an agent)
 
 1. P0-1: keep `deploy-api.yml` as a deploy path (and reconcile it) or demote

--- a/scripts/sql/kb_fts_safe_rollout.py
+++ b/scripts/sql/kb_fts_safe_rollout.py
@@ -13,10 +13,11 @@ WHY THIS SCRIPT EXISTS
   timed out. The statement was terminated. Nothing was changed.
 
 WHAT THIS SCRIPT DOES INSTEAD (each step is short or interruptible)
-  1. Runs the (rewritten) migration.sql: adds a PLAIN nullable tsvector column
-     (catalog-only, milliseconds) and installs the BEFORE INSERT OR UPDATE OF
-     content trigger. On a production-sized table the file itself refuses to
-     backfill or build the index and says so with a NOTICE.
+  1. Bootstraps the schema itself (the same DDL migration.sql carries): a PLAIN
+     nullable tsvector column (catalog-only, milliseconds) and the BEFORE INSERT
+     OR UPDATE OF content trigger. migration.sql is NOT run on a production-sized
+     table — it deliberately RAISES there, so `prisma migrate deploy` can never
+     record the migration as applied before the backfill and index exist.
   2. Backfills `content_tsv` in small committed batches, sleeping between
      batches. Never one long transaction. Ctrl-C between batches is safe.
   3. Builds the GIN index with CREATE INDEX CONCURRENTLY (outside any
@@ -58,6 +59,36 @@ INDEX = "kb_chunk_content_tsv_idx"
 TRIGGER = "kbchunk_content_tsv_trg"
 CONFIG = "simple"
 LOCK_TIMEOUT = "5s"
+
+# Mirrors the column/trigger part of migration.sql. Keep the two in sync: the
+# PGlite test replays migration.sql; production runs this.
+BOOTSTRAP_SQL = f"""
+SET lock_timeout = '{LOCK_TIMEOUT}';
+CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger
+LANGUAGE plpgsql AS $fn$
+BEGIN
+  NEW.{COLUMN} := to_tsvector('{CONFIG}', NEW.content);
+  RETURN NEW;
+END
+$fn$;
+DO $$
+DECLARE col_generated "char";
+BEGIN
+  SELECT a.attgenerated INTO col_generated FROM pg_attribute a
+  WHERE a.attrelid = to_regclass('{TABLE}') AND a.attname = '{COLUMN}' AND NOT a.attisdropped;
+  IF col_generated IS NULL THEN
+    ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS {COLUMN} tsvector;
+    col_generated := '';
+  END IF;
+  IF col_generated = 's' THEN
+    DROP TRIGGER IF EXISTS {TRIGGER} ON {TABLE};
+  ELSE
+    DROP TRIGGER IF EXISTS {TRIGGER} ON {TABLE};
+    CREATE TRIGGER {TRIGGER} BEFORE INSERT OR UPDATE OF content ON {TABLE}
+      FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
+  END IF;
+END$$;
+"""
 
 
 class Db:
@@ -156,19 +187,17 @@ def main() -> int:
         print("\ncontent_tsv is a legacy STORED generated column: Postgres maintains it, nothing to backfill.")
     if not args.execute:
         print("\nDRY RUN. Plan with --execute:")
-        print(f"  1. psql -f {MIGRATION_SQL.relative_to(REPO)}   (lock_timeout {LOCK_TIMEOUT}; column + trigger only on this table size)")
+        print(f"  1. bootstrap column + trigger (same DDL as migration.sql; lock_timeout {LOCK_TIMEOUT})")
         print(f"  2. backfill {before['nulls']} NULL rows in batches of {args.batch_size}, sleeping {args.sleep}s between batches")
         print(f"  3. CREATE INDEX CONCURRENTLY {INDEX} (if absent or INVALID)")
         print("  4. verify: 0 NULL rows, index valid, lexical query returns rows")
         print(f"  5. prisma migrate resolve --applied {MIGRATION}")
         return 0
 
-    # 1. column + trigger (the migration file refuses the heavy steps on a big table)
-    print("\n[1/5] applying migration.sql (column + trigger) ...")
-    out = db.exec_file(MIGRATION_SQL, timeout=120)
-    for line in out.splitlines():
-        if "NOTICE" in line or "ERROR" in line:
-            print("      " + line.strip()[:160])
+    # 1. column + trigger. Same DDL as migration.sql, minus its backfill/index and
+    #    minus its large-table guard: this script IS the large-table path.
+    print("\n[1/5] bootstrapping column + trigger (catalog-only, lock_timeout " + LOCK_TIMEOUT + ") ...")
+    db.exec(BOOTSTRAP_SQL, timeout=120)
     st = state(db)
     if st["column"] == "absent" or (st["column"] == "plain" and st["trigger"] != "enabled"):
         print(f"      unexpected state after migration.sql: {st}", file=sys.stderr)
@@ -251,6 +280,13 @@ def main() -> int:
     print("      " + (r.stdout + r.stderr).strip().splitlines()[-1][:160])
     if r.returncode != 0:
         return 1
+    # Proof that the file is now a no-op on this database (its large-table guard is
+    # satisfied): a future `prisma migrate deploy` re-run cannot break anything.
+    try:
+        db.exec_file(MIGRATION_SQL, timeout=120)
+        print("      migration.sql re-run: no-op OK")
+    except RuntimeError as e:
+        print("      WARNING: migration.sql re-run failed: " + str(e).splitlines()[0][:140], file=sys.stderr)
     print("\nDone. Check GET /v1/health/retrieval → fullTextSearch.status should be 'ok' (the boot probe re-runs on the next deploy or within the re-probe window).")
     return 0
 

--- a/scripts/sql/kb_fts_safe_rollout.py
+++ b/scripts/sql/kb_fts_safe_rollout.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Production rollout of the KbChunk full-text-search column (issue #92 / PR #98)
+WITHOUT a table rewrite.
+
+WHY THIS SCRIPT EXISTS
+  On 2026-09-12 the first version of migration 20260908000000_restore_kb_chunk_fts
+  re-added `content_tsv` as a STORED generated column. Postgres implements that as
+  a full rewrite of "KbChunk" under an ACCESS EXCLUSIVE lock, and the rewrite
+  rebuilds every index on the table — including the pgvector HNSW index. On
+  suchi-db that ran for 15+ minutes; every retrieval query queued behind the
+  lock, the connection pool filled, /v1/health stopped answering and chat turns
+  timed out. The statement was terminated. Nothing was changed.
+
+WHAT THIS SCRIPT DOES INSTEAD (each step is short or interruptible)
+  1. Runs the (rewritten) migration.sql: adds a PLAIN nullable tsvector column
+     (catalog-only, milliseconds) and installs the BEFORE INSERT OR UPDATE OF
+     content trigger. On a production-sized table the file itself refuses to
+     backfill or build the index and says so with a NOTICE.
+  2. Backfills `content_tsv` in small committed batches, sleeping between
+     batches. Never one long transaction. Ctrl-C between batches is safe.
+  3. Builds the GIN index with CREATE INDEX CONCURRENTLY (outside any
+     transaction; does not block reads or writes).
+  4. Verifies: zero NULL rows, index present AND valid (pg_index.indisvalid),
+     the shipped lexical query returns rows.
+  5. Marks the migration applied in Prisma's history
+     (`prisma migrate resolve --applied ...`) — only after 1–4 succeeded.
+
+USAGE (from the repo root, with the Cloud SQL proxy running on 127.0.0.1:5433;
+see docs/OPERATIONS_RUNBOOK.md §1 and §4a):
+
+    export DATABASE_URL="$(gcloud secrets versions access latest --secret=database-url)"
+    python3 scripts/sql/kb_fts_safe_rollout.py                 # dry run: prints state + plan
+    python3 scripts/sql/kb_fts_safe_rollout.py --execute       # do it
+    python3 scripts/sql/kb_fts_safe_rollout.py --execute --batch-size 1000 --sleep 0.5
+
+  Run it in a low-traffic window (night IST). Watch DB CPU and connection count
+  while the backfill runs; it prints progress per batch. The password is never
+  printed. Re-running is safe: every step is idempotent and skips finished work.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+import urllib.parse as urlparse
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+API_DIR = REPO / "apps" / "api"
+MIGRATION = "20260908000000_restore_kb_chunk_fts"
+MIGRATION_SQL = API_DIR / "prisma" / "migrations" / MIGRATION / "migration.sql"
+TABLE = '"KbChunk"'
+COLUMN = "content_tsv"
+INDEX = "kb_chunk_content_tsv_idx"
+TRIGGER = "kbchunk_content_tsv_trg"
+CONFIG = "simple"
+LOCK_TIMEOUT = "5s"
+
+
+class Db:
+    def __init__(self, url: str, host: str, port: int) -> None:
+        p = urlparse.urlparse(url)
+        self.user = urlparse.unquote(p.username or "")
+        self.password = urlparse.unquote(p.password or "")
+        self.dbname = p.path.lstrip("/")
+        self.host, self.port = host, port
+
+    def _base(self) -> list[str]:
+        return ["psql", "-h", self.host, "-p", str(self.port), "-U", self.user, "-d", self.dbname, "-v", "ON_ERROR_STOP=1", "-X", "-q"]
+
+    def _env(self) -> dict[str, str]:
+        return {**os.environ, "PGPASSWORD": self.password}
+
+    def scalar(self, sql: str) -> str:
+        r = subprocess.run(self._base() + ["-At", "-c", sql], env=self._env(), capture_output=True, text=True, timeout=120)
+        if r.returncode != 0:
+            raise RuntimeError(r.stderr.strip())
+        return r.stdout.strip()
+
+    def exec(self, sql: str, timeout: int = 600) -> str:
+        r = subprocess.run(self._base() + ["-c", sql], env=self._env(), capture_output=True, text=True, timeout=timeout)
+        if r.returncode != 0:
+            raise RuntimeError(r.stderr.strip())
+        return (r.stdout + r.stderr).strip()
+
+    def exec_file(self, path: Path, timeout: int = 600) -> str:
+        r = subprocess.run(self._base() + ["-f", str(path)], env=self._env(), capture_output=True, text=True, timeout=timeout)
+        if r.returncode != 0:
+            raise RuntimeError(r.stderr.strip())
+        return (r.stdout + r.stderr).strip()
+
+    def prisma_url(self) -> str:
+        return f"postgresql://{urlparse.quote(self.user)}:{urlparse.quote(self.password)}@{self.host}:{self.port}/{self.dbname}"
+
+
+def state(db: Db) -> dict[str, str]:
+    q = {
+        "rows": f"SELECT count(*) FROM {TABLE};",
+        "column": (
+            "SELECT coalesce((SELECT CASE WHEN attgenerated = 's' THEN 'generated' ELSE 'plain' END FROM pg_attribute "
+            f"WHERE attrelid = to_regclass('{TABLE}') AND attname = '{COLUMN}' AND NOT attisdropped), 'absent');"
+        ),
+        "trigger": (
+            f"SELECT coalesce((SELECT CASE WHEN tgenabled <> 'D' THEN 'enabled' ELSE 'disabled' END FROM pg_trigger "
+            f"WHERE tgrelid = to_regclass('{TABLE}') AND tgname = '{TRIGGER}'), 'absent');"
+        ),
+        "nulls": f"SELECT count(*) FROM {TABLE} WHERE {COLUMN} IS NULL;",
+        "index": (
+            "SELECT coalesce((SELECT CASE WHEN i.indisvalid AND i.indisready THEN 'valid' ELSE 'INVALID' END "
+            f"FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = '{INDEX}'), 'absent');"
+        ),
+        "prisma": f"SELECT coalesce((SELECT 'applied' FROM _prisma_migrations WHERE migration_name = '{MIGRATION}' AND finished_at IS NOT NULL AND rolled_back_at IS NULL LIMIT 1), 'not recorded');",
+        "waiting_on_locks": "SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND datname = current_database();",
+    }
+    out: dict[str, str] = {}
+    for k, sql in q.items():
+        try:
+            out[k] = db.scalar(sql)
+        except RuntimeError as e:
+            out[k] = f"? ({e.splitlines()[0][:80]})"
+    return out
+
+
+def show(title: str, st: dict[str, str]) -> None:
+    print(f"\n== {title} ==")
+    for k, v in st.items():
+        print(f"  {k:17} {v}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--execute", action="store_true", help="actually change the database (default: dry run)")
+    ap.add_argument("--batch-size", type=int, default=1500, help="rows per committed backfill batch (default 1500)")
+    ap.add_argument("--sleep", type=float, default=0.5, help="seconds to sleep between batches (default 0.5)")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=5433, help="Cloud SQL proxy port (default 5433)")
+    ap.add_argument("--skip-resolve", action="store_true", help="do everything except `prisma migrate resolve`")
+    args = ap.parse_args()
+
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is not set (export it from Secret Manager; never paste it into a file).", file=sys.stderr)
+        return 2
+    if not MIGRATION_SQL.exists():
+        print(f"missing {MIGRATION_SQL}", file=sys.stderr)
+        return 2
+
+    db = Db(url, args.host, args.port)
+    before = state(db)
+    show("current state", before)
+
+    if before["column"] == "generated":
+        print("\ncontent_tsv is a legacy STORED generated column: Postgres maintains it, nothing to backfill.")
+    if not args.execute:
+        print("\nDRY RUN. Plan with --execute:")
+        print(f"  1. psql -f {MIGRATION_SQL.relative_to(REPO)}   (lock_timeout {LOCK_TIMEOUT}; column + trigger only on this table size)")
+        print(f"  2. backfill {before['nulls']} NULL rows in batches of {args.batch_size}, sleeping {args.sleep}s between batches")
+        print(f"  3. CREATE INDEX CONCURRENTLY {INDEX} (if absent or INVALID)")
+        print("  4. verify: 0 NULL rows, index valid, lexical query returns rows")
+        print(f"  5. prisma migrate resolve --applied {MIGRATION}")
+        return 0
+
+    # 1. column + trigger (the migration file refuses the heavy steps on a big table)
+    print("\n[1/5] applying migration.sql (column + trigger) ...")
+    out = db.exec_file(MIGRATION_SQL, timeout=120)
+    for line in out.splitlines():
+        if "NOTICE" in line or "ERROR" in line:
+            print("      " + line.strip()[:160])
+    st = state(db)
+    if st["column"] == "absent" or (st["column"] == "plain" and st["trigger"] != "enabled"):
+        print(f"      unexpected state after migration.sql: {st}", file=sys.stderr)
+        return 1
+    print(f"      column={st['column']} trigger={st['trigger']}")
+
+    # 2. batched backfill (skip for a generated column — Postgres already did it)
+    if st["column"] == "plain":
+        remaining = int(st["nulls"])
+        print(f"\n[2/5] backfilling {remaining} rows, {args.batch_size} per batch ...")
+        batch = 0
+        t0 = time.time()
+        while remaining > 0:
+            batch += 1
+            db.exec(
+                f"SET lock_timeout = '{LOCK_TIMEOUT}'; "
+                f"UPDATE {TABLE} SET {COLUMN} = to_tsvector('{CONFIG}', content) "
+                f"WHERE id IN (SELECT id FROM {TABLE} WHERE {COLUMN} IS NULL LIMIT {args.batch_size});",
+                timeout=300,
+            )
+            remaining = int(db.scalar(f"SELECT count(*) FROM {TABLE} WHERE {COLUMN} IS NULL;"))
+            waiting = db.scalar("SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND datname = current_database();")
+            print(f"      batch {batch:3d}  remaining {remaining:6d}  lock-waiters {waiting}  {time.time()-t0:6.1f}s", flush=True)
+            if int(waiting) > 0:
+                print("      lock waiters present — pausing 5s before the next batch", flush=True)
+                time.sleep(5)
+            elif remaining > 0:
+                time.sleep(args.sleep)
+    else:
+        print("\n[2/5] generated column — backfill not needed")
+
+    # 3. concurrent index (never inside a transaction; psql -c autocommits)
+    st = state(db)
+    if st["index"] == "INVALID":
+        print(f"\n[3/5] dropping INVALID {INDEX} left by an interrupted build ...")
+        db.exec(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX};", timeout=600)
+        st["index"] = "absent"
+    if st["index"] == "absent":
+        print(f"\n[3/5] CREATE INDEX CONCURRENTLY {INDEX} ... (does not block reads/writes; may take a few minutes)")
+        t0 = time.time()
+        db.exec(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX} ON {TABLE} USING GIN ({COLUMN});", timeout=3600)
+        print(f"      built in {time.time()-t0:.1f}s")
+    else:
+        print(f"\n[3/5] index already {st['index']}")
+
+    # 4. verify
+    print("\n[4/5] verifying ...")
+    st = state(db)
+    hits = db.scalar(
+        f"SELECT count(*) FROM {TABLE} c, websearch_to_tsquery('{CONFIG}', 'cancer treatment') q WHERE c.{COLUMN} @@ q;"
+    )
+    show("after", {**st, "lexical hits 'cancer treatment'": hits})
+    problems = []
+    if st["column"] == "plain" and int(st["nulls"]) != 0:
+        problems.append(f"{st['nulls']} rows still NULL")
+    if st["index"] != "valid":
+        problems.append(f"index is {st['index']}")
+    if int(hits) == 0:
+        problems.append("lexical query returned 0 rows")
+    if problems:
+        print("\nNOT resolving the migration — problems: " + "; ".join(problems), file=sys.stderr)
+        return 1
+
+    # 5. prisma history
+    if args.skip_resolve:
+        print("\n[5/5] skipped (--skip-resolve)")
+        return 0
+    if st["prisma"] == "applied":
+        print("\n[5/5] already recorded in _prisma_migrations")
+        return 0
+    print(f"\n[5/5] prisma migrate resolve --applied {MIGRATION} ...")
+    r = subprocess.run(
+        ["npx", "prisma", "migrate", "resolve", "--applied", MIGRATION],
+        cwd=API_DIR,
+        env={**os.environ, "DATABASE_URL": db.prisma_url()},
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    print("      " + (r.stdout + r.stderr).strip().splitlines()[-1][:160])
+    if r.returncode != 0:
+        return 1
+    print("\nDone. Check GET /v1/health/retrieval → fullTextSearch.status should be 'ok' (the boot probe re-runs on the next deploy or within the re-probe window).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #92, #98. Follow-up to the **2026-09-12 incident** (recorded in `docs/RELIABILITY_BACKLOG.md`): applying the first version of `20260908000000_restore_kb_chunk_fts` re-added `content_tsv` as a `GENERATED ALWAYS … STORED` column. Postgres rewrote the whole `KbChunk` table under an ACCESS EXCLUSIVE lock and rebuilt every index including the pgvector HNSW one; on `db-f1-micro` it ran 15+ minutes, queued all retrieval, exhausted the pool and took `/v1/health` down until the backend was terminated. Nothing was applied. **No persistent database has recorded this migration** (checked: suchi-db is the only Postgres for this product; its `_prisma_migrations` ends at `20260622`), so the migration is rewritten in place under the same name rather than followed by a forward migration.

## The rollout sequence (per review)

| step | where | what |
|---|---|---|
| 1 | `migration.sql` | `SET lock_timeout='5s'`; add `content_tsv` as a **plain, nullable** tsvector, no default — catalog-only |
| 2 | `migration.sql` | **trigger first**: `BEFORE INSERT OR UPDATE OF content` → `NEW.content_tsv := to_tsvector('simple', NEW.content)` |
| 3 | `scripts/sql/kb_fts_safe_rollout.py` | backfill in **committed batches** (default 1 500, sleep between, pauses when lock waiters appear); never one transaction |
| 4 | script | **after** the backfill: `CREATE INDEX CONCURRENTLY` (drops an INVALID leftover first; outside any transaction) |
| 5 | script | verify `COUNT(*) WHERE content_tsv IS NULL = 0`, `pg_index.indisvalid AND indisready`, live lexical hits > 0 |
| 6 | script | only then `prisma migrate resolve --applied 20260908000000_restore_kb_chunk_fts` |

On a table with ≤ 5 000 rows (dev, CI, the PGlite test) the migration itself does the backfill and a plain index build; on a production-sized table it stops with a `NOTICE` pointing at the script. A legacy STORED generated column (a DB that never ran `20260606`) is left untouched — Postgres maintains it.

## Probe strengthened (`kb-fts.sql.ts`, `KbFtsHealthService`)

Reports **how** the column is maintained — generation expression *or* the enabled trigger and its function body (which carries the `'simple'` config) — and whether the GIN index is **valid**, not merely present (`pg_index.indisvalid AND indisready`; an interrupted concurrent build leaves an invalid index that the planner ignores).

| state | verdict |
|---|---|
| column absent | unavailable |
| plain column, no enabled trigger (what `prisma migrate diff` emits) | unavailable |
| trigger or generated, wrong config | degraded |
| index missing | degraded |
| index present but INVALID | degraded (new) |
| maintained on `'simple'`, index valid | ok |

The runtime check is structural only; the full-table `NULL` count runs in the deployment procedure, not on every `/health`.

## Tests

PGlite (real Postgres, real migrations replayed oldest-first, shipped query): trigger populates on INSERT and on UPDATE OF content · a `db push`-shaped schema is repaired with the trigger and answers queries · unmaintained column → unavailable · **INVALID index → degraded** · the `20260606`-drop and config-mismatch cases unchanged. `kb-fts.spec.ts` 17/17; full API suite **60 suites / 1080 tests**; `tsc` clean; `prisma validate` ok; parity and secret guards ok.

## Runbook

`docs/OPERATIONS_RUNBOOK.md` §4a "Schema changes on `KbChunk` — never a table rewrite": which statements rewrite, the six-step safe pattern, the script invocation, and how to find/terminate a lock holder. Rule 4 under *Deploying* points at it.

## After merge

Run in a night-IST window:
```
export DATABASE_URL="$(gcloud secrets versions access latest --secret=database-url)"
python3 scripts/sql/kb_fts_safe_rollout.py            # dry run
python3 scripts/sql/kb_fts_safe_rollout.py --execute
```
then `GET /v1/health/retrieval` → `fullTextSearch.status: ok`. No code deploy is required for the column to start being used; the running revision already ships the query and the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
