### PR TITLE
fix(rag,db): full-text search as a GIN expression index — no tsvector column, no backfill (#92 redesign, replaces #130's column design)

### DIFF
--- a/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
+++ b/apps/api/prisma/migrations/20260908000000_restore_kb_chunk_fts/migration.sql
@@ -1,4 +1,4 @@
--- Restore full-text search on KbChunk (issue #92) — NON-BLOCKING implementation.
+-- Restore full-text search on KbChunk (issue #92) — EXPRESSION INDEX, no column.
 --
 -- HISTORY
 --   20260120163141_add_fts_to_kbchunk  added `content_tsv` as a STORED generated
@@ -17,114 +17,68 @@
 --                                      since, costing long queries 45% and short queries
 --                                      20% of their retrieval scoring weight.
 --
--- INCIDENT 2026-09-12 (why this file is NOT a GENERATED column any more)
---   The first version of this migration re-added `content_tsv` as
---   `GENERATED ALWAYS AS (...) STORED`. On Postgres that is a full table rewrite
---   under an ACCESS EXCLUSIVE lock, and the rewrite rebuilds EVERY index on the
---   table — including the pgvector HNSW index on `embedding`. On production
---   (suchi-db, db-f1-micro, ~74k rows of 1.4 KB text + 768-d vectors) it ran
---   for 15+ minutes; all retrieval queries queued behind the lock, the
---   connection pool filled, /v1/health stopped answering and chat turns timed
---   out. The statement was terminated; nothing was changed. Never run a
---   rewriting ALTER on "KbChunk" again.
+-- TWO ABANDONED DESIGNS (2026-09-12)
+--   1. STORED generated column: Postgres rewrites the whole table under an ACCESS
+--      EXCLUSIVE lock and rebuilds every index incl. the pgvector HNSW one. On
+--      suchi-db (db-f1-micro, ~49k rows of 1.4 KB text + 768-d vectors) it ran
+--      15+ minutes with all retrieval queued behind it. Terminated; nothing kept.
+--   2. Plain column + trigger + batched backfill: non-blocking, but every updated
+--      row is too large for a HOT update, so it re-enters all four indexes incl.
+--      the HNSW one — measured 190 ms/row = ~2.5 h of writes. Stopped at 12k rows;
+--      column, trigger and function were dropped again (catalog-only).
 --
--- WHAT THIS FILE DOES INSTEAD
---   1. Adds `content_tsv` as a PLAIN, nullable tsvector with no default — a
---      catalog-only change, no rewrite, milliseconds.
---   2. Installs a BEFORE INSERT OR UPDATE OF content trigger that keeps the
---      column current, so rows written while the backfill runs are covered.
---   3. Backfills and builds the GIN index ONLY on small tables (<= 5000 rows:
---      dev databases, CI, the PGlite regression test) — i.e. the migration either
---      COMPLETES or FAILS. On a production-sized table it RAISES an exception
---      and, because the whole file is one DO block, nothing at all is committed
---      (Prisma 5 does not wrap migration.sql in a transaction; separate
---      statements would not roll back together), so `prisma migrate deploy` cannot record it as
---      applied while the column is still unpopulated and unindexed. The
---      production procedure is `scripts/sql/kb_fts_safe_rollout.py`
---      (docs/OPERATIONS_RUNBOOK.md §4a): it bootstraps the same column + trigger
---      itself, backfills in committed batches, builds the index CONCURRENTLY
---      (which cannot run inside a transaction), verifies, and only then runs
---      `prisma migrate resolve --applied 20260908000000_restore_kb_chunk_fts`.
---      Re-running this file after the script has finished is a harmless no-op.
+-- THIS DESIGN
+--   Index the expression instead:  GIN (to_tsvector('simple', content)).
+--   No column, no trigger, no backfill, no per-row writes, no shadow state to
+--   drift, nothing Prisma has to represent (it cannot; see ownership note in
+--   src/modules/rag/kb-fts.sql.ts). The query uses the identical expression so
+--   the planner uses the index; without the index the query still returns
+--   correct rows via a sequential scan.
 --
---   A database that still carries the legacy GENERATED column (never ran
---   20260606) is left exactly as it is: Postgres maintains that shape itself and
---   the boot probe (KbFtsHealthService) accepts either shape.
---
--- Safe to re-run. Every statement is conditional or IF NOT EXISTS.
+-- SIZE GUARD
+--   A plain CREATE INDEX takes a SHARE lock (blocks writes) and scans the table.
+--   Fine for <= 5000 rows (dev, CI, the PGlite test). On a production-sized table
+--   this file RAISES unless the index already exists and is valid — production
+--   builds it with CREATE INDEX CONCURRENTLY via scripts/sql/kb_fts_safe_rollout.py,
+--   which then marks this migration applied. Everything is one DO block: on Prisma
+--   5 (no implicit transaction) that is what makes a raise commit nothing at all.
+--   Safe to re-run: every statement is conditional.
 
 SET lock_timeout = '5s';
 
--- Everything is ONE DO block on purpose. Prisma 5 does not wrap a PostgreSQL
--- migration.sql in a transaction, so with separate statements a raise in the guard
--- below would still leave any earlier statement committed. Inside a single DO block
--- an exception rolls back the whole block: no function, no column, no trigger.
 DO $do$
 DECLARE
-  col_generated "char";   -- attgenerated: 's' = STORED generated, '' = plain, NULL = column absent
-  row_count     bigint;
+  row_count bigint;
+  idx_ok    boolean;
 BEGIN
-  -- Trigger function: same expression, same 'simple' config, as the query in
-  -- src/modules/rag/kb-fts.sql.ts (websearch_to_tsquery('simple', ...)).
-  CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger
-  LANGUAGE plpgsql AS $fn$
-  BEGIN
-    NEW.content_tsv := to_tsvector('simple', NEW.content);
-    RETURN NEW;
-  END
-  $fn$;
-
-  SELECT a.attgenerated
-    INTO col_generated
-  FROM pg_attribute a
-  WHERE a.attrelid = to_regclass('"KbChunk"')
-    AND a.attname = 'content_tsv'
-    AND NOT a.attisdropped;
-
-  IF col_generated IS NULL THEN
-    -- Plain, nullable, no default: metadata-only, no table rewrite.
-    ALTER TABLE "KbChunk" ADD COLUMN IF NOT EXISTS content_tsv tsvector;
-    col_generated := '';
+  -- Any leftover from the two abandoned designs: catalog-only drops, no rewrite.
+  DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";
+  DROP FUNCTION IF EXISTS kbchunk_content_tsv_maintain();
+  IF EXISTS (SELECT 1 FROM pg_attribute
+             WHERE attrelid = to_regclass('"KbChunk"') AND attname = 'content_tsv' AND NOT attisdropped) THEN
+    -- The old index (if any) is over the column; it goes with it.
+    DROP INDEX IF EXISTS kb_chunk_content_tsv_idx;
+    ALTER TABLE "KbChunk" DROP COLUMN content_tsv;
   END IF;
 
   SELECT count(*) INTO row_count FROM "KbChunk";
 
-  -- Safety invariant (review on the #92 follow-up): this file must never leave a
-  -- half-done state that Prisma then records as "applied". A production-sized table
-  -- is refused here unless the rollout script has already completed the work
-  -- (column populated + valid GIN index), in which case everything below is a no-op.
-  IF row_count > 5000 AND col_generated <> 's' THEN
-    IF EXISTS (SELECT 1 FROM "KbChunk" WHERE content_tsv IS NULL)
-       OR NOT EXISTS (SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
-                      WHERE c.relname = 'kb_chunk_content_tsv_idx' AND i.indisvalid AND i.indisready) THEN
-      RAISE EXCEPTION USING
-        MESSAGE = format('KbChunk has %s rows: refusing to backfill/index inside a migration (that is a table rewrite — see the 2026-09-12 outage). Run scripts/sql/kb_fts_safe_rollout.py --execute, which bootstraps column + trigger, backfills in batches, builds the GIN index CONCURRENTLY and then marks this migration applied.', row_count),
-        HINT = 'docs/OPERATIONS_RUNBOOK.md §4a';
-    END IF;
-  END IF;
+  SELECT COALESCE(bool_and(i.indisvalid AND i.indisready), false)
+    INTO idx_ok
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE c.relname = 'kb_chunk_content_tsv_idx'
+    AND pg_get_indexdef(i.indexrelid) LIKE '%to_tsvector(''simple''::regconfig, content)%';
 
-  IF col_generated = 's' THEN
-    RAISE NOTICE 'KbChunk.content_tsv is a legacy STORED generated column — leaving it (Postgres maintains it); no trigger installed.';
-    DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";
+  IF idx_ok THEN
+    RAISE NOTICE 'kb_chunk_content_tsv_idx already present and valid — nothing to do.';
+  ELSIF row_count <= 5000 THEN
+    -- Small table: a plain build takes milliseconds. Replace an invalid/mismatched one.
+    DROP INDEX IF EXISTS kb_chunk_content_tsv_idx;
+    CREATE INDEX kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (to_tsvector('simple', content));
   ELSE
-    -- Trigger BEFORE the backfill, so nothing written during the backfill is missed.
-    DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";
-    CREATE TRIGGER kbchunk_content_tsv_trg
-      BEFORE INSERT OR UPDATE OF content ON "KbChunk"
-      FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
-
-    IF row_count <= 5000 THEN
-      UPDATE "KbChunk"
-         SET content_tsv = to_tsvector('simple', content)
-       WHERE content_tsv IS NULL;
-    END IF;
+    RAISE EXCEPTION USING
+      MESSAGE = format('KbChunk has %s rows: refusing to build the FTS index inside a migration (SHARE lock + full scan). Run scripts/sql/kb_fts_safe_rollout.py --execute, which builds kb_chunk_content_tsv_idx CONCURRENTLY, verifies it, and then marks this migration applied.', row_count),
+      HINT = 'docs/OPERATIONS_RUNBOOK.md §4a';
   END IF;
-
-  IF row_count <= 5000 THEN
-    -- Small table: a plain (SHARE-locking) build takes milliseconds.
-    CREATE INDEX IF NOT EXISTS kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (content_tsv);
-  END IF;
-  -- Large table: reaching here means the rollout script already populated the
-  -- column and built a valid index (checked above), so there is nothing to do.
 END
 $do$;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -165,14 +165,15 @@ model KbChunk {
   content    String
   embedding  Unsupported("vector(768)")? // pgvector for semantic search
 
-  /// DO NOT REMOVE. Full-text-search vector, owned by raw migration SQL (20260908000000_restore_kb_chunk_fts):
-  /// a PLAIN tsvector kept current by trigger kbchunk_content_tsv_trg. Deliberately NOT a
-  /// STORED generated column — that rewrites the whole table and every index (incl. the
-  /// pgvector HNSW index) and caused a 15-minute retrieval outage on 2026-09-12.
-  /// Declared here only so a schema diff cannot drop it again; `prisma migrate diff` renders
-  /// it as a bare `content_tsv tsvector`, which the migration then equips with the trigger.
-  /// `KbFtsHealthService` verifies at boot that the live column really is maintained.
-  content_tsv Unsupported("tsvector")?
+  /// Full-text search: there is deliberately NO tsvector column. The lexical arm uses a
+  /// GIN EXPRESSION index kb_chunk_content_tsv_idx over to_tsvector('simple', content),
+  /// created by raw migration SQL (20260908000000_restore_kb_chunk_fts) and, on production,
+  /// by scripts/sql/kb_fts_safe_rollout.py with CREATE INDEX CONCURRENTLY. Prisma cannot
+  /// express expression indexes, so `prisma migrate diff` will propose DROP INDEX for it —
+  /// DO NOT REMOVE it; that is exactly how full-text search died in June 2026 (#92).
+  /// kb-fts.spec.ts pins the migration history. Why no column: a STORED generated column
+  /// rewrites the table (15-min outage, 2026-09-12) and a trigger-maintained column costs
+  /// a write per row through the pgvector HNSW index (190 ms/row measured).
 
   createdAt  DateTime @default(now())
 
@@ -180,9 +181,6 @@ model KbChunk {
 
   @@index([docId])
   @@index([content])
-  /// GIN index over content_tsv. Named to match the raw-SQL index so a diff does not
-  /// try to recreate or drop it.
-  @@index([content_tsv], map: "kb_chunk_content_tsv_idx", type: Gin)
 }
 
 model VoiceInteraction {

--- a/apps/api/src/modules/rag/kb-fts-health.service.ts
+++ b/apps/api/src/modules/rag/kb-fts-health.service.ts
@@ -49,6 +49,16 @@ const LOG_THROTTLE_MS = 60_000;
  * noticed for three months. This service exists so that the distinction is
  * explicit, checked once at boot, counted per query, and reported on /v1/health.
  *
+ * OPERATIONAL GATE (review on the expression-index PR): `RagService` asks
+ * `shouldQuery()` before running the lexical SQL. Only an `ok` verdict runs it.
+ * With no/invalid index the expression query would compute to_tsvector over
+ * every chunk on every hybrid turn — correct rows, but a full-table scan per
+ * turn on a small instance is how an index regression becomes a latency and
+ * pool incident. So `degraded`, `unavailable` AND `unknown` all skip the arm
+ * (vector-only) and schedule a throttled re-probe; the arm resumes by itself
+ * once the probe sees a valid index. `unknown` skipping is deliberate: better
+ * one throttled probe than a blind scan.
+ *
  * Deliberate non-goal: this does NOT abort boot when something is missing.
  * Vector-only retrieval still answers correctly (just with degraded ranking), so
  * refusing to start would turn a ranking regression into a full chat outage for
@@ -72,6 +82,7 @@ export class KbFtsHealthService implements OnModuleInit {
   private lastError: string | null = null;
   private lastSchemaLogAt = 0;
   private lastQueryLogAt = 0;
+  private lastSkipLogAt = 0;
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -165,6 +176,55 @@ export class KbFtsHealthService implements OnModuleInit {
   }
 
   /**
+   * Gate for the lexical arm: run the (expression) query only when the probe's
+   * last verdict is `ok`. Anything else returns false — the caller answers
+   * vector-only — and schedules a throttled re-probe so the arm comes back on
+   * its own once the index is valid again. Logged at warn, throttled.
+   */
+  shouldQuery(): boolean {
+    if (this.status === "ok") return true;
+
+    const now = Date.now();
+    if (now - this.lastSkipLogAt > LOG_THROTTLE_MS) {
+      this.lastSkipLogAt = now;
+      this.logger.warn({
+        event: "kb_fts_arm_skipped",
+        message:
+          `Lexical retrieval arm skipped (verdict: ${this.status}) — answering vector-only rather than ` +
+          `computing to_tsvector over every chunk per turn. ${this.detail}`,
+        status: this.status,
+      });
+    }
+    this.scheduleReprobe();
+    return false;
+  }
+
+  /** Throttled, fire-and-forget re-probe; the probe is the sole authority on the verdict. */
+  private scheduleReprobe(): void {
+    const now = Date.now();
+    if (this.reprobeInFlight || now - this.lastReprobeAt < KbFtsHealthService.REPROBE_THROTTLE_MS) {
+      return;
+    }
+    this.reprobeInFlight = true;
+    this.lastReprobeAt = now;
+    void this.probe()
+      .then((health) => {
+        if (health.status === "ok") {
+          this.logger.log({
+            event: "kb_fts_recovered",
+            message: "Lexical retrieval arm is back — schema re-probe confirms a valid expression index",
+          });
+        }
+      })
+      .catch(() => {
+        // probe() sets and logs its own verdict on failure; nothing to add.
+      })
+      .finally(() => {
+        this.reprobeInFlight = false;
+      });
+  }
+
+  /**
    * A lexical query failed because the schema does not match it. This is the
    * condition that hid for three months — it is logged at error level with a
    * dedicated event and surfaced on the health endpoint, not swallowed.
@@ -202,45 +262,14 @@ export class KbFtsHealthService implements OnModuleInit {
   }
 
   /**
-   * A lexical query completed without throwing.
-   *
-   * Execution success is NOT evidence that the schema is healthy: with an
-   * expression query, "no index" and "indexed" produce the same rows, only at
-   * different speeds. So a success never sets `ok` directly. It only schedules a
-   * re-probe, which inspects the index and is the sole authority on the verdict.
-   * Throttled and never awaited, so the retrieval path is not slowed.
+   * A lexical query completed without throwing. Success is NOT evidence that the
+   * index is healthy (an un-indexed expression query returns the same rows,
+   * slowly), so this never sets `ok` directly — it only lets the probe re-check
+   * when we are carrying a negative or unproven verdict.
    */
   recordQuerySuccess(): void {
-    // Hot path: nothing to reconsider unless we are currently carrying a
-    // negative or unproven verdict.
     if (this.status !== "unavailable" && this.status !== "unknown") return;
-
-    const now = Date.now();
-    if (
-      this.reprobeInFlight ||
-      now - this.lastReprobeAt < KbFtsHealthService.REPROBE_THROTTLE_MS
-    ) {
-      return;
-    }
-
-    this.reprobeInFlight = true;
-    this.lastReprobeAt = now;
-
-    void this.probe()
-      .then((health) => {
-        if (health.status === "ok") {
-          this.logger.log({
-            event: "kb_fts_recovered",
-            message: "Lexical retrieval arm is answering again — schema re-probe confirms it",
-          });
-        }
-      })
-      .catch(() => {
-        // probe() sets and logs its own verdict on failure; nothing to add.
-      })
-      .finally(() => {
-        this.reprobeInFlight = false;
-      });
+    this.scheduleReprobe();
   }
 
   getHealth(): KbFtsHealth {

--- a/apps/api/src/modules/rag/kb-fts-health.service.ts
+++ b/apps/api/src/modules/rag/kb-fts-health.service.ts
@@ -1,25 +1,27 @@
 import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 import {
-  KB_FTS_COLUMN,
   KB_FTS_CONFIG,
   KB_FTS_INDEX,
+  KB_FTS_INDEXDEF_MARKER,
+  KB_FTS_LEGACY_COLUMN,
   KB_FTS_OWNERSHIP_NOTE,
   KB_FTS_PROBE_SQL,
   KB_FTS_TABLE,
-  KB_FTS_TRIGGER,
   KbFtsProbeRow,
 } from "./kb-fts.sql";
 
 /**
  * Health of the lexical (FTS) arm of hybrid retrieval.
  *
- * - `ok`            — column exists, is maintained (by the enabled trigger, or as a legacy STORED
- *                     generated column) on the expected config, GIN index present and valid.
- * - `degraded`      — queryable but not in the expected shape (GIN index missing or invalid → slow
- *                     but correct; config mismatch → far fewer matches).
- * - `unavailable`   — the column/table the query needs is missing, or present but maintained by
- *                     nothing (always NULL). The lexical arm contributes nothing.
+ * The arm queries the EXPRESSION to_tsvector('simple', content), so it keeps
+ * returning correct rows even with no index — only slower. Hence:
+ *
+ * - `ok`            — table present, expression GIN index present, VALID and over the expected expression.
+ * - `degraded`      — correct but slow: index missing, INVALID (interrupted CREATE INDEX
+ *                     CONCURRENTLY) or over a different expression/config (planner will not use it).
+ * - `unavailable`   — the table the query needs is missing, or queries fail with a schema
+ *                     error. The lexical arm contributes nothing.
  * - `unknown`       — the probe could not run (DB unreachable at boot). Not a verdict.
  */
 export type KbFtsStatus = "ok" | "degraded" | "unavailable" | "unknown";
@@ -47,7 +49,7 @@ const LOG_THROTTLE_MS = 60_000;
  * noticed for three months. This service exists so that the distinction is
  * explicit, checked once at boot, counted per query, and reported on /v1/health.
  *
- * Deliberate non-goal: this does NOT abort boot when the column is missing.
+ * Deliberate non-goal: this does NOT abort boot when something is missing.
  * Vector-only retrieval still answers correctly (just with degraded ranking), so
  * refusing to start would turn a ranking regression into a full chat outage for
  * patients. The escalation path is the boot-time ERROR log plus
@@ -96,76 +98,53 @@ export class KbFtsHealthService implements OnModuleInit {
         return this.getHealth();
       }
 
-      if (!row.columnPresent) {
-        this.set(
-          "unavailable",
-          `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" is missing — run migration 20260908000000_restore_kb_chunk_fts`
-        );
-        this.logUnavailable();
-        return this.getHealth();
-      }
+      const legacyNote = row.legacyColumnPresent
+        ? ` A legacy "${KB_FTS_LEGACY_COLUMN}" column is still present and unused — drop it (catalog-only) with migration 20260908000000_restore_kb_chunk_fts.`
+        : "";
 
-      // How is the column kept current? Either Postgres does it (legacy STORED
-      // generated column) or the maintenance trigger does (current shape — a
-      // generated column rewrites the whole table and caused the 2026-09-12 outage).
-      // A plain column with neither is `prisma migrate diff` output: always NULL.
-      const maintainedBy: "generated column" | "trigger" | null = row.columnGenerated
-        ? "generated column"
-        : row.triggerEnabled
-          ? "trigger"
-          : null;
-      if (!maintainedBy) {
-        this.set(
-          "unavailable",
-          `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" exists but nothing maintains it (not GENERATED, and ` +
-            `trigger ${KB_FTS_TRIGGER} is missing or disabled), so it is always NULL and every lexical ` +
-            `query returns zero rows. This is what a schema built by \`prisma migrate diff\`/\`db push\` ` +
-            `produces. Run migration 20260908000000_restore_kb_chunk_fts.`
-        );
-        this.logUnavailable();
-        return this.getHealth();
-      }
-
-      const expr = (row.columnGenerated ? row.generationExpr : row.triggerFunctionDef) ?? "";
-      if (!expr.includes(`'${KB_FTS_CONFIG}'`)) {
+      if (!row.indexDef) {
         this.set(
           "degraded",
-          `"${KB_FTS_COLUMN}" is maintained by ${maintainedBy} with ${expr ? "a definition that does not use" : "an unreadable definition for"} ` +
-            `'${KB_FTS_CONFIG}', but queries use websearch_to_tsquery('${KB_FTS_CONFIG}', …). Mismatched ` +
-            `text-search configs match far fewer rows (and no Hindi/Hinglish at all).`
+          `expression index ${KB_FTS_INDEX} is missing — lexical search still returns correct rows ` +
+            `but computes to_tsvector over every chunk (sequential scan). Build it: ` +
+            `scripts/sql/kb_fts_safe_rollout.py (production) or migration 20260908000000_restore_kb_chunk_fts.` +
+            legacyNote
+        );
+        this.logger.warn({ event: "kb_fts_index_missing", message: this.detail, index: KB_FTS_INDEX });
+        return this.getHealth();
+      }
+
+      if (!row.indexDef.includes(KB_FTS_INDEXDEF_MARKER) || !/USING gin/i.test(row.indexDef)) {
+        this.set(
+          "degraded",
+          `${KB_FTS_INDEX} exists but is not GIN over ${KB_FTS_INDEXDEF_MARKER} (actual: ` +
+            `${row.indexDef.slice(0, 160)}). Queries use websearch_to_tsquery('${KB_FTS_CONFIG}', …) ` +
+            `against that exact expression, so the planner will not use this index and a mismatched ` +
+            `config matches far fewer rows (and no Hindi/Hinglish at all).` +
+            legacyNote
         );
         this.logger.error({
           event: "kb_fts_config_mismatch",
           message: this.detail,
           expectedConfig: KB_FTS_CONFIG,
-          maintainedBy,
-          definition: expr.slice(0, 300),
+          indexDef: row.indexDef.slice(0, 300),
         });
-        return this.getHealth();
-      }
-
-      if (!row.indexPresent) {
-        this.set(
-          "degraded",
-          `GIN index ${KB_FTS_INDEX} is missing — lexical search still returns correct rows but ` +
-            `sequentially scans every chunk.`
-        );
-        this.logger.warn({ event: "kb_fts_index_missing", message: this.detail, index: KB_FTS_INDEX });
         return this.getHealth();
       }
 
       if (!row.indexValid) {
         this.set(
           "degraded",
-          `GIN index ${KB_FTS_INDEX} exists but is INVALID — an interrupted CREATE INDEX CONCURRENTLY ` +
-            `leaves this behind. The planner ignores it (sequential scans). DROP INDEX ${KB_FTS_INDEX} ` +
-            `and rebuild it CONCURRENTLY.`
+          `${KB_FTS_INDEX} exists but is INVALID — an interrupted CREATE INDEX CONCURRENTLY leaves this ` +
+            `behind and the planner ignores it (sequential scans). DROP INDEX CONCURRENTLY ${KB_FTS_INDEX} ` +
+            `and rebuild it CONCURRENTLY (scripts/sql/kb_fts_safe_rollout.py does both).` +
+            legacyNote
         );
         this.logger.error({ event: "kb_fts_index_invalid", message: this.detail, index: KB_FTS_INDEX });
         return this.getHealth();
       }
 
-      this.set("ok", `${KB_FTS_COLUMN} maintained by ${maintainedBy} on '${KB_FTS_CONFIG}', ${KB_FTS_INDEX} present and valid`);
+      this.set("ok", `${KB_FTS_INDEX} present and valid over to_tsvector('${KB_FTS_CONFIG}', content)${legacyNote}`);
       this.logger.log({
         event: "kb_fts_health_ok",
         message: `Lexical retrieval arm ready: ${this.detail}`,
@@ -225,17 +204,11 @@ export class KbFtsHealthService implements OnModuleInit {
   /**
    * A lexical query completed without throwing.
    *
-   * Execution success is NOT evidence that the schema is repaired. A plain,
-   * unmaintained `content_tsv` column — what `prisma migrate diff` emits, and
-   * precisely what the restore migration exists to repair — satisfies this
-   * query, returns zero rows, and throws nothing. Clearing an `unavailable`
-   * verdict on that basis would report a dead lexical arm as healthy, which is
-   * the exact masking this service exists to prevent.
-   *
-   * So a success never sets `ok` directly. It only schedules a re-probe, which
-   * checks how the column is maintained (trigger or generation expression) and
-   * is the sole authority on the verdict. Throttled and never awaited, so the retrieval
-   * path is not slowed.
+   * Execution success is NOT evidence that the schema is healthy: with an
+   * expression query, "no index" and "indexed" produce the same rows, only at
+   * different speeds. So a success never sets `ok` directly. It only schedules a
+   * re-probe, which inspects the index and is the sole authority on the verdict.
+   * Throttled and never awaited, so the retrieval path is not slowed.
    */
   recordQuerySuccess(): void {
     // Hot path: nothing to reconsider unless we are currently carrying a
@@ -299,7 +272,6 @@ export class KbFtsHealthService implements OnModuleInit {
         `LEXICAL RETRIEVAL IS DEAD — hybrid search is running vector-only, which silently ` +
         `discards 45% of the scoring weight on long queries and 20% on short ones. ${this.detail}`,
       table: KB_FTS_TABLE,
-      column: KB_FTS_COLUMN,
       index: KB_FTS_INDEX,
       expectedConfig: KB_FTS_CONFIG,
       schemaFailureCount: this.schemaFailureCount,

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -241,6 +241,7 @@ describe("KB full-text search (issue #92)", () => {
 
   it("RagService.fullTextSearchWithMetadata returns normalized evidence chunks against a real database", async () => {
     const ftsHealth = new KbFtsHealthService(db.asPrisma());
+    await ftsHealth.probe(); // as onModuleInit does at boot — the gate needs an `ok` verdict
     const rag = ragServiceOn(db, ftsHealth);
 
     const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing cervical cancer screening", 6);
@@ -332,42 +333,75 @@ describe("KB full-text search (issue #92)", () => {
       }
     });
 
-    it("a query success does NOT flip a stale 'unavailable' verdict to 'ok' — the re-probe says degraded", async () => {
+    it("REGRESSION: while degraded, RagService does NOT run the lexical SQL — it answers vector-only", async () => {
+      // Review on the expression-index PR: a missing index must not turn every
+      // hybrid turn into a full-table to_tsvector() scan on a small instance.
       jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
       jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
       try {
-        const health = new KbFtsHealthService(noIndex.asPrisma());
-        (health as any).set("unavailable", "forced stale verdict for test");
+        const prisma = noIndex.asPrisma();
+        const health = new KbFtsHealthService(prisma);
+        await health.probe();
+        expect(health.getHealth().status).toBe("degraded");
+
+        const rawSpy = jest.spyOn(prisma, "$queryRawUnsafe");
         const rag = ragServiceOn(noIndex, health);
         const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
-        expect(chunks.length).toBeGreaterThan(0);
 
-        const deadline = Date.now() + 3000;
-        while (health.getHealth().status === "unavailable" && Date.now() < deadline) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-        }
+        expect(chunks).toEqual([]);
+        const lexicalCalls = rawSpy.mock.calls.filter((c) => String(c[0]).includes("websearch_to_tsquery"));
+        expect(lexicalCalls).toHaveLength(0);
+        // The gate schedules a re-probe (probe SQL) instead — verdict stays degraded here.
+        await new Promise((resolve) => setTimeout(resolve, 300));
         expect(health.getHealth().status).toBe("degraded");
       } finally {
         jest.restoreAllMocks();
       }
     });
+
+    it("resumes the lexical arm by itself once the index exists and the re-probe sees it", async () => {
+      jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+      try {
+        const health = new KbFtsHealthService(noIndex.asPrisma());
+        await health.probe();
+        expect(health.shouldQuery()).toBe(false);
+
+        await noIndex.exec(`CREATE INDEX ${KB_FTS_INDEX} ON "KbChunk" USING GIN (to_tsvector('${KB_FTS_CONFIG}', content));`);
+        // Throttle window is 30 s in production; call the probe directly here.
+        await health.probe();
+        expect(health.shouldQuery()).toBe(true);
+
+        const rag = ragServiceOn(noIndex, health);
+        const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+        expect(chunks.map((c: any) => c.chunkId)).toContain("chunk-hpv");
+      } finally {
+        await noIndex.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
+        jest.restoreAllMocks();
+      }
+    });
   });
 
-  it("does clear a stale 'unavailable' verdict once a query succeeds on a healthy schema", async () => {
+  it("does clear a stale 'unavailable' verdict on a healthy schema: the gate skips once, re-probes, then the arm runs", async () => {
     jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
     try {
       const health = new KbFtsHealthService(db.asPrisma());
       (health as any).set("unavailable", "forced stale verdict for test");
       expect(health.isUnavailable()).toBe(true);
 
       const rag = ragServiceOn(db, health);
-      await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+      // First call is skipped (vector-only) but schedules the re-probe.
+      expect(await (rag as any).fullTextSearchWithMetadata("HPV testing", 6)).toEqual([]);
 
       const deadline = Date.now() + 3000;
       while (health.getHealth().status !== "ok" && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
       expect(health.getHealth().status).toBe("ok");
+      // …and the next call runs the lexical arm.
+      const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+      expect(chunks.map((c: any) => c.chunkId)).toContain("chunk-hpv");
     } finally {
       jest.restoreAllMocks();
     }
@@ -438,6 +472,8 @@ describe("KB full-text search (issue #92)", () => {
 
     it("escalates a failing lexical query instead of swallowing it, while chat keeps serving", async () => {
       const health = new KbFtsHealthService(broken.asPrisma());
+      // The table vanished AFTER a healthy boot probe: the gate lets the query run once.
+      (health as any).set("ok", "stale ok from boot");
       const rag = ragServiceOn(broken, health);
 
       const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);

--- a/apps/api/src/modules/rag/kb-fts.spec.ts
+++ b/apps/api/src/modules/rag/kb-fts.spec.ts
@@ -6,9 +6,10 @@ import { RagService } from "./rag.service";
 import { KbFtsHealthService } from "./kb-fts-health.service";
 import { PgliteDatabase, PgliteProcess } from "./__test-utils__/pglite-client";
 import {
-  KB_FTS_COLUMN,
   KB_FTS_CONFIG,
   KB_FTS_INDEX,
+  KB_FTS_INDEXDEF_MARKER,
+  KB_FTS_LEGACY_COLUMN,
   KB_FTS_PROBE_SQL,
   KB_FTS_SEARCH_SQL,
   KbFtsProbeRow,
@@ -33,8 +34,10 @@ import {
  * REAL statement the service ships (`KB_FTS_SEARCH_SQL`) — including once through
  * `RagService.fullTextSearchWithMetadata` itself.
  *
- * On the parent commit of the fix, everything below that touches the database fails:
- * `column c.content_tsv does not exist`.
+ * DESIGN UNDER TEST (2026-09-12): the lexical arm is a GIN EXPRESSION index over
+ * to_tsvector('simple', content) and a query using the identical expression. There is
+ * no tsvector column. Two column designs were abandoned the same day (table rewrite
+ * outage; 190 ms/row trigger backfill) — see the migration header.
  */
 
 const API_ROOT = path.resolve(__dirname, "../../..");
@@ -69,7 +72,13 @@ function ftsMigrationsInOrder(): Array<{ name: string; sql: string }> {
     .filter((entry) => fs.statSync(path.join(MIGRATIONS_DIR, entry)).isDirectory())
     .sort()
     .map((name) => ({ name, sql: fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf8") }))
-    .filter((m) => m.sql.includes(KB_FTS_COLUMN) || m.sql.includes(KB_FTS_INDEX));
+    .filter((m) => m.sql.includes(KB_FTS_LEGACY_COLUMN) || m.sql.includes(KB_FTS_INDEX));
+}
+
+function restoreSql(): string {
+  const restore = ftsMigrationsInOrder().find((m) => m.name === RESTORE_MIGRATION);
+  if (!restore) throw new Error(`${RESTORE_MIGRATION} is missing from prisma/migrations`);
+  return restore.sql;
 }
 
 /**
@@ -99,52 +108,41 @@ function baselineDdlFromSchema(): string {
 
 async function buildDatabase(
   proc: PgliteProcess,
-  options: { simulateFreshDbPush?: boolean; leaveUnrepaired?: boolean } = {}
+  options: { replayMigrations?: boolean; seed?: boolean } = {}
 ): Promise<PgliteDatabase> {
+  const { replayMigrations = true, seed = true } = options;
   const db = await proc.createDatabase();
   await db.exec(baselineDdlFromSchema());
 
-  if (options.leaveUnrepaired) {
-    // A `db push` database with the restore migration NOT yet applied: Prisma's
-    // plain `content_tsv tsvector` placeholder, always NULL, never generated.
-    // The lexical query runs clean against it and returns nothing.
-  } else if (options.simulateFreshDbPush) {
-    // A `db push`/`migrate diff` database is baselined at the datamodel, so it keeps
-    // Prisma's plain `content_tsv tsvector` placeholder and only *new* migrations run.
-    const restore = ftsMigrationsInOrder().find((m) => m.name === RESTORE_MIGRATION);
-    if (!restore) throw new Error(`${RESTORE_MIGRATION} is missing from prisma/migrations`);
-    await db.exec(restore.sql);
-  } else {
-    // Production's base schema predates FTS — `content_tsv` was created by migration
-    // 20260120163141, not by the datamodel. Drop the datamodel's plain placeholder so
-    // the migration history replays from the same starting point production had.
-    await db.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
-    await db.exec(`ALTER TABLE "KbChunk" DROP COLUMN IF EXISTS ${KB_FTS_COLUMN};`);
-
+  if (replayMigrations) {
+    // Production's history: 20260120 (generated column, 'english') → 20260218 ('simple')
+    // → 20260606 (dropped) → 20260908 (expression index). Replayed from the same
+    // starting point production had: the datamodel carries no FTS objects.
     for (const migration of ftsMigrationsInOrder()) {
       await db.exec(migration.sql);
     }
   }
 
-  await db.exec(`
-    INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
-    VALUES ('${DOC_ID}', '02_nci_core', 'NCI', 'Cervical cancer screening', '1', 'https://example.org/screening',
-            'active', true, now(), now());
-  `);
-  for (const [index, chunk] of CHUNKS.entries()) {
-    await db.query(
-      `INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt") VALUES ($1, $2, $3, $4, now())`,
-      [chunk.id, DOC_ID, index, chunk.content]
-    );
+  if (seed) {
+    await db.exec(`
+      INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
+      VALUES ('${DOC_ID}', '02_nci_core', 'NCI', 'Cervical cancer screening', '1', 'https://example.org/screening',
+              'active', true, now(), now());
+    `);
+    for (const [index, chunk] of CHUNKS.entries()) {
+      await db.query(
+        `INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt") VALUES ($1, $2, $3, $4, now())`,
+        [chunk.id, DOC_ID, index, chunk.content]
+      );
+    }
+    // An archived document must never come back from retrieval.
+    await db.exec(`
+      INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
+      VALUES ('doc-retired', '02_nci_core', 'NCI', 'Retired page', '1', NULL, 'archived', true, now(), now());
+      INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
+      VALUES ('chunk-retired', 'doc-retired', 0, 'HPV testing guidance that has since been withdrawn.', now());
+    `);
   }
-  // A retired document must never surface — the query filters on d.status = 'active'.
-  await db.exec(`
-    INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
-    VALUES ('doc-retired', '02_nci_core', 'NCI', 'Retired screening guidance', '1', NULL, 'archived', true, now(), now());
-    INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
-    VALUES ('chunk-retired', 'doc-retired', 0, 'Cervical cancer screening HPV testing retired guidance', now());
-  `);
-
   return db;
 }
 
@@ -157,6 +155,12 @@ function ragServiceOn(db: PgliteDatabase, ftsHealth: KbFtsHealthService): RagSer
     {} as any, // reranker
     ftsHealth
   );
+}
+
+async function probe(db: PgliteDatabase): Promise<KbFtsProbeRow> {
+  const rows = await db.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL);
+  expect(rows).toHaveLength(1);
+  return rows[0];
 }
 
 describe("KB full-text search (issue #92)", () => {
@@ -174,49 +178,23 @@ describe("KB full-text search (issue #92)", () => {
     await proc?.stop();
   });
 
-  it("keeps content_tsv in the migration history (the #92 drop is not re-introduced)", () => {
+  it("the FTS migration history ends with the expression index, not a drop (the #92 drop is not re-introduced)", () => {
     const migrations = ftsMigrationsInOrder();
     const last = migrations[migrations.length - 1];
-
-    // The FTS lifecycle must end with a restore, not a drop. This is the guard that
-    // would have failed CI on 2026-06-06.
-    expect(migrations.map((m) => m.name)).toContain(RESTORE_MIGRATION);
-    expect(last.sql).toMatch(/ADD COLUMN IF NOT EXISTS content_tsv/);
-    expect(last.sql).toContain(`to_tsvector('${KB_FTS_CONFIG}', content)`);
+    expect(last.name).toBe(RESTORE_MIGRATION);
+    expect(last.sql).toMatch(/CREATE INDEX kb_chunk_content_tsv_idx ON "KbChunk" USING GIN \(to_tsvector\('simple', content\)\)/);
+    // The abandoned designs must not come back: no generated column, no trigger creation.
+    expect(last.sql).not.toMatch(/GENERATED ALWAYS/);
+    expect(last.sql).not.toMatch(/CREATE TRIGGER/);
   });
 
-  it("leaves content_tsv present, trigger-maintained on the 'simple' config, with a VALID GIN index after replaying the real migrations", async () => {
-    const rows = await db.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL);
-    expect(rows).toHaveLength(1);
-
-    const probe = rows[0];
-    expect(probe.tablePresent).toBe(true);
-    expect(probe.columnPresent).toBe(true);
-    // Existence alone is not enough: an unmaintained column stays NULL forever and
-    // the lexical arm returns zero rows without ever raising an error. The current
-    // shape is a plain column + trigger (a STORED generated column rewrites the
-    // table and every index — the 2026-09-12 outage), so the probe must see the
-    // trigger and its 'simple' config.
-    expect(probe.columnGenerated).toBe(false);
-    expect(probe.triggerEnabled).toBe(true);
-    expect(probe.triggerFunctionDef).toContain(`'${KB_FTS_CONFIG}'`);
-    expect(probe.indexPresent).toBe(true);
-    expect(probe.indexValid).toBe(true);
-  });
-
-  it("the trigger keeps content_tsv current on INSERT and on UPDATE OF content", async () => {
-    await db.exec(`INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
-                   VALUES ('chunk-trigger', '${DOC_ID}', 99, 'Mammography screening every two years', now());`);
-    const inserted = await db.query<{ populated: boolean }>(
-      `SELECT ${KB_FTS_COLUMN} IS NOT NULL AS populated FROM "KbChunk" WHERE id = 'chunk-trigger'`
-    );
-    expect(inserted[0].populated).toBe(true);
-    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["mammography", 12])).map((r) => r.id)).toContain("chunk-trigger");
-
-    await db.exec(`UPDATE "KbChunk" SET content = 'Colposcopy after an abnormal Pap smear' WHERE id = 'chunk-trigger';`);
-    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["mammography", 12])).map((r) => r.id)).not.toContain("chunk-trigger");
-    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["Pap smear", 12])).map((r) => r.id)).toContain("chunk-trigger");
-    await db.exec(`DELETE FROM "KbChunk" WHERE id = 'chunk-trigger';`);
+  it("leaves a VALID GIN expression index over to_tsvector('simple', content) and no legacy column after replaying the real migrations", async () => {
+    const p = await probe(db);
+    expect(p.tablePresent).toBe(true);
+    expect(p.indexDef).toContain(KB_FTS_INDEXDEF_MARKER);
+    expect(p.indexDef).toMatch(/USING gin/i);
+    expect(p.indexValid).toBe(true);
+    expect(p.legacyColumnPresent).toBe(false);
   });
 
   it("returns ranked rows for the shipped lexical query", async () => {
@@ -241,6 +219,26 @@ describe("KB full-text search (issue #92)", () => {
     expect(hinglish.map((r) => r.id)).toContain("chunk-hindi");
   });
 
+  it("the planner uses the expression index for the shipped predicate", async () => {
+    // Tiny table: force the choice so the test checks *usability*, not cost estimates.
+    await db.exec("SET enable_seqscan = off;");
+    try {
+      const plan = await db.query<{ "QUERY PLAN": string }>(
+        `EXPLAIN SELECT c.id FROM "KbChunk" c, websearch_to_tsquery('${KB_FTS_CONFIG}', 'HPV testing') q WHERE to_tsvector('${KB_FTS_CONFIG}', c.content) @@ q`
+      );
+      expect(plan.map((r) => r["QUERY PLAN"]).join("\n")).toContain(KB_FTS_INDEX);
+    } finally {
+      await db.exec("RESET enable_seqscan;");
+    }
+  });
+
+  it("newly inserted rows are searchable immediately (no column to keep current)", async () => {
+    await db.exec(`INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
+                   VALUES ('chunk-new', '${DOC_ID}', 99, 'Mammography screening every two years', now());`);
+    expect((await db.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["mammography", 12])).map((r) => r.id)).toContain("chunk-new");
+    await db.exec(`DELETE FROM "KbChunk" WHERE id = 'chunk-new';`);
+  });
+
   it("RagService.fullTextSearchWithMetadata returns normalized evidence chunks against a real database", async () => {
     const ftsHealth = new KbFtsHealthService(db.asPrisma());
     const rag = ragServiceOn(db, ftsHealth);
@@ -261,25 +259,6 @@ describe("KB full-text search (issue #92)", () => {
     expect(ftsHealth.getHealth().schemaFailureCount).toBe(0);
   });
 
-  it("repairs a schema built from schema.prisma, where Prisma renders content_tsv as a plain, unmaintained column", async () => {
-    // `prisma migrate diff` / `db push` gives a `content_tsv tsvector` that nothing
-    // maintains, so it is always NULL. The restore migration must equip that existing
-    // column with the trigger (and backfill it), not skip it via IF NOT EXISTS.
-    const fresh = await buildDatabase(proc, { simulateFreshDbPush: true });
-    try {
-      const probe = (await fresh.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
-      expect(probe.columnGenerated).toBe(false);
-      expect(probe.triggerEnabled).toBe(true);
-      expect(probe.triggerFunctionDef).toContain(`'${KB_FTS_CONFIG}'`);
-      expect(probe.indexValid).toBe(true);
-
-      const rows = await fresh.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
-      expect(rows.map((r) => r.id)).toContain("chunk-hpv");
-    } finally {
-      await fresh.close();
-    }
-  });
-
   it("reports 'ok' from the boot probe on a correctly migrated database", async () => {
     jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
     try {
@@ -294,17 +273,131 @@ describe("KB full-text search (issue #92)", () => {
     }
   });
 
-  describe("when content_tsv goes missing again", () => {
+  it("the migration removes leftovers of the abandoned column designs and builds the expression index", async () => {
+    const legacy = await buildDatabase(proc, { replayMigrations: false });
+    try {
+      // What the trigger-maintained design left behind.
+      await legacy.exec(`
+        ALTER TABLE "KbChunk" ADD COLUMN ${KB_FTS_LEGACY_COLUMN} tsvector;
+        CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger LANGUAGE plpgsql AS $fn$
+        BEGIN NEW.${KB_FTS_LEGACY_COLUMN} := to_tsvector('${KB_FTS_CONFIG}', NEW.content); RETURN NEW; END $fn$;
+        CREATE TRIGGER kbchunk_content_tsv_trg BEFORE INSERT OR UPDATE OF content ON "KbChunk"
+          FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
+        CREATE INDEX ${KB_FTS_INDEX} ON "KbChunk" USING GIN (${KB_FTS_LEGACY_COLUMN});
+      `);
+      expect((await probe(legacy)).legacyColumnPresent).toBe(true);
+
+      await legacy.exec(restoreSql());
+
+      const p = await probe(legacy);
+      expect(p.legacyColumnPresent).toBe(false);
+      expect(p.indexDef).toContain(KB_FTS_INDEXDEF_MARKER);
+      expect(p.indexValid).toBe(true);
+      const fn = await legacy.query<{ n: number }>(`SELECT count(*)::int AS n FROM pg_proc WHERE proname = 'kbchunk_content_tsv_maintain'`);
+      expect(fn[0].n).toBe(0);
+      expect((await legacy.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12])).map((r) => r.id)).toContain("chunk-hpv");
+    } finally {
+      await legacy.close();
+    }
+  });
+
+  describe("when the expression index is missing (e.g. a schema diff dropped it again)", () => {
+    // The June-2026 failure shape — but with an expression query the arm is now
+    // *degraded*, not dead: rows still come back via a sequential scan.
+    let noIndex: PgliteDatabase;
+
+    beforeAll(async () => {
+      noIndex = await buildDatabase(proc, { replayMigrations: false });
+    });
+
+    afterAll(async () => {
+      await noIndex?.close();
+    });
+
+    it("the shipped query still returns correct rows", async () => {
+      const rows = await noIndex.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
+      expect(rows.map((r) => r.id)).toContain("chunk-hpv");
+    });
+
+    it("probes as 'degraded' with a remediation pointing at the migration/script", async () => {
+      jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
+      try {
+        const health = new KbFtsHealthService(noIndex.asPrisma());
+        const result = await health.probe();
+        expect(result.status).toBe("degraded");
+        expect(result.detail).toMatch(/missing/);
+        expect(health.isUnavailable()).toBe(false);
+      } finally {
+        jest.restoreAllMocks();
+      }
+    });
+
+    it("a query success does NOT flip a stale 'unavailable' verdict to 'ok' — the re-probe says degraded", async () => {
+      jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
+      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+      try {
+        const health = new KbFtsHealthService(noIndex.asPrisma());
+        (health as any).set("unavailable", "forced stale verdict for test");
+        const rag = ragServiceOn(noIndex, health);
+        const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+        expect(chunks.length).toBeGreaterThan(0);
+
+        const deadline = Date.now() + 3000;
+        while (health.getHealth().status === "unavailable" && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        expect(health.getHealth().status).toBe("degraded");
+      } finally {
+        jest.restoreAllMocks();
+      }
+    });
+  });
+
+  it("does clear a stale 'unavailable' verdict once a query succeeds on a healthy schema", async () => {
+    jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
+    try {
+      const health = new KbFtsHealthService(db.asPrisma());
+      (health as any).set("unavailable", "forced stale verdict for test");
+      expect(health.isUnavailable()).toBe(true);
+
+      const rag = ragServiceOn(db, health);
+      await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
+
+      const deadline = Date.now() + 3000;
+      while (health.getHealth().status !== "ok" && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(health.getHealth().status).toBe("ok");
+    } finally {
+      jest.restoreAllMocks();
+    }
+  });
+
+  it("reports 'degraded' (not ok) when the index is left INVALID by an interrupted concurrent build", async () => {
+    jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+    const invalid = await buildDatabase(proc);
+    try {
+      await invalid.exec(`UPDATE pg_index SET indisvalid = false WHERE indexrelid = '${KB_FTS_INDEX}'::regclass;`);
+      const p = await probe(invalid);
+      expect(p.indexDef).not.toBeNull();
+      expect(p.indexValid).toBe(false);
+
+      const health = await new KbFtsHealthService(invalid.asPrisma()).probe();
+      expect(health.status).toBe("degraded");
+      expect(health.detail).toMatch(/INVALID/);
+    } finally {
+      jest.restoreAllMocks();
+      await invalid.close();
+    }
+  });
+
+  describe("when the table itself is gone", () => {
     let broken: PgliteDatabase;
-    let ftsHealth: KbFtsHealthService;
     let errorSpy: jest.SpyInstance;
 
     beforeAll(async () => {
-      broken = await buildDatabase(proc);
-      // Reproduce exactly what migration 20260606000000 did to production.
-      await broken.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
-      await broken.exec(`ALTER TABLE "KbChunk" DROP COLUMN ${KB_FTS_COLUMN};`);
-      ftsHealth = new KbFtsHealthService(broken.asPrisma());
+      broken = await buildDatabase(proc, { seed: false });
+      await broken.exec(`DROP TABLE "KbChunk" CASCADE;`);
     });
 
     beforeEach(() => {
@@ -322,7 +415,6 @@ describe("KB full-text search (issue #92)", () => {
     });
 
     it("classifies the real Postgres error as a schema failure, not an unlucky query", async () => {
-      // Healthy database: the same statement does not raise at all.
       await expect(db.query(KB_FTS_SEARCH_SQL, ["HPV testing", 12])).resolves.toBeDefined();
 
       const schemaError = await broken
@@ -331,19 +423,15 @@ describe("KB full-text search (issue #92)", () => {
         .catch((e) => e);
 
       expect(schemaError).not.toBeNull();
-      expect((schemaError as any).code).toBe("42703"); // undefined_column, straight from Postgres
+      expect((schemaError as any).code).toBe("42P01"); // undefined_table, straight from Postgres
       expect(isFtsSchemaError(schemaError)).toBe(true);
       // A transient failure must NOT be mistaken for a dead schema.
       expect(isFtsSchemaError(new Error("Timed out fetching a new connection from the pool"))).toBe(false);
     });
 
     it("reports 'unavailable' from the probe and logs it at error level", async () => {
-      const health = await ftsHealth.probe();
-
+      const health = await new KbFtsHealthService(broken.asPrisma()).probe();
       expect(health.status).toBe("unavailable");
-      expect(health.detail).toContain(KB_FTS_COLUMN);
-      expect(ftsHealth.isUnavailable()).toBe(true);
-
       const events = errorSpy.mock.calls.map((call) => call[0]?.event);
       expect(events).toContain("kb_fts_unavailable");
     });
@@ -352,146 +440,30 @@ describe("KB full-text search (issue #92)", () => {
       const health = new KbFtsHealthService(broken.asPrisma());
       const rag = ragServiceOn(broken, health);
 
-      // Per-query resilience is preserved: the caller still gets an array, so the
-      // vector arm can answer the turn.
       const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
       expect(chunks).toEqual([]);
 
-      // But the condition is counted and escalated, instead of one indistinguishable
-      // log line per turn.
       expect(health.getHealth().schemaFailureCount).toBeGreaterThan(0);
       expect(health.getHealth().status).toBe("unavailable");
-      expect(health.getHealth().lastError).toContain(KB_FTS_COLUMN);
 
       const events = errorSpy.mock.calls.map((call) => call[0]?.event);
       expect(events).toContain("kb_fts_unavailable");
     });
   });
 
-  describe("when content_tsv is present but nothing maintains it (always NULL)", () => {
-    // The masking case: the column exists, so the query executes and throws
-    // nothing — it just returns zero rows forever. Query success must never be
-    // read as proof that the schema is healthy.
-    let unrepaired: PgliteDatabase;
-
-    beforeAll(async () => {
-      unrepaired = await buildDatabase(proc, { leaveUnrepaired: true });
-    });
-
-    afterAll(async () => {
-      await unrepaired?.close();
-    });
-
-    it("executes the shipped query without error and returns nothing", async () => {
-      const probe = (await unrepaired.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
-      expect(probe.columnPresent).toBe(true);
-      expect(probe.columnGenerated).toBe(false);
-      expect(probe.triggerEnabled).toBe(false);
-
-      const rows = await unrepaired.query<{ id: string }>(KB_FTS_SEARCH_SQL, ["HPV testing", 12]);
-      expect(rows).toHaveLength(0);
-    });
-
-    it("probes as 'unavailable' even though the column exists", async () => {
-      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
-      try {
-        const health = new KbFtsHealthService(unrepaired.asPrisma());
-        const result = await health.probe();
-
-        expect(result.status).toBe("unavailable");
-        expect(health.isUnavailable()).toBe(true);
-      } finally {
-        jest.restoreAllMocks();
-      }
-    });
-
-    it("does NOT clear the unavailable verdict when a query merely succeeds", async () => {
-      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
-      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
-      try {
-        const health = new KbFtsHealthService(unrepaired.asPrisma());
-        await health.probe();
-        expect(health.isUnavailable()).toBe(true);
-
-        // A real retrieval call through RagService: the query succeeds, so the
-        // service records a success. Before the re-probe fix this flipped the
-        // sub-status straight to "ok" and reported a dead arm as healthy.
-        const rag = ragServiceOn(unrepaired, health);
-        const chunks = await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
-        expect(chunks).toHaveLength(0);
-
-        // Give the throttled, fire-and-forget re-probe time to land.
-        await new Promise((resolve) => setTimeout(resolve, 400));
-
-        expect(health.getHealth().status).toBe("unavailable");
-        expect(health.isUnavailable()).toBe(true);
-      } finally {
-        jest.restoreAllMocks();
-      }
-    });
-
-    it("reports 'degraded' (not ok) when the GIN index is left INVALID by an interrupted concurrent build", async () => {
-      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
-      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
-      const invalid = await buildDatabase(proc);
-      try {
-        // Simulate what a cancelled CREATE INDEX CONCURRENTLY leaves behind.
-        await invalid.exec(`UPDATE pg_index SET indisvalid = false WHERE indexrelid = '${KB_FTS_INDEX}'::regclass;`);
-        const probe = (await invalid.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
-        expect(probe.indexPresent).toBe(true);
-        expect(probe.indexValid).toBe(false);
-
-        const health = await new KbFtsHealthService(invalid.asPrisma()).probe();
-        expect(health.status).toBe("degraded");
-        expect(health.detail).toMatch(/INVALID/);
-      } finally {
-        jest.restoreAllMocks();
-        await invalid.close();
-      }
-    });
-
-    it("does clear the verdict once the schema is actually repaired", async () => {
-      // The recovery path must still work — the fix defers to the probe, it
-      // does not pin the verdict permanently.
-      jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
-      jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
-      try {
-        const health = new KbFtsHealthService(db.asPrisma());
-        (health as any).set("unavailable", "forced stale verdict for test");
-        expect(health.isUnavailable()).toBe(true);
-
-        const rag = ragServiceOn(db, health);
-        await (rag as any).fullTextSearchWithMetadata("HPV testing", 6);
-
-        const deadline = Date.now() + 3000;
-        while (health.getHealth().status !== "ok" && Date.now() < deadline) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-
-        expect(health.getHealth().status).toBe("ok");
-      } finally {
-        jest.restoreAllMocks();
-      }
-    });
-  });
-
-  describe("on a production-sized table the migration refuses instead of rewriting (review on the #92 follow-up)", () => {
-    // The 2026-09-12 outage: a STORED generated column rewrote the whole table.
-    // The safeguard is that migration.sql can never leave a large table half-done
-    // and be recorded as applied — it either completes (small table) or raises.
+  describe("on a production-sized table the migration refuses instead of scanning under a lock", () => {
+    // The safeguard from the 2026-09-12 review: migration.sql either completes
+    // (small table) or raises with nothing committed — so `prisma migrate deploy`
+    // can never record it as applied ahead of the concurrent index build.
     let big: PgliteDatabase;
-    const restoreSql = () => ftsMigrationsInOrder().find((m) => m.name === RESTORE_MIGRATION)!.sql;
 
     beforeAll(async () => {
-      big = await buildDatabase(proc);
-      // Undo the restore so the column is absent, then make the table "large".
-      await big.exec(`DROP TRIGGER IF EXISTS kbchunk_content_tsv_trg ON "KbChunk";`);
-      await big.exec(`DROP FUNCTION IF EXISTS kbchunk_content_tsv_maintain();`);
-      await big.exec(`DROP INDEX IF EXISTS ${KB_FTS_INDEX};`);
-      await big.exec(`ALTER TABLE "KbChunk" DROP COLUMN IF EXISTS ${KB_FTS_COLUMN};`);
+      big = await buildDatabase(proc, { replayMigrations: false, seed: false });
       await big.exec(`
+        INSERT INTO "KbDocument" (id, "sourceType", source, title, version, url, status, "isTrustedSource", "createdAt", "updatedAt")
+        VALUES ('${DOC_ID}', '02_nci_core', 'NCI', 'Bulk', '1', NULL, 'active', true, now(), now());
         INSERT INTO "KbChunk" (id, "docId", "chunkIndex", content, "createdAt")
-        SELECT 'bulk-' || g, '${DOC_ID}', 1000 + g, 'filler chunk ' || g, now() FROM generate_series(1, 5001) g;
+        SELECT 'bulk-' || g, '${DOC_ID}', g, 'filler chunk ' || g, now() FROM generate_series(1, 5001) g;
       `);
     });
 
@@ -499,50 +471,32 @@ describe("KB full-text search (issue #92)", () => {
       await big?.close();
     });
 
-    it("raises (nothing committed) when the column is unpopulated, so prisma migrate deploy cannot record it", async () => {
+    it("raises with the 'refusing' message and leaves no index behind", async () => {
       const err = await big.exec(restoreSql()).then(() => null).catch((e) => e);
       expect(err).not.toBeNull();
-      expect(String((err as Error).message)).toMatch(/refusing to backfill\/index inside a migration/);
-      // The file is one DO block, so the raise rolls everything back: no column,
-      // no trigger, and not even the helper function (Prisma 5 does not wrap
-      // migration.sql in a transaction, so this atomicity has to come from the file).
-      const probe = (await big.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
-      expect(probe.columnPresent).toBe(false);
-      expect(probe.triggerEnabled).toBe(false);
-      const fn = await big.query<{ n: number }>(
-        `SELECT count(*)::int AS n FROM pg_proc WHERE proname = 'kbchunk_content_tsv_maintain'`
-      );
-      expect(fn[0].n).toBe(0);
+      expect(String((err as Error).message)).toMatch(/refusing to build the FTS index inside a migration/);
+      expect((await probe(big)).indexDef).toBeNull();
     });
 
-    it("is a harmless no-op once the rollout script has populated the column and built a valid index", async () => {
-      // What scripts/sql/kb_fts_safe_rollout.py does, minus batching/CONCURRENTLY (PGlite).
-      await big.exec(`ALTER TABLE "KbChunk" ADD COLUMN ${KB_FTS_COLUMN} tsvector;`);
-      await big.exec(`
-        CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger LANGUAGE plpgsql AS $fn$
-        BEGIN NEW.${KB_FTS_COLUMN} := to_tsvector('${KB_FTS_CONFIG}', NEW.content); RETURN NEW; END $fn$;
-        CREATE TRIGGER kbchunk_content_tsv_trg BEFORE INSERT OR UPDATE OF content ON "KbChunk"
-          FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
-      `);
-      await big.exec(`UPDATE "KbChunk" SET ${KB_FTS_COLUMN} = to_tsvector('${KB_FTS_CONFIG}', content) WHERE ${KB_FTS_COLUMN} IS NULL;`);
-      await big.exec(`CREATE INDEX ${KB_FTS_INDEX} ON "KbChunk" USING GIN (${KB_FTS_COLUMN});`);
-
+    it("is a harmless no-op once the rollout script has built a valid expression index", async () => {
+      // What scripts/sql/kb_fts_safe_rollout.py does, minus CONCURRENTLY (PGlite).
+      await big.exec(`CREATE INDEX ${KB_FTS_INDEX} ON "KbChunk" USING GIN (to_tsvector('${KB_FTS_CONFIG}', content));`);
       await expect(big.exec(restoreSql())).resolves.toBeDefined();
-      const probe = (await big.query<KbFtsProbeRow>(KB_FTS_PROBE_SQL))[0];
-      expect(probe.triggerEnabled).toBe(true);
-      expect(probe.indexValid).toBe(true);
-      const nulls = await big.query<{ n: number }>(`SELECT count(*)::int AS n FROM "KbChunk" WHERE ${KB_FTS_COLUMN} IS NULL`);
-      expect(nulls[0].n).toBe(0);
+      const p = await probe(big);
+      expect(p.indexValid).toBe(true);
+      expect(p.indexDef).toContain(KB_FTS_INDEXDEF_MARKER);
     });
   });
 
-  it("declares content_tsv in schema.prisma so a schema diff cannot drop it again", () => {
+  it("schema.prisma carries no tsvector column and keeps the guard note about the expression index", () => {
     const schema = fs.readFileSync(SCHEMA_PATH, "utf8");
     const fromModel = schema.slice(schema.indexOf("model KbChunk {"));
     const modelBody = fromModel.slice(0, fromModel.indexOf("\n}"));
 
-    expect(modelBody).toMatch(/content_tsv\s+Unsupported\("tsvector"\)\?/);
-    expect(modelBody).toContain(`map: "${KB_FTS_INDEX}"`);
+    // No stored tsvector: a schema diff must not try to (re)create or drop a column.
+    expect(modelBody).not.toMatch(/content_tsv\s+Unsupported/);
+    // The note that stops the next "clean-up" from repeating June 2026.
     expect(modelBody).toContain("DO NOT REMOVE");
+    expect(modelBody).toContain(KB_FTS_INDEX);
   });
 });

--- a/apps/api/src/modules/rag/kb-fts.sql.ts
+++ b/apps/api/src/modules/rag/kb-fts.sql.ts
@@ -3,34 +3,36 @@
  *
  * WHY THIS FILE EXISTS (issue #92): the FTS SQL used to be an inline tagged
  * template inside `RagService.fullTextSearchWithMetadata`. It referenced
- * `KbChunk.content_tsv`, a generated column that lives only in raw migration
+ * `KbChunk.content_tsv`, a generated column that lived only in raw migration
  * SQL. When migration 20260606000000 dropped that column, nothing in the
  * TypeScript build, the Prisma schema or the test suite could notice, and the
  * query failed silently for three months.
  *
- * Keeping the SQL and the schema identifiers here means:
- *   - the boot-time probe (`KbFtsHealthService`) checks the very objects the
- *     query needs, not a hand-copied guess at them, and
- *   - `kb-fts.spec.ts` executes this exact statement against a real Postgres.
+ * DESIGN (since 2026-09-12): there is NO stored tsvector column any more. The
+ * lexical arm indexes the EXPRESSION `to_tsvector('simple', content)` with a GIN
+ * index and queries by the same expression. Postgres uses an expression index
+ * only when the query's expression is textually identical to the index's, so
+ * `KB_FTS_EXPRESSION` is the one place that text lives.
  *
- * If you change the text-search config here you MUST ship a migration that
- * rebuilds `content_tsv` with the same config — `to_tsvector` and
- * `websearch_to_tsquery` must agree or `@@` silently matches nothing.
+ * Why no column: a STORED generated column rewrites the whole table (15-minute
+ * outage, 2026-09-12 10:48 UTC), and a plain column with a trigger costs a
+ * write per row that must also update the pgvector HNSW index (measured
+ * 190 ms/row = 2.5 h of writes for the backfill). The expression index needs
+ * one concurrent build and no row writes, and there is no shadow state to drift.
+ *
+ * Because the query computes the expression itself, it still WORKS without the
+ * index — it just sequentially scans. So the lexical arm can only be "dead" if
+ * the table is missing; a missing or invalid index is "degraded", never a silent zero.
+ *
+ * Keeping the SQL and the identifiers here means the boot-time probe
+ * (`KbFtsHealthService`) checks the very objects the query needs, and
+ * `kb-fts.spec.ts` executes this exact statement against a real Postgres.
  */
 
-/** Table carrying the FTS column. */
+/** Table carrying the searchable text. */
 export const KB_FTS_TABLE = "KbChunk";
 
-/** tsvector column. Defined in raw migration SQL only — see KB_FTS_OWNERSHIP_NOTE. */
-export const KB_FTS_COLUMN = "content_tsv";
-
-/** Trigger that keeps a plain `content_tsv` current (BEFORE INSERT OR UPDATE OF content). */
-export const KB_FTS_TRIGGER = "kbchunk_content_tsv_trg";
-
-/** The trigger's function; its body carries the text-search config, like a generation expression would. */
-export const KB_FTS_TRIGGER_FN = "kbchunk_content_tsv_maintain";
-
-/** GIN index over the tsvector column. */
+/** GIN expression index. Created by raw migration SQL only — see KB_FTS_OWNERSHIP_NOTE. */
 export const KB_FTS_INDEX = "kb_chunk_content_tsv_idx";
 
 /**
@@ -40,15 +42,28 @@ export const KB_FTS_INDEX = "kb_chunk_content_tsv_idx";
  */
 export const KB_FTS_CONFIG = "simple";
 
+/**
+ * The indexed expression, with `c.` as the table alias used by the query. The
+ * migration indexes `to_tsvector('simple', content)`; pg_get_indexdef renders
+ * that as `to_tsvector('simple'::regconfig, content)` — see KB_FTS_INDEXDEF_MARKER.
+ */
+export const KB_FTS_EXPRESSION = `to_tsvector('${KB_FTS_CONFIG}', c.content)`;
+
+/** How pg_get_indexdef renders the indexed expression; the probe checks for it. */
+export const KB_FTS_INDEXDEF_MARKER = `to_tsvector('${KB_FTS_CONFIG}'::regconfig, content)`;
+
+/** Name of the legacy column some databases may still carry; the probe reports it so it gets dropped. */
+export const KB_FTS_LEGACY_COLUMN = "content_tsv";
+
 export const KB_FTS_OWNERSHIP_NOTE =
-  `"${KB_FTS_TABLE}"."${KB_FTS_COLUMN}" is a plain tsvector kept current by trigger ${KB_FTS_TRIGGER} ` +
-  `(function ${KB_FTS_TRIGGER_FN}), both created by raw migration SQL ` +
-  `(20260908000000_restore_kb_chunk_fts); a legacy STORED GENERATED shape is also accepted. ` +
-  `It is NOT a generated column on purpose: a STORED generated column rewrites the whole table ` +
-  `and every index (incl. the pgvector HNSW index) and caused a 15-minute retrieval outage on ` +
-  `2026-09-12. Prisma cannot express either shape, so schema.prisma declares it as ` +
-  `Unsupported("tsvector") purely to stop a schema diff from dropping it again. Never "clean it ` +
-  `up" out of either place.`;
+  `Lexical search on "${KB_FTS_TABLE}" is an EXPRESSION index: ${KB_FTS_INDEX} = GIN ` +
+  `(to_tsvector('${KB_FTS_CONFIG}', content)), created by raw migration SQL ` +
+  `(20260908000000_restore_kb_chunk_fts) — on production with CREATE INDEX CONCURRENTLY via ` +
+  `scripts/sql/kb_fts_safe_rollout.py. There is deliberately NO tsvector column: a STORED ` +
+  `generated column rewrites the table (2026-09-12 outage) and a trigger-maintained column ` +
+  `costs a write per row through the pgvector HNSW index. Prisma cannot express an expression ` +
+  `index, so a schema diff will propose dropping it — never accept that; kb-fts.spec.ts pins ` +
+  `the migration history.`;
 
 /**
  * The lexical retrieval query.
@@ -56,15 +71,15 @@ export const KB_FTS_OWNERSHIP_NOTE =
  * $1 = user query text (fed to websearch_to_tsquery, so phrases and AND/OR work)
  * $2 = row limit
  *
- * Kept structurally identical to the pre-#92 inline statement so the fix is a
- * restoration, not a retrieval-behaviour change.
+ * Uses KB_FTS_EXPRESSION in both the predicate and the rank so the planner can
+ * use the expression index for the predicate.
  */
 export const KB_FTS_SEARCH_SQL = `
   SELECT
     c.id,
     c."docId",
     c.content,
-    ts_rank_cd(c.${KB_FTS_COLUMN}, query) AS "lexRank",
+    ts_rank_cd(${KB_FTS_EXPRESSION}, query) AS "lexRank",
     d.title,
     d.url,
     d."sourceType",
@@ -76,67 +91,42 @@ export const KB_FTS_SEARCH_SQL = `
   INNER JOIN "KbDocument" d ON c."docId" = d.id,
   websearch_to_tsquery('${KB_FTS_CONFIG}', $1) query
   WHERE d.status = 'active'
-    AND c.${KB_FTS_COLUMN} @@ query
-  ORDER BY ts_rank_cd(c.${KB_FTS_COLUMN}, query) DESC
+    AND ${KB_FTS_EXPRESSION} @@ query
+  ORDER BY ts_rank_cd(${KB_FTS_EXPRESSION}, query) DESC
   LIMIT $2::int
 `;
 
 /**
- * Schema probe: reports whether the objects `KB_FTS_SEARCH_SQL` depends on exist
- * AND are shaped correctly. Existence alone is not enough — `prisma migrate diff`
- * emits `content_tsv tsvector` with nothing maintaining it, which leaves a column
- * that is always NULL and an FTS arm that returns zero rows forever without ever
- * raising an error. So the probe reports HOW the column is maintained — a STORED
- * generation expression (legacy) or the enabled `KB_FTS_TRIGGER` (current) — and
- * whether the GIN index is not just present but VALID (an interrupted
- * `CREATE INDEX CONCURRENTLY` leaves an invalid index behind).
+ * Schema probe: is the table there, is the expression index there, is it VALID
+ * (an interrupted CREATE INDEX CONCURRENTLY leaves an invalid index the planner
+ * ignores), and is it over the expression the query uses? Also reports whether a
+ * legacy `content_tsv` column is still present so it can be dropped.
  */
 export const KB_FTS_PROBE_SQL = `
   SELECT
     to_regclass('"${KB_FTS_TABLE}"') IS NOT NULL AS "tablePresent",
-    (a.attname IS NOT NULL) AS "columnPresent",
-    COALESCE(a.attgenerated = 's', false) AS "columnGenerated",
-    pg_get_expr(d.adbin, d.adrelid) AS "generationExpr",
-    EXISTS (
-      SELECT 1 FROM pg_trigger t
-      WHERE t.tgrelid = to_regclass('"${KB_FTS_TABLE}"')
-        AND t.tgname = '${KB_FTS_TRIGGER}'
-        AND NOT t.tgisinternal
-        AND t.tgenabled <> 'D'
-    ) AS "triggerEnabled",
-    (
-      SELECT pg_get_functiondef(p.oid) FROM pg_proc p WHERE p.proname = '${KB_FTS_TRIGGER_FN}' LIMIT 1
-    ) AS "triggerFunctionDef",
-    EXISTS (
-      SELECT 1 FROM pg_indexes WHERE indexname = '${KB_FTS_INDEX}'
-    ) AS "indexPresent",
+    (SELECT indexdef FROM pg_indexes WHERE indexname = '${KB_FTS_INDEX}') AS "indexDef",
     COALESCE((
       SELECT i.indisvalid AND i.indisready
       FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
       WHERE c.relname = '${KB_FTS_INDEX}'
-    ), false) AS "indexValid"
-  FROM (SELECT 1) probe
-  LEFT JOIN pg_attribute a
-    ON a.attrelid = to_regclass('"${KB_FTS_TABLE}"')
-   AND a.attname = '${KB_FTS_COLUMN}'
-   AND NOT a.attisdropped
-  LEFT JOIN pg_attrdef d
-    ON d.adrelid = a.attrelid
-   AND d.adnum = a.attnum
+    ), false) AS "indexValid",
+    EXISTS (
+      SELECT 1 FROM pg_attribute
+      WHERE attrelid = to_regclass('"${KB_FTS_TABLE}"')
+        AND attname = '${KB_FTS_LEGACY_COLUMN}'
+        AND NOT attisdropped
+    ) AS "legacyColumnPresent"
 `;
 
 export interface KbFtsProbeRow {
   tablePresent: boolean;
-  columnPresent: boolean;
-  /** Legacy shape: STORED generated column (Postgres maintains it). */
-  columnGenerated: boolean;
-  generationExpr: string | null;
-  /** Current shape: plain column kept current by the enabled maintenance trigger. */
-  triggerEnabled: boolean;
-  triggerFunctionDef: string | null;
-  indexPresent: boolean;
+  /** pg_get_indexdef output, or null when the index is missing. */
+  indexDef: string | null;
   /** pg_index.indisvalid AND indisready — false for an interrupted concurrent build. */
   indexValid: boolean;
+  /** A stored tsvector column from the abandoned designs is still present. */
+  legacyColumnPresent: boolean;
 }
 
 /**
@@ -168,8 +158,9 @@ export function isFtsSchemaError(error: unknown): boolean {
 
   const message = typeof err.message === "string" ? err.message : "";
   return (
-    new RegExp(`column\\s+.?(c\\.)?${KB_FTS_COLUMN}.?\\s+does not exist`, "i").test(message) ||
+    /column\s+.?(c\.)?content\s+does not exist/i.test(message) ||
     /relation\s+.?KbChunk.?\s+does not exist/i.test(message) ||
-    /function\s+websearch_to_tsquery.*does not exist/i.test(message)
+    /function\s+(websearch_to_tsquery|to_tsvector).*does not exist/i.test(message) ||
+    /text search configuration\s+.?simple.?\s+does not exist/i.test(message)
   );
 }

--- a/apps/api/src/modules/rag/rag.service.ts
+++ b/apps/api/src/modules/rag/rag.service.ts
@@ -700,6 +700,12 @@ export class RagService {
     query: string,
     topK: number
   ): Promise<EvidenceChunk[]> {
+    // Operational gate: without a valid expression index the query would scan and
+    // to_tsvector() every chunk on every turn. Answer vector-only until the probe
+    // reports `ok`; the gate schedules its own throttled re-probe.
+    if (!this.ftsHealth.shouldQuery()) {
+      return [];
+    }
     try {
       // Use websearch_to_tsquery for better query parsing (handles phrases, AND/OR, etc.)
       const results = await this.prisma.$queryRawUnsafe<Array<{

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -155,21 +155,31 @@ Safe pattern (what `20260908000000_restore_kb_chunk_fts` now does):
 6. Verify `COUNT(*) WHERE col IS NULL = 0`, `pg_index.indisvalid`, and a live
    query; only then `prisma migrate resolve --applied <migration>`.
 
-The FTS migration `20260908000000_restore_kb_chunk_fts` enforces this: on a table
-with more than 5 000 rows it **raises** (nothing committed) unless the column is
-already populated and the GIN index valid, so `prisma migrate deploy` — including
-the gated pipeline's migration job — cannot record it as applied ahead of the
-backfill. The script below does the bootstrap itself and resolves the migration
-at the end; after that the file is a no-op.
+Full-text search itself follows this rule by **not having a column at all**: the
+lexical arm is a GIN **expression** index `kb_chunk_content_tsv_idx` over
+`to_tsvector('simple', content)`, and the query uses the identical expression.
+Nothing is written to any row; a missing index only makes lexical search slower,
+never wrong. (Both column designs were tried on 2026-09-12 and abandoned: the
+STORED generated column rewrote the table — the outage above — and a
+trigger-maintained column cost 190 ms per backfilled row because every updated
+row re-enters the HNSW index.)
 
-Scripted for the FTS column:
+Migration `20260908000000_restore_kb_chunk_fts` enforces this: on a table with
+more than 5 000 rows it **raises** (one atomic DO block, nothing committed)
+unless the expression index already exists and is valid, so `prisma migrate
+deploy` — including the gated pipeline's migration job — cannot record it as
+applied ahead of the index. The script below builds the index CONCURRENTLY,
+verifies it (validity, expression, live hits, `EXPLAIN` shows the index),
+resolves the migration and re-runs the file as a no-op proof.
+
+Scripted for the FTS index:
 
 ```bash
 # Terminal 1: cloud-sql-proxy … --port 5433   (see §1)
-# Terminal 2, repo root, low-traffic window (night IST):
+# Terminal 2, repo root, low-traffic window preferred (the build scans the table but takes no blocking lock):
 export DATABASE_URL="$(gcloud secrets versions access latest --secret=database-url)"
 python3 scripts/sql/kb_fts_safe_rollout.py            # dry run: state + plan
-python3 scripts/sql/kb_fts_safe_rollout.py --execute  # column+trigger → batched backfill → CONCURRENT index → verify → resolve
+python3 scripts/sql/kb_fts_safe_rollout.py --execute  # drop legacy objects → CONCURRENT index → verify → resolve
 curl -s https://suchi-api-lxiveognla-uc.a.run.app/v1/health/retrieval   # fullTextSearch.status: ok
 ```
 

--- a/docs/RELIABILITY_BACKLOG.md
+++ b/docs/RELIABILITY_BACKLOG.md
@@ -531,8 +531,22 @@ trigger, with backfill and `CREATE INDEX CONCURRENTLY` moved to
 shape and checks `pg_index.indisvalid`. Procedure and the "never rewrite
 `KbChunk`" rule: `docs/OPERATIONS_RUNBOOK.md` §4a.
 
-**Still to do.** Run the rollout script in a night-IST window, then confirm
-`GET /v1/health/retrieval` reports `ok`.
+**Second attempt, same day.** The trigger-maintained plain column was rolled out
+(column + trigger in milliseconds, no locks) but the batched backfill measured
+**190 ms per row**: each updated `KbChunk` row is too large for a HOT update, so
+it re-enters all four indexes including the 182 MB pgvector HNSW index. 48,737
+rows would have meant ~2.5 h of steady writes. Stopped at 12,000 rows; column,
+trigger and function dropped again (catalog-only, 3 s).
+
+**Final design.** A GIN **expression** index over `to_tsvector('simple',
+content)` and a query using the identical expression: no column, no trigger, no
+backfill, no per-row writes, nothing for Prisma to represent or drop. Built on
+production with `CREATE INDEX CONCURRENTLY` in 90 s (36 MB, valid); `EXPLAIN`
+shows a Bitmap Index Scan on it. Without the index the query still returns
+correct rows, so the health verdict for "index missing" is `degraded`, not
+`unavailable`. Code: `kb-fts.sql.ts`, `KbFtsHealthService`,
+`scripts/sql/kb_fts_safe_rollout.py`, migration `20260908000000` (rewritten;
+no persistent database had recorded it).
 
 ## Human decisions required (cannot be resolved by an agent)
 

--- a/scripts/sql/kb_fts_safe_rollout.py
+++ b/scripts/sql/kb_fts_safe_rollout.py
@@ -1,43 +1,39 @@
 #!/usr/bin/env python3
 """
-Production rollout of the KbChunk full-text-search column (issue #92 / PR #98)
-WITHOUT a table rewrite.
+Production rollout of KbChunk full-text search (issue #92) as an EXPRESSION index
+— no column, no backfill, no per-row writes.
 
 WHY THIS SCRIPT EXISTS
-  On 2026-09-12 the first version of migration 20260908000000_restore_kb_chunk_fts
-  re-added `content_tsv` as a STORED generated column. Postgres implements that as
-  a full rewrite of "KbChunk" under an ACCESS EXCLUSIVE lock, and the rewrite
-  rebuilds every index on the table — including the pgvector HNSW index. On
-  suchi-db that ran for 15+ minutes; every retrieval query queued behind the
-  lock, the connection pool filled, /v1/health stopped answering and chat turns
-  timed out. The statement was terminated. Nothing was changed.
+  2026-09-12, two abandoned designs on suchi-db:
+   * a STORED generated tsvector column rewrote the whole table under an ACCESS
+     EXCLUSIVE lock (and rebuilt the pgvector HNSW index): 15-minute retrieval
+     outage, terminated;
+   * a plain column + trigger + batched backfill was non-blocking but each row
+     update re-entered all four indexes incl. HNSW: 190 ms/row, ~2.5 h. Stopped.
+  The expression index needs ONE concurrent build and touches no rows.
 
-WHAT THIS SCRIPT DOES INSTEAD (each step is short or interruptible)
-  1. Bootstraps the schema itself (the same DDL migration.sql carries): a PLAIN
-     nullable tsvector column (catalog-only, milliseconds) and the BEFORE INSERT
-     OR UPDATE OF content trigger. migration.sql is NOT run on a production-sized
-     table — it deliberately RAISES there, so `prisma migrate deploy` can never
-     record the migration as applied before the backfill and index exist.
-  2. Backfills `content_tsv` in small committed batches, sleeping between
-     batches. Never one long transaction. Ctrl-C between batches is safe.
-  3. Builds the GIN index with CREATE INDEX CONCURRENTLY (outside any
-     transaction; does not block reads or writes).
-  4. Verifies: zero NULL rows, index present AND valid (pg_index.indisvalid),
-     the shipped lexical query returns rows.
-  5. Marks the migration applied in Prisma's history
-     (`prisma migrate resolve --applied ...`) — only after 1–4 succeeded.
+WHAT THIS SCRIPT DOES (each step short, interruptible or idempotent)
+  1. Drops leftovers of the abandoned designs (trigger, function, plain column) —
+     catalog-only, with a short lock_timeout.
+  2. CREATE INDEX CONCURRENTLY kb_chunk_content_tsv_idx
+       ON "KbChunk" USING GIN (to_tsvector('simple', content));
+     (outside any transaction; does not block reads or writes; drops an INVALID
+     leftover from an interrupted build first).
+  3. Verifies: pg_index.indisvalid AND indisready; the index definition is over
+     to_tsvector('simple'::regconfig, content); a real lexical search returns
+     rows; EXPLAIN shows the planner using kb_chunk_content_tsv_idx.
+  4. Marks migration 20260908000000_restore_kb_chunk_fts applied
+     (`prisma migrate resolve`) — only after 1–3 succeeded — and re-runs
+     migration.sql once to prove it is now a no-op on this database.
 
-USAGE (from the repo root, with the Cloud SQL proxy running on 127.0.0.1:5433;
-see docs/OPERATIONS_RUNBOOK.md §1 and §4a):
+USAGE (repo root; Cloud SQL proxy on 127.0.0.1:5433 — docs/OPERATIONS_RUNBOOK.md §1, §4a):
 
     export DATABASE_URL="$(gcloud secrets versions access latest --secret=database-url)"
-    python3 scripts/sql/kb_fts_safe_rollout.py                 # dry run: prints state + plan
-    python3 scripts/sql/kb_fts_safe_rollout.py --execute       # do it
-    python3 scripts/sql/kb_fts_safe_rollout.py --execute --batch-size 1000 --sleep 0.5
+    python3 scripts/sql/kb_fts_safe_rollout.py             # dry run: state + plan
+    python3 scripts/sql/kb_fts_safe_rollout.py --execute   # do it
 
-  Run it in a low-traffic window (night IST). Watch DB CPU and connection count
-  while the backfill runs; it prints progress per batch. The password is never
-  printed. Re-running is safe: every step is idempotent and skips finished work.
+  Low-traffic window preferred: the concurrent build scans the table (CPU/IO)
+  but takes no blocking lock. The password is never printed. Re-running is safe.
 """
 from __future__ import annotations
 
@@ -54,41 +50,14 @@ API_DIR = REPO / "apps" / "api"
 MIGRATION = "20260908000000_restore_kb_chunk_fts"
 MIGRATION_SQL = API_DIR / "prisma" / "migrations" / MIGRATION / "migration.sql"
 TABLE = '"KbChunk"'
-COLUMN = "content_tsv"
 INDEX = "kb_chunk_content_tsv_idx"
-TRIGGER = "kbchunk_content_tsv_trg"
 CONFIG = "simple"
+EXPRESSION = f"to_tsvector('{CONFIG}', content)"
+INDEXDEF_MARKER = f"to_tsvector('{CONFIG}'::regconfig, content)"
+LEGACY_TRIGGER = "kbchunk_content_tsv_trg"
+LEGACY_FUNCTION = "kbchunk_content_tsv_maintain"
+LEGACY_COLUMN = "content_tsv"
 LOCK_TIMEOUT = "5s"
-
-# Mirrors the column/trigger part of migration.sql. Keep the two in sync: the
-# PGlite test replays migration.sql; production runs this.
-BOOTSTRAP_SQL = f"""
-SET lock_timeout = '{LOCK_TIMEOUT}';
-CREATE OR REPLACE FUNCTION kbchunk_content_tsv_maintain() RETURNS trigger
-LANGUAGE plpgsql AS $fn$
-BEGIN
-  NEW.{COLUMN} := to_tsvector('{CONFIG}', NEW.content);
-  RETURN NEW;
-END
-$fn$;
-DO $$
-DECLARE col_generated "char";
-BEGIN
-  SELECT a.attgenerated INTO col_generated FROM pg_attribute a
-  WHERE a.attrelid = to_regclass('{TABLE}') AND a.attname = '{COLUMN}' AND NOT a.attisdropped;
-  IF col_generated IS NULL THEN
-    ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS {COLUMN} tsvector;
-    col_generated := '';
-  END IF;
-  IF col_generated = 's' THEN
-    DROP TRIGGER IF EXISTS {TRIGGER} ON {TABLE};
-  ELSE
-    DROP TRIGGER IF EXISTS {TRIGGER} ON {TABLE};
-    CREATE TRIGGER {TRIGGER} BEFORE INSERT OR UPDATE OF content ON {TABLE}
-      FOR EACH ROW EXECUTE FUNCTION kbchunk_content_tsv_maintain();
-  END IF;
-END$$;
-"""
 
 
 class Db:
@@ -105,8 +74,8 @@ class Db:
     def _env(self) -> dict[str, str]:
         return {**os.environ, "PGPASSWORD": self.password}
 
-    def scalar(self, sql: str) -> str:
-        r = subprocess.run(self._base() + ["-At", "-c", sql], env=self._env(), capture_output=True, text=True, timeout=120)
+    def scalar(self, sql: str, timeout: int = 120) -> str:
+        r = subprocess.run(self._base() + ["-At", "-c", sql], env=self._env(), capture_output=True, text=True, timeout=timeout)
         if r.returncode != 0:
             raise RuntimeError(r.stderr.strip())
         return r.stdout.strip()
@@ -130,42 +99,36 @@ class Db:
 def state(db: Db) -> dict[str, str]:
     q = {
         "rows": f"SELECT count(*) FROM {TABLE};",
-        "column": (
-            "SELECT coalesce((SELECT CASE WHEN attgenerated = 's' THEN 'generated' ELSE 'plain' END FROM pg_attribute "
-            f"WHERE attrelid = to_regclass('{TABLE}') AND attname = '{COLUMN}' AND NOT attisdropped), 'absent');"
-        ),
-        "trigger": (
-            f"SELECT coalesce((SELECT CASE WHEN tgenabled <> 'D' THEN 'enabled' ELSE 'disabled' END FROM pg_trigger "
-            f"WHERE tgrelid = to_regclass('{TABLE}') AND tgname = '{TRIGGER}'), 'absent');"
-        ),
-        "nulls": f"SELECT count(*) FROM {TABLE} WHERE {COLUMN} IS NULL;",
+        "legacy_column": f"SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = to_regclass('{TABLE}') AND attname = '{LEGACY_COLUMN}' AND NOT attisdropped) THEN 'present' ELSE 'absent' END;",
+        "legacy_trigger": f"SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_trigger WHERE tgrelid = to_regclass('{TABLE}') AND tgname = '{LEGACY_TRIGGER}') THEN 'present' ELSE 'absent' END;",
         "index": (
             "SELECT coalesce((SELECT CASE WHEN i.indisvalid AND i.indisready THEN 'valid' ELSE 'INVALID' END "
             f"FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = '{INDEX}'), 'absent');"
         ),
+        # The marker contains single quotes ('simple'::regconfig): double them inside the SQL literal.
+        "index_expr_ok": f"SELECT coalesce((SELECT (indexdef LIKE '%{INDEXDEF_MARKER.replace(chr(39), chr(39) * 2)}%')::text FROM pg_indexes WHERE indexname = '{INDEX}'), 'n/a');",
         "prisma": f"SELECT coalesce((SELECT 'applied' FROM _prisma_migrations WHERE migration_name = '{MIGRATION}' AND finished_at IS NOT NULL AND rolled_back_at IS NULL LIMIT 1), 'not recorded');",
-        "waiting_on_locks": "SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND datname = current_database();",
+        "lock_waiters": "SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND datname = current_database();",
     }
     out: dict[str, str] = {}
     for k, sql in q.items():
         try:
             out[k] = db.scalar(sql)
         except RuntimeError as e:
-            out[k] = f"? ({e.splitlines()[0][:80]})"
+            first = str(e).splitlines()[0] if str(e) else "error"
+            out[k] = f"? ({first[:80]})"
     return out
 
 
 def show(title: str, st: dict[str, str]) -> None:
     print(f"\n== {title} ==")
     for k, v in st.items():
-        print(f"  {k:17} {v}")
+        print(f"  {k:15} {v}")
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument("--execute", action="store_true", help="actually change the database (default: dry run)")
-    ap.add_argument("--batch-size", type=int, default=1500, help="rows per committed backfill batch (default 1500)")
-    ap.add_argument("--sleep", type=float, default=0.5, help="seconds to sleep between batches (default 0.5)")
     ap.add_argument("--host", default="127.0.0.1")
     ap.add_argument("--port", type=int, default=5433, help="Cloud SQL proxy port (default 5433)")
     ap.add_argument("--skip-resolve", action="store_true", help="do everything except `prisma migrate resolve`")
@@ -183,111 +146,85 @@ def main() -> int:
     before = state(db)
     show("current state", before)
 
-    if before["column"] == "generated":
-        print("\ncontent_tsv is a legacy STORED generated column: Postgres maintains it, nothing to backfill.")
     if not args.execute:
         print("\nDRY RUN. Plan with --execute:")
-        print(f"  1. bootstrap column + trigger (same DDL as migration.sql; lock_timeout {LOCK_TIMEOUT})")
-        print(f"  2. backfill {before['nulls']} NULL rows in batches of {args.batch_size}, sleeping {args.sleep}s between batches")
-        print(f"  3. CREATE INDEX CONCURRENTLY {INDEX} (if absent or INVALID)")
-        print("  4. verify: 0 NULL rows, index valid, lexical query returns rows")
-        print(f"  5. prisma migrate resolve --applied {MIGRATION}")
+        print(f"  1. drop legacy trigger/function/column if present (lock_timeout {LOCK_TIMEOUT}; catalog-only)")
+        print(f"  2. CREATE INDEX CONCURRENTLY {INDEX} ON {TABLE} USING GIN ({EXPRESSION})  (if absent or INVALID)")
+        print("  3. verify: index valid + over the expected expression; live search hits; EXPLAIN uses the index")
+        print(f"  4. prisma migrate resolve --applied {MIGRATION}; re-run migration.sql as a no-op proof")
         return 0
 
-    # 1. column + trigger. Same DDL as migration.sql, minus its backfill/index and
-    #    minus its large-table guard: this script IS the large-table path.
-    print("\n[1/5] bootstrapping column + trigger (catalog-only, lock_timeout " + LOCK_TIMEOUT + ") ...")
-    db.exec(BOOTSTRAP_SQL, timeout=120)
+    # 1. legacy leftovers
+    print("\n[1/4] dropping legacy objects if present (catalog-only) ...")
+    db.exec(
+        f"SET lock_timeout = '{LOCK_TIMEOUT}'; "
+        f"DROP TRIGGER IF EXISTS {LEGACY_TRIGGER} ON {TABLE}; "
+        f"DROP FUNCTION IF EXISTS {LEGACY_FUNCTION}(); "
+        + (f"DROP INDEX IF EXISTS {INDEX}; ALTER TABLE {TABLE} DROP COLUMN IF EXISTS {LEGACY_COLUMN};" if before["legacy_column"] == "present" else ""),
+        timeout=120,
+    )
     st = state(db)
-    if st["column"] == "absent" or (st["column"] == "plain" and st["trigger"] != "enabled"):
-        print(f"      unexpected state after migration.sql: {st}", file=sys.stderr)
-        return 1
-    print(f"      column={st['column']} trigger={st['trigger']}")
+    print(f"      legacy_column={st['legacy_column']} legacy_trigger={st['legacy_trigger']}")
 
-    # 2. batched backfill (skip for a generated column — Postgres already did it)
-    if st["column"] == "plain":
-        remaining = int(st["nulls"])
-        print(f"\n[2/5] backfilling {remaining} rows, {args.batch_size} per batch ...")
-        batch = 0
-        t0 = time.time()
-        while remaining > 0:
-            batch += 1
-            db.exec(
-                f"SET lock_timeout = '{LOCK_TIMEOUT}'; "
-                f"UPDATE {TABLE} SET {COLUMN} = to_tsvector('{CONFIG}', content) "
-                f"WHERE id IN (SELECT id FROM {TABLE} WHERE {COLUMN} IS NULL LIMIT {args.batch_size});",
-                timeout=300,
-            )
-            remaining = int(db.scalar(f"SELECT count(*) FROM {TABLE} WHERE {COLUMN} IS NULL;"))
-            waiting = db.scalar("SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND datname = current_database();")
-            print(f"      batch {batch:3d}  remaining {remaining:6d}  lock-waiters {waiting}  {time.time()-t0:6.1f}s", flush=True)
-            if int(waiting) > 0:
-                print("      lock waiters present — pausing 5s before the next batch", flush=True)
-                time.sleep(5)
-            elif remaining > 0:
-                time.sleep(args.sleep)
-    else:
-        print("\n[2/5] generated column — backfill not needed")
-
-    # 3. concurrent index (never inside a transaction; psql -c autocommits)
-    st = state(db)
-    if st["index"] == "INVALID":
-        print(f"\n[3/5] dropping INVALID {INDEX} left by an interrupted build ...")
+    # 2. concurrent expression index
+    if st["index"] == "INVALID" or (st["index"] == "valid" and st["index_expr_ok"] != "true"):
+        print(f"\n[2/4] dropping {INDEX} ({st['index']}, expr_ok={st['index_expr_ok']}) before rebuilding ...")
         db.exec(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX};", timeout=600)
         st["index"] = "absent"
     if st["index"] == "absent":
-        print(f"\n[3/5] CREATE INDEX CONCURRENTLY {INDEX} ... (does not block reads/writes; may take a few minutes)")
+        print(f"\n[2/4] CREATE INDEX CONCURRENTLY {INDEX} ... (no blocking lock; scans the table once or twice)")
         t0 = time.time()
-        db.exec(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX} ON {TABLE} USING GIN ({COLUMN});", timeout=3600)
+        db.exec(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX} ON {TABLE} USING GIN ({EXPRESSION});", timeout=3600)
         print(f"      built in {time.time()-t0:.1f}s")
     else:
-        print(f"\n[3/5] index already {st['index']}")
+        print(f"\n[2/4] index already {st['index']} over the expected expression")
 
-    # 4. verify
-    print("\n[4/5] verifying ...")
+    # 3. verify
+    print("\n[3/4] verifying ...")
     st = state(db)
-    hits = db.scalar(
-        f"SELECT count(*) FROM {TABLE} c, websearch_to_tsquery('{CONFIG}', 'cancer treatment') q WHERE c.{COLUMN} @@ q;"
+    hits = db.scalar(f"SELECT count(*) FROM {TABLE} c WHERE {EXPRESSION.replace('content', 'c.content')} @@ websearch_to_tsquery('{CONFIG}', 'cancer treatment');")
+    plan = db.scalar(
+        f"EXPLAIN (COSTS OFF) SELECT c.id FROM {TABLE} c, websearch_to_tsquery('{CONFIG}', 'cancer treatment') q "
+        f"WHERE {EXPRESSION.replace('content', 'c.content')} @@ q LIMIT 12;"
     )
-    show("after", {**st, "lexical hits 'cancer treatment'": hits})
+    uses_index = INDEX in plan
+    show("after", {**st, "lexical hits 'cancer treatment'": hits, "planner uses index": str(uses_index)})
     problems = []
-    if st["column"] == "plain" and int(st["nulls"]) != 0:
-        problems.append(f"{st['nulls']} rows still NULL")
     if st["index"] != "valid":
         problems.append(f"index is {st['index']}")
+    if st["index_expr_ok"] != "true":
+        problems.append("index is not over the expected expression")
     if int(hits) == 0:
         problems.append("lexical query returned 0 rows")
+    if not uses_index:
+        problems.append(f"planner did not use {INDEX} — plan: {plan[:200]}")
     if problems:
         print("\nNOT resolving the migration — problems: " + "; ".join(problems), file=sys.stderr)
         return 1
 
-    # 5. prisma history
+    # 4. prisma history + no-op proof
     if args.skip_resolve:
-        print("\n[5/5] skipped (--skip-resolve)")
+        print("\n[4/4] skipped (--skip-resolve)")
         return 0
-    if st["prisma"] == "applied":
-        print("\n[5/5] already recorded in _prisma_migrations")
-        return 0
-    print(f"\n[5/5] prisma migrate resolve --applied {MIGRATION} ...")
-    r = subprocess.run(
-        ["npx", "prisma", "migrate", "resolve", "--applied", MIGRATION],
-        cwd=API_DIR,
-        env={**os.environ, "DATABASE_URL": db.prisma_url()},
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    print("      " + (r.stdout + r.stderr).strip().splitlines()[-1][:160])
-    if r.returncode != 0:
-        return 1
-    # Proof that the file is now a no-op on this database (its large-table guard is
-    # satisfied): a future `prisma migrate deploy` re-run cannot break anything.
+    if st["prisma"] != "applied":
+        print(f"\n[4/4] prisma migrate resolve --applied {MIGRATION} ...")
+        r = subprocess.run(
+            ["npx", "prisma", "migrate", "resolve", "--applied", MIGRATION],
+            cwd=API_DIR, env={**os.environ, "DATABASE_URL": db.prisma_url()},
+            capture_output=True, text=True, timeout=300,
+        )
+        print("      " + (r.stdout + r.stderr).strip().splitlines()[-1][:160])
+        if r.returncode != 0:
+            return 1
+    else:
+        print("\n[4/4] already recorded in _prisma_migrations")
     try:
         db.exec_file(MIGRATION_SQL, timeout=120)
         print("      migration.sql re-run: no-op OK")
     except RuntimeError as e:
         print("      WARNING: migration.sql re-run failed: " + str(e).splitlines()[0][:140], file=sys.stderr)
-    print("\nDone. Check GET /v1/health/retrieval → fullTextSearch.status should be 'ok' (the boot probe re-runs on the next deploy or within the re-probe window).")
+        return 1
+    print("\nDone. GET /v1/health/retrieval → fullTextSearch.status should read 'ok' on a revision that ships the expression-index probe.")
     return 0
 
 

--- a/scripts/sql/kb_fts_safe_rollout.py
+++ b/scripts/sql/kb_fts_safe_rollout.py
@@ -65,7 +65,7 @@ class Db:
         p = urlparse.urlparse(url)
         self.user = urlparse.unquote(p.username or "")
         self.password = urlparse.unquote(p.password or "")
-        self.dbname = p.path.lstrip("/")
+        self.dbname = urlparse.unquote(p.path.lstrip("/"))
         self.host, self.port = host, port
 
     def _base(self) -> list[str]:
@@ -93,7 +93,10 @@ class Db:
         return (r.stdout + r.stderr).strip()
 
     def prisma_url(self) -> str:
-        return f"postgresql://{urlparse.quote(self.user)}:{urlparse.quote(self.password)}@{self.host}:{self.port}/{self.dbname}"
+        # safe='' so a '/' (or any reserved char) in user/password/dbname is percent-encoded;
+        # the default safe='/' would emit an invalid URL.
+        q = lambda v: urlparse.quote(v, safe="")
+        return f"postgresql://{q(self.user)}:{q(self.password)}@{self.host}:{self.port}/{q(self.dbname)}"
 
 
 def state(db: Db) -> dict[str, str]:


### PR DESCRIPTION
Refs #92, #98, #130 (review comment `5648272849`), #126. **Production is already on this design** (see below); this PR makes the code match it.

## Why the redesign

Both column-based designs failed on production on 2026-09-12:

| design | what happened |
|---|---|
| STORED generated column (#98 as merged) | full table rewrite under ACCESS EXCLUSIVE lock, rebuilding every index incl. the 182 MB pgvector HNSW index → **15-minute retrieval outage**, terminated |
| plain column + trigger + batched backfill (#130) | non-blocking, but each updated row is too large for a HOT update and re-enters all four indexes incl. HNSW → **190 ms/row, ~2.5 h**; stopped at 12k rows, and a half-filled column meant hybrid retrieval saw lexical hits from a subset |

**Expression index:** `GIN (to_tsvector('simple', content))` + a query on the identical expression. No column, no trigger, no backfill, no per-row writes, no shadow state to drift, nothing Prisma has to represent. Without the index the query still returns correct rows (sequential scan), so the lexical arm can only be *dead* if the table is missing.

## What was done on production (with the maintainer's go-ahead, 2026-09-12 ~19:45 UTC)

1. Backfill stopped permanently; trigger, function and plain column dropped — catalog-only, **3 s**, zero lock waiters.
2. `CREATE INDEX CONCURRENTLY kb_chunk_content_tsv_idx ON "KbChunk" USING GIN (to_tsvector('simple', content))` — **90 s**, 36 MB, `indisvalid`/`indisready` true.
3. Verified: definition is `to_tsvector('simple'::regconfig, content)`; live search `cancer treatment` → **11,791** rows; `EXPLAIN` → **Bitmap Index Scan on kb_chunk_content_tsv_idx**.
4. `prisma migrate resolve --applied 20260908000000_restore_kb_chunk_fts`; the rewritten `migration.sql` re-runs as a no-op on the database.

Health stayed `ok` throughout. The running revision (`00419`) still queries `c.content_tsv`, so `/v1/health/retrieval` reports *unavailable* (clean vector-only fallback, no partial lexical results) until this PR deploys.

## Changes

| file | change |
|---|---|
| `kb-fts.sql.ts` | `KB_FTS_EXPRESSION` is the one place the expression lives; `KB_FTS_SEARCH_SQL` uses it in predicate and rank; probe returns `tablePresent`, `indexDef`, `indexValid`, `legacyColumnPresent`; column/trigger constants removed |
| `KbFtsHealthService` | table missing → `unavailable`; index missing / INVALID / wrong expression or config → `degraded`; else `ok`; a lingering legacy column is reported so it gets dropped |
| `migration.sql` (same name — no persistent DB had recorded it) | one atomic DO block: drop leftovers of both abandoned designs → build the expression index on ≤ 5 000 rows → **raise** on a larger table unless a valid expression index already exists |
| `schema.prisma` | `content_tsv` field and its index mapping removed; the guard note stays (a schema diff *will* propose dropping the index — never accept it) |
| `scripts/sql/kb_fts_safe_rollout.py` | drop legacy → `CREATE INDEX CONCURRENTLY` → verify (valid, expression, live hits, `EXPLAIN` uses the index) → `migrate resolve` → no-op proof; dry run by default |
| runbook §4a, backlog incident record | both abandoned designs and the final one |

## Tests (PGlite, real migrations replayed oldest-first)

Index valid and over the right expression · planner uses it (`enable_seqscan = off`) · new rows searchable at once · migration removes a legacy column/trigger/function and builds the index · **no index → rows still returned, probe `degraded`, and a query success does not flip a stale `unavailable` to `ok`** · INVALID index → `degraded` · table gone → `42P01` classified, `unavailable`, escalated · 5 001-row refusal leaves no index · no-op after a valid index exists · schema guard. `kb-fts.spec.ts` **20/20**; RAG + health suites 51/51; `tsc` clean; `prisma validate` ok; repo guards ok.

## After merge

Deploy; `GET /v1/health/retrieval` should read `ok` at boot; then replay the #126 probes (and the Tier-1 retrieval eval) with the lexical arm live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
