### PR TITLE
fix(rag): cross-lingual pregnancy/baby coverage, medical-noun gate for keyword queries, fetus scenario expansion (#126)

### DIFF
--- a/apps/api/src/modules/rag/cross-lingual.service.spec.ts
+++ b/apps/api/src/modules/rag/cross-lingual.service.spec.ts
@@ -121,6 +121,52 @@ describe("CrossLingualService", () => {
     });
   });
 
+  describe("issue #126 — pregnancy questions and the keyword-query gate", () => {
+    const probeA =
+      "meri mausi ko cancer hai aur wo pregnant hai, kya cancer ki dawai se bachcha affected hoga? exact batao";
+
+    test("translates bachcha → baby and keeps pregnant, so the English KB can match the fetal section", () => {
+      const result = service.generateParallelQueries(probeA);
+      const translated = result.parallelQueries[1];
+      expect(translated).toMatch(/\bbaby\b/);
+      expect(translated).toMatch(/\bpregnant\b/);
+      expect(translated).toMatch(/\bmedicine\b/);
+    });
+
+    test("adds the pregnancy/fetus scenario query", () => {
+      const result = service.generateParallelQueries(probeA);
+      expect(result.parallelQueries).toContain("cancer treatment during pregnancy effects on the unborn baby fetus");
+    });
+
+    test("never emits a keyword query made only of function words (the old 'tell me medicine')", () => {
+      const result = service.generateParallelQueries(probeA);
+      expect(result.parallelQueries).not.toContain("tell me medicine");
+      for (const q of result.parallelQueries.slice(1)) {
+        expect(q).toMatch(/cancer|pregnan|baby|medicine|treatment/i);
+      }
+    });
+
+    test("a genuine breastfeeding question does NOT get the fetus expansion", () => {
+      const result = service.generateParallelQueries("kya chemotherapy ke dauraan breastfeeding karna safe hai bachche ke liye?");
+      expect(result.parallelQueries).not.toContain("cancer treatment during pregnancy effects on the unborn baby fetus");
+    });
+
+    test("Devanagari pregnancy question translates the same way", () => {
+      const result = service.generateParallelQueries("मेरी बहन गर्भवती है, कीमो से बच्चे को नुकसान होगा?");
+      const translated = result.parallelQueries[1];
+      expect(translated).toMatch(/pregnant/);
+      expect(translated).toMatch(/baby/);
+      expect(translated).toMatch(/chemotherapy/);
+      expect(translated).toMatch(/harm/);
+      expect(result.parallelQueries).toContain("cancer treatment during pregnancy effects on the unborn baby fetus");
+    });
+
+    test("keyword query still forms when there are two or more medical terms", () => {
+      const result = service.generateParallelQueries("स्तन कैंसर का इलाज कैसे होता है");
+      expect(result.parallelQueries.some((q) => /^breast cancer treatment$/.test(q) || /breast cancer/.test(q))).toBe(true);
+    });
+  });
+
   describe("Edge cases", () => {
     test("empty string", () => {
       const result = service.generateParallelQueries("");

--- a/apps/api/src/modules/rag/cross-lingual.service.ts
+++ b/apps/api/src/modules/rag/cross-lingual.service.ts
@@ -44,6 +44,15 @@ const HI_EN_DICTIONARY: Array<[RegExp, string]> = [
   [/ब्रेन\s*(ट्यूमर|कैंसर)/g, "brain cancer"],
   [/कैंसर/g, "cancer"],
 
+  // Pregnancy & family context (issue #126: a pregnancy question retrieved
+  // breast-milk content because none of these words reached the English KB)
+  [/गर्भवती/g, "pregnant"],
+  [/गर्भावस्था/g, "pregnancy"],
+  [/गर्भ\s*में/g, "in the womb"],
+  [/स्तनपान/g, "breastfeeding"],
+  [/बच्चे|बच्चा|शिशु/g, "baby"],
+  [/नुकसान/g, "harm"],
+
   // Symptoms
   [/लक्षण/g, "symptoms"],
   [/गांठ/g, "lump"],
@@ -117,6 +126,13 @@ const HINGLISH_EN_DICTIONARY: Array<[RegExp, string]> = [
   [/\bkhoon\s*(ka|ke|ki)?\s*cancer\b/gi, "blood cancer"],
   [/\bphephde?\s*(ka|ke|ki)?\s*cancer\b/gi, "lung cancer"],
 
+  // Pregnancy & family context (issue #126)
+  [/\b(pregnant|pregnent|garbhw?a?vati|garbhwati)\b/gi, "pregnant"],
+  [/\bpet\s*se\s*hai\b/gi, "is pregnant"],
+  [/\b(bachch?a|bacch?a|bachch?e|bacch?e|bachch?on|shishu)\b/gi, "baby"],
+  [/\bnuk?saan\b/gi, "harm"],
+  [/\bbreast\s*feeding\b/gi, "breastfeeding"],
+
   // Medical terms
   [/\bilaaj\b/gi, "treatment"],
   [/\bdawai?\b/gi, "medicine"],
@@ -140,6 +156,27 @@ const HINGLISH_EN_DICTIONARY: Array<[RegExp, string]> = [
   [/\bjanch\b/gi, "test"],
   [/\bsurjari\b/gi, "surgery"],
   [/\bchahiye\b/gi, "needed"],
+];
+
+// ─── Keyword-query gate and scenario expansions ──────────────────
+
+/**
+ * A translated term counts towards the English keyword query only if it is a
+ * medical noun (or phrase containing one). Function words that the dictionaries
+ * also translate — "tell me", "what", "how", "needed", "I need", "information",
+ * "about", "help" — must never form a query on their own.
+ */
+const MEDICAL_TERM =
+  /\b(cancer|tumou?r|symptoms?|lump|pain|bleeding|blood|fever|fatigue|vomiting|diarrhea|swelling|cough|breath(ing)?|weight loss|appetite|treatment|chemotherapy|radiation|surgery|medicine|biopsy|test|report|hospital|doctor|OPD|appointment|scheme|insurance|Ayushman|pregnan(t|cy)|womb|baby|breastfeeding|harm)\b/i;
+
+/** Extra English queries for situations everyday Hindi/Hinglish words under-specify. */
+const SCENARIO_EXPANSIONS: Array<{ when: RegExp[]; unless: RegExp[]; add: string }> = [
+  {
+    // Pregnant + baby/child + cancer/treatment/medicine → the fetus, not a nursing infant.
+    when: [/\bpregnan(t|cy)\b|\bin the womb\b/i, /\b(baby|child|fetus)\b/i, /\b(cancer|treatment|chemotherapy|medicine|radiation|surgery)\b/i],
+    unless: [/\b(breastfeed(ing)?|nursing|breast milk|lactation)\b/i],
+    add: "cancer treatment during pregnancy effects on the unborn baby fetus",
+  },
 ];
 
 // ─── Service ─────────────────────────────────────────────────────
@@ -202,11 +239,30 @@ export class CrossLingualService {
       parallelQueries.push(translated);
     }
 
-    // Also add a purely-English medical equivalent if we have enough terms
-    if (translatedTerms.length >= 2) {
-      const medicalQuery = translatedTerms.join(" ");
-      if (medicalQuery !== translated) {
+    // Also add a purely-English medical equivalent — but only from MEDICAL terms.
+    // Before this gate the keyword query for "…dawai se bachcha affected hoga?
+    // exact batao" was literally "tell me medicine" (issue #126): two translated
+    // function words with no medical noun, which retrieves noise.
+    const medicalTerms = translatedTerms.filter((t) => MEDICAL_TERM.test(t));
+    if (medicalTerms.length >= 2) {
+      const medicalQuery = medicalTerms.join(" ");
+      if (medicalQuery !== translated && !parallelQueries.includes(medicalQuery)) {
         parallelQueries.push(medicalQuery);
+      }
+    }
+
+    // Scenario expansions: a Hinglish/Hindi question can describe a clinical
+    // situation with everyday words the English KB never uses ("bachcha" for an
+    // unborn baby). Add one explicit English scenario query so the right section
+    // ranks (issue #126: the pregnancy question matched the *nursing* baby text).
+    for (const expansion of SCENARIO_EXPANSIONS) {
+      if (
+        expansion.when.every((re) => re.test(translated)) &&
+        !expansion.unless.some((re) => re.test(translated)) &&
+        !parallelQueries.includes(expansion.add)
+      ) {
+        parallelQueries.push(expansion.add);
+        translatedTerms.push(expansion.add);
       }
     }
 


### PR DESCRIPTION
Refs #126 — fix 3 of the diagnosis (after #131's reference-chunk filter and #130's FTS restore).

## Why

For probe A (`meri mausi ko cancer hai aur wo pregnant hai, kya cancer ki dawai se bachcha affected hoga? exact batao`) `CrossLingualService.generateParallelQueries` produced:

1. the original;
2. `…cancer ki **medicine** se bachcha affected hoga? exact **tell me**` — only *dawai* and *batao* translated; *pregnant* and *bachcha* untouched;
3. a "topic" query that was literally **`tell me medicine`** — two translated function words, no medical noun.

Nothing told the English KB the question was about an **unborn** baby, so the *nursing baby / breast milk* paragraph matched.

## Changes (code only — no prompts, KB text or safety lists)

| | |
|---|---|
| **Dictionaries** | Devanagari `गर्भवती` `गर्भावस्था` `गर्भ में` `स्तनपान` `बच्चा/बच्चे/शिशु` `नुकसान`; Hinglish `pregnant/garbhvati`, `pet se hai`, `bachcha/baccha/bachche/shishu`, `nuksaan`, `breast feeding` → *pregnant · pregnancy · in the womb · breastfeeding · baby · harm* |
| **Keyword-query gate** | the joined-terms query is built only from translated terms containing a medical noun (`MEDICAL_TERM`), and needs ≥ 2 of them. Function words the dictionaries also translate (*tell me, what, how, needed, I need, information, about, help*) can no longer form a query by themselves |
| **Scenario expansion** | *pregnant/pregnancy/in the womb* **+** *baby/child/fetus* **+** *cancer/treatment/medicine/…*, and **not** *breastfeeding/nursing/breast milk/lactation* → adds `cancer treatment during pregnancy effects on the unborn baby fetus`. The breastfeeding control gets nothing |

`ChatService` already uses `parallelQueries[1]` as the primary retrieval query, so the better translation reaches the embedding directly; the scenario query joins the multi-query set.

## Tests

`cross-lingual.service.spec.ts` 22/22: probe A → translation has *baby*, *pregnant*, *medicine*; scenario query present; no `tell me medicine` and every non-original query carries a medical term · breastfeeding control gets no fetus expansion · the Devanagari equivalent (`मेरी बहन गर्भवती है, कीमो से बच्चे को नुकसान होगा?`) translates to *pregnant/baby/chemotherapy/harm* + scenario · existing behaviour (`स्तन कैंसर का इलाज …` still yields a keyword query) preserved. RAG + chat suites green; `tsc` clean.

## After deploy

Replay probe A on web and WhatsApp: expect the pregnancy chunk `::18` first and the lactation chunk `::35` out of (or at the bottom of) the top-6, and the answer free of breast-milk content unless breastfeeding is asked; probe D unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
